### PR TITLE
Replace [] with array() for php 5.3 support

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,7 +1,7 @@
 <?php
     $cmd = "echo $((`cat /sys/class/thermal/thermal_zone0/temp | cut -c1-2`))";
     $output = shell_exec($cmd);
-    $output = str_replace(["\r\n","\r","\n"],"", $output);
+    $output = str_replace(array("\r\n","\r","\n"),"", $output);
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
Fixes #157 

Changes proposed in this pull request:

-  Use array() syntax instead of short syntax to allow web UI to load on PHP 5.3

@pi-hole/dashboard

Short array syntax introduced in PHP 5.4