### PR TITLE
Checks hash of input password with stored hash

### DIFF
--- a/list.php
+++ b/list.php
@@ -118,7 +118,7 @@ require "footer.php";
             $.ajax({
                 url: "php/add.php",
                 method: "get",
-                data: {"domain":domain, "list":"<?php echo $list ?>", "pass":password},
+                data: {"domain":domain, "list":"<?php echo $list ?>", "pass":btoa(password)},
                 success: function(response) {
                     if(response.length !== 0)
                         return;
@@ -138,7 +138,7 @@ require "footer.php";
             $.ajax({
                 url: "php/sub.php",
                 method: "get",
-                data: {"domain":entry, "list":"<?php echo $list ?>", "pass":password},
+                data: {"domain":entry, "list":"<?php echo $list ?>", "pass":btoa(password)},
                 success: function(response) {
                     if(response.length !== 0)
                         return;
@@ -157,7 +157,7 @@ require "footer.php";
             $.ajax({
                 url: "php/checkPass.php",
                 method: "get",
-                data: {"pass":password},
+                data: {"pass":btoa(password)},
                 success: function(response) {
                     if(response === "Correct")
                         callback();
@@ -185,7 +185,7 @@ require "footer.php";
                 $.ajax({
                     url: "php/checkPass.php",
                     method: "get",
-                    data: {"pass":password},
+                    data: {"pass":btoa(password)},
                     success: function(response) {
                         if(response === "Correct") {
                             passInput.html("");

--- a/php/functions.php
+++ b/php/functions.php
@@ -1,5 +1,5 @@
 <?php
 function checkPass($pass) {
     // Check password
-    return $pass == str_replace(array("\r", "\n"), '', file_get_contents("/etc/pihole/password.txt"));
+    return hash_equals(str_replace(array("\r", "\n"), '', file_get_contents("/etc/pihole/password.txt")), hash("sha256", $pass));
 }

--- a/php/functions.php
+++ b/php/functions.php
@@ -1,5 +1,8 @@
 <?php
-function checkPass($pass) {
+function checkPass($passB64) {
+    // Convert from Base64
+    $pass = base64_decode($passB64);
+    
     // Check password
     return hash_equals(str_replace(array("\r", "\n"), '', file_get_contents("/etc/pihole/password.txt")), hash("sha256", $pass));
 }


### PR DESCRIPTION
Should fix any security holes associated with checking passwords through the web interface. See [#360](https://github.com/pi-hole/pi-hole/pull/360) for the other side of things.

Changes proposed in this pull request:

- Check password by hashing and checking with original hash

@pihole/dashboard

