### PR TITLE
Fix possible list param exploit

### DIFF
--- a/php/get.php
+++ b/php/get.php
@@ -3,6 +3,10 @@ if(!isset($_GET['list']))
     die();
 
 $type = $_GET['list'];
+
+if($type !== "white" || $type !== "black")
+    die("Invalid list parameter");
+
 $rawList = file_get_contents("/etc/pihole/${type}list.txt");
 $list = explode("\n", $rawList);
 

--- a/php/get.php
+++ b/php/get.php
@@ -4,7 +4,7 @@ if(!isset($_GET['list']))
 
 $type = $_GET['list'];
 
-if($type !== "white" || $type !== "black")
+if($type !== "white" && $type !== "black")
     die("Invalid list parameter");
 
 $rawList = file_get_contents("/etc/pihole/${type}list.txt");


### PR DESCRIPTION
Changes proposed in this pull request:

- Sanitize input to `/php/get.php`, so that only the whitelist or blacklist are able to be read.

Disclaimer: I did this through Github's editor, and haven't tested it yet.

@pi-hole/dashboard 