### PR TITLE
fix for journal flooding causing high cpu usage.

### DIFF
--- a/data.php
+++ b/data.php
@@ -156,11 +156,12 @@
         $file="/etc/pihole/gravity.list";
         $linecount = 0;
         $handle = fopen($file, "r");
-        while(!feof($handle)){
-          $line = fgets($handle);
-          $linecount++;
+        if(gettype($handle) == "resource") {
+	  while(!feof($handle)){
+            $line = fgets($handle);
+            $linecount++;
+          }
         }
-        
         fclose($handle);
         
         return $linecount;


### PR DESCRIPTION
Im running pi-hole from github in arch linux and found that i was seeing high cpu usage from systemd.
Journal was being flooded with php warnings.

- 

@pi-hole/dashboard

PHP Warning:  fgets() expects parameter 1 to be resource, boolean given in