### PR TITLE
Fixes #150 - parsing issue for double space in between Month and Day

### DIFF
--- a/data.php
+++ b/data.php
@@ -266,6 +266,7 @@
     }
 
     function findAds($var) {
+      $var = preg_replace('/ {2,}/', ' ', $var);          
       $exploded = explode(" ", $var);
       if(count($exploded) == 8) {
           $tmp = $exploded[count($exploded) - 4];


### PR DESCRIPTION
Fixes #150.

@pi-hole/dashboard

During the beginning of the month with the log having two spaces between Month & Day we get 9 values back instead of 8.  Stripping double spaces fixes.  E.G. `Oct  1` comapred to `Sep 26`

Did this in my docker to test.  got back: 

416
Ads Blocked Today

5,187
DNS Queries Today

8.0%
Of Today's Traffic Is Ads