### PR TITLE
Add a size check to the exploded array in findAds so we can avoid an offset warning.

### DIFF
--- a/data.php
+++ b/data.php
@@ -264,11 +264,14 @@
     }
 
     function findAds($var) {
-      $exploded = explode(" ", $var);
-      $tmp = $exploded[count($exploded)-4];
-      $tmp2 = $exploded[count($exploded)-5];
-      //filter out bad names and host file reloads:
-      return (substr($tmp, strlen($tmp) - 12, 12)  == "gravity.list" && $tmp2 != "read") ;
+        $exploded = explode(" ", $var);
+        if (count($exploded) >= 5) {
+            $tmp = $exploded[count($exploded) - 4];
+            $tmp2 = $exploded[count($exploded) - 5];
+            //filter out bad names and host file reloads:
+            return (substr($tmp, strlen($tmp) - 12, 12) == "gravity.list" && $tmp2 != "read");
+        }
+        return false;
     }
 
     function findForwards($var) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a size check on the exploded variable so we can avoid an offset error.

This PR removes the following notices from lighttpd logs:
`2016-09-22 02:25:09: (mod_fastcgi.c.2695) FastCGI-stderr: PHP Notice:  Undefined offset: -2 in /var/www/html/admin/data.php on line 268`
`2016-09-22 02:25:09: (mod_fastcgi.c.2695) FastCGI-stderr: PHP Notice:  Undefined offset: -3 in /var/www/html/admin/data.php on line 269`

@pi-hole/dashboard

