### PR TITLE
Fix for high CPU usage caused by "PHP Warning" flooding the journal.

### DIFF
--- a/data.php
+++ b/data.php
@@ -156,11 +156,12 @@
         $file="/etc/pihole/gravity.list";
         $linecount = 0;
         $handle = fopen($file, "r");
-        while(!feof($handle)){
+        if(gettype($handle) == "resource") {
+          while(!feof($handle)){
           $line = fgets($handle);
           $linecount++;
+          }
         }
-        
         fclose($handle);
         
         return $linecount;

--- a/data.php
+++ b/data.php
@@ -156,12 +156,9 @@
         $file="/etc/pihole/gravity.list";
         $linecount = 0;
         $handle = fopen($file, "r");
-        if(gettype($handle) == "resource") {
-          while(!feof($handle)){
-          $line = fgets($handle);
-          $linecount++;
-          }
-        }
+        while ($chunk = fread($handle, 1024000)) {
+          $linecount += substr_count($chunk, "\n");
+        }      
         fclose($handle);
         
         return $linecount;

--- a/data.php
+++ b/data.php
@@ -153,15 +153,15 @@
     /******** Private Members ********/
     function readInBlockList() {
         //returns count of domains in blocklist.
-        $file="/etc/pihole/gravity.list";
-        $linecount = 0;
-        $handle = fopen($file, "r");
-        while ($chunk = fread($handle, 1024000)) {
-          $linecount += substr_count($chunk, "\n");
+        $gravity="/etc/pihole/gravity.list";
+        $swallowed = 0;
+        $NGC4889 = fopen($gravity, "r");
+        while ($stars = fread($NGC4889, 1024000)) {
+          $swallowed += substr_count($stars, "\n");
         }      
-        fclose($handle);
+        fclose($NGC4889);
         
-        return $linecount;
+        return $swallowed;
             
     }
     function readInLog() {


### PR DESCRIPTION
This should fix the journal flooding causing high CPU usage

@pi-hole/dashboard

PHP Warning:  fgets() expects parameter 1 to be resource, boolean was given