### PR TITLE
fix template team link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ Changes proposed in this pull request:
 
 - 
 
-@pihole/dashboard
+@pi-hole/dashboard


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds `-` in team link, as seen below.

@pi-hole/dashboard 

