### PR TITLE
Add Mobile Support To Javascript Disabled Pop-up

### DIFF
--- a/css/js-warn.css
+++ b/css/js-warn.css
@@ -1,4 +1,4 @@
-/* Made by Verpz https://github.com/Verpz/ Licensed Under Apache License 2.0 Details On GitHub */
+/* Made by Verpz https://github.com/Verpz/ Licensed Under MIT License Details On GitHub */
 .js-warn {
   background: #EEE;
   color: #555;
@@ -10,7 +10,7 @@
   margin-left: auto;
   margin-top: 50px;
   border-radius: 10px;
-  box-shadow: 0px 10px 70px;
+  box-shadow: 0 10px 70px;
   text-align: center;
   position: fixed;
   font-family: sans-serif, serif;
@@ -23,6 +23,7 @@
   padding: 10px 10px 0 10px;
 }
 .js-warn p {
+  font-family: sans-serif, serif;
   padding: 0 10px 10px 10px;
 }
 .js-warn a {
@@ -51,4 +52,20 @@
   cursor: pointer;
   border-radius: 3px;
   float: right;
+}
+
+@media screen and (max-width: 700px) {
+  .js-warn {
+    width: 60%;
+  }
+}
+
+@media screen and (max-width: 400px) {
+  .js-warn {
+    width: 80%;
+  }
+  .js-warn h1 {
+      font-size: large;
+      font-weight: 500;
+  }
 }


### PR DESCRIPTION
Adds mobile support to the Javascript disabled warning popup.

Before:
![screenshot_20160527-203638](https://cloud.githubusercontent.com/assets/12567692/15606384/3416c256-244f-11e6-8c7c-53bd2afea647.png)
After:
![screenshot_20160527-203539](https://cloud.githubusercontent.com/assets/12567692/15606383/3414d1a8-244f-11e6-9d1a-3a315b3cce66.png)

