### PR TITLE
Dynamic versions in footer - New Versioning System?

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -4,7 +4,8 @@
     <!-- /.content-wrapper -->
     <footer class="main-footer">
         <div class="pull-right hidden-xs">
-            <b>Pi-hole Version</b> 2.2
+            <b>Pi-hole Version </b> <?php echo exec("cd /etc/.pihole/ && git describe --tags --abbrev=0"); ?>
+            <b>Web Interface Version </b> <?php echo exec("cd /var/www/html/admin/ && git describe --tags --abbrev=0"); ?>
         </div>
         <i class="fa fa-github"></i> <strong><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=3J2L3Z4DHW9UY">Donate</a></strong> if you found this useful.
     </footer>

--- a/index.php
+++ b/index.php
@@ -93,7 +93,7 @@
 </div><!-- /.box -->
 
 <?php
-    require "footer.html";
+    require "footer.php";
 ?>
 
 <script src="https://cdn.datatables.net/1.10.10/js/jquery.dataTables.min.js" type="text/javascript"></script>

--- a/list.php
+++ b/list.php
@@ -41,7 +41,7 @@ function getFullName() {
 <ul class="list-group" id="list"></ul>
 
 <?php
-require "footer.html";
+require "footer.php";
 ?>
 
 <script>


### PR DESCRIPTION
Shows Pi-hole and Web Interface versions. It grabs these by running ```git describe --tags --abbrev=0``` on each repo.
![Screenshot](http://i.imgur.com/A533gvP.png)
Will both the Pi-hole and web interface start on 2.4 and just naturally continue? Or will they both restart at 1.0.0 or something and continue separately from there?