### PR TITLE
apple-touch-icon now is png

### DIFF
--- a/header.php
+++ b/header.php
@@ -14,7 +14,7 @@
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
     <link rel="shortcut icon" href="img/favicon.png" type="image/x-icon" />
     <meta name="theme-color" content="#367fa9">
-    <link rel="apple-touch-icon" sizes="180x180" href="img/logo.svg">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon.png">
     <link rel="icon" type="image/png" sizes="192x192"  href="img/logo.svg">
     <link rel="icon" type="image/png" sizes="96x96" href="img/logo.svg">
     <meta name="msapplication-TileColor" content="#367fa9">


### PR DESCRIPTION
Fixes #[none] .

Changes proposed in this pull request:

- A Webpage Icon should be png like specified here:
https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html
So I changed it to point the favicon.png icon.
Now on my phone 5S running iOS 9.3.5 the new pi-hole icon is used both when I choose to *Add Bookmark* but also when I *Add to Home Screen* from Safari.

@pi-hole/dashboard