### PR TITLE
web-version edit & HTML minor edit

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -6,10 +6,10 @@
         <div class="pull-right hidden-xs">
             <?php
             $piholeVersion = exec("cd /etc/.pihole/ && git describe --tags --abbrev=0");
-            $webVersion = exec("cd /var/www/html/admin/ && git describe --tags --abbrev=0");
+            $webVersion = exec("git describe --tags --abbrev=0");
             ?>
-            <b>Pi-hole Version </b> <div id="piholeVersion" style="display: inline"><?php echo $piholeVersion; ?></div>
-            <b>Web Interface Version </b> <div id="webVersion" style="display: inline"><?php echo $webVersion; ?></div>
+            <b>Pi-hole Version </b> <span id="piholeVersion"><?php echo $piholeVersion; ?></span>
+            <b>Web Interface Version </b> <span id="webVersion"><?php echo $webVersion; ?></span>
         </div>
         <i class="fa fa-github"></i> <strong><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=3J2L3Z4DHW9UY">Donate</a></strong> if you found this useful.
     </footer>


### PR DESCRIPTION
Changes proposed in this pull request:

- modify div's with display to use HTML span elements

- allows footer to get correct AdminLTE version, even if not at `/var/www/html/`

@pi-hole/dashboard

I know I shouldn't have, but I moved to `/var/www/public/`. This stopped the version from reporting for admin LTE.

I'm actually planning on moving it again and this has helped as `.git` repository is in the same folder as `footer.php` so you only need to worry about specifying path if that changes.