### PR TITLE
Toggle units for CPU temperature

### DIFF
--- a/header.php
+++ b/header.php
@@ -10,7 +10,8 @@
     }
     $cmd = "echo $((`cat /sys/class/thermal/thermal_zone0/temp | cut -c1-2`))";
     $output = shell_exec($cmd);
-    $output = str_replace(array("\r\n","\r","\n"),"", $output);
+    $celsius = str_replace(array("\r\n","\r","\n"),"", $output);
+    $fahrenheit = str_replace(["\r\n","\r","\n"],"", $output*9./5)+32;
 ?>
 
 <!DOCTYPE html>
@@ -148,11 +149,15 @@
                         }
 
                         // CPU Temp
-                        if ($output > "45") {
-                            echo '<a href="#"><i class="fa fa-fire" style="color:#FF0000"></i> Temp: ' . $output . '</a>';
-                        } else {
-                            echo '<a href="#"><i class="fa fa-fire" style="color:#3366FF"></i> Temp: ' . $output . '</a>';
+                        echo '<a href="#" id="temperature"><i class="fa fa-fire" style="color:';
+                        if ($celsius > "45") {
+                            echo '#FF0000';
                         }
+                        else
+                        {
+                            echo '#3366FF';
+                        }
+                        echo '""></i> Temp: <span id="celsius" style="display: inline;">' . $celsius . '&deg;C</span><span id="fahrenheit" style="display: none;">' . $fahrenheit . '&deg;F</span></a>';
                     ?>
                 </div>
             </div>

--- a/js/pihole/footer.js
+++ b/js/pihole/footer.js
@@ -8,6 +8,14 @@ $("body").on("click", function(event) {
     }
 });
 
+// Temperature display toogle
+$(function() {
+    $( "#temperature" ).click(function() {
+        $( "#celsius" ).toggle();
+        $( "#fahrenheit" ).toggle();
+    });
+});
+
 var piholeVersion = $("#piholeVersion").html();
 var webVersion = $("#webVersion").html();
 


### PR DESCRIPTION
Fixes #176 

Changes proposed in this pull request:

- Compute CPU temperature both in units Celsius and Fahrenheit. The units can be toggled by clicking on the temperature.

Celsius (initially shown):
![celsius](https://cloud.githubusercontent.com/assets/16748619/20139574/22d9113c-a687-11e6-8336-032a6547837f.png)

Fahrenheit (initially hidden):
![fahrenheit](https://cloud.githubusercontent.com/assets/16748619/20139578/28f71276-a687-11e6-9baf-123f611cf01c.png)



@pi-hole/dashboard