### PR TITLE
Remove "More Info" buttons

### DIFF
--- a/index.php
+++ b/index.php
@@ -133,7 +133,6 @@
                                 <div class="icon">
                                     <i class="ion ion-android-hand"></i>
                                 </div>
-                                <a href="#" class="small-box-footer">More info <i class="fa fa-arrow-circle-right"></i></a>
                             </div>
                         </div>
                         <!-- ./col -->
@@ -147,7 +146,6 @@
                                 <div class="icon">
                                     <i class="ion ion-earth"></i>
                                 </div>
-                                <a href="#" class="small-box-footer">More info <i class="fa fa-arrow-circle-right"></i></a>
                             </div>
                         </div>
                         <!-- ./col -->
@@ -161,7 +159,6 @@
                                 <div class="icon">
                                     <i class="ion ion-pie-graph"></i>
                                 </div>
-                                <a href="#" class="small-box-footer">More info <i class="fa fa-arrow-circle-right"></i></a>
                             </div>
                         </div>
                         <!-- ./col -->
@@ -175,7 +172,6 @@
                                 <div class="icon">
                                     <i class="ion ion-ios-list"></i>
                                 </div>
-                                <a href="#" class="small-box-footer">More info <i class="fa fa-arrow-circle-right"></i></a>
                             </div>
                         </div>
                         <!-- ./col -->


### PR DESCRIPTION
These buttons confused some users, as they are not actually linked to anything!
The development branch has done away with them, so in order to save some people
the confusion, they should be killed off. :)