### PR TITLE
Updated dropdown with more intuitive buttons and links

### DIFF
--- a/header.html
+++ b/header.html
@@ -67,13 +67,13 @@
                             <!-- Menu Body -->
                             <li class="user-body">
                                 <div class="col-xs-4 text-center">
-                                    <a href="https://github.com/jacobsalmela/pi-hole">Free</a>
+                                    <a href="https://github.com/jacobsalmela/pi-hole">Github</a>
                                 </div>
                                 <div class="col-xs-4 text-center">
                                     <a href="http://jacobsalmela.com/block-millions-ads-network-wide-with-a-raspberry-pi-hole-2-0/">Details</a>
                                 </div>
                                 <div class="col-xs-4 text-center">
-                                    <a href="#">Updates</a>
+                                    <a href="https://github.com/pi-hole/pi-hole/releases">Updates</a>
                                 </div>
                             </li>
                             <!-- Menu Footer-->


### PR DESCRIPTION
Changes "Free" to "Github" to reflect the fact that it links to Github.
Adds a link to "Updates" that goes to the [releases page](https://github.com/pi-hole/pi-hole/releases). (Didn't have a link before. That might have confused some people. Kind of like the "More Info" button that does nothing)

Goes from this:
![Before](http://i.imgur.com/ucJbyNQ.png)
To this:
![After](http://i.imgur.com/e9XQZhH.png)