### PR TITLE
Stop PHP from crashing if there aren't enough queries to make a graph

### DIFF
--- a/data.php
+++ b/data.php
@@ -253,6 +253,10 @@
     }
 
     function alignTimeArrays(&$times1, &$times2) {
+        if(count($times1) == 0 || count($times2) < 2) {
+            return;
+        }
+
         $max = max(array_merge(array_keys($times1), array_keys($times2)));
         $min = min(array_merge(array_keys($times1), array_keys($times2)));
 


### PR DESCRIPTION
Fixes #96

Changes proposed in this pull request:
- Avoid getting PHP angry by asking for the max of an empty array.

@pi-hole/dashboard
