### PR TITLE
Increase temporal resolution in main diagram from 1h to 10min

### DIFF
--- a/api.php
+++ b/api.php
@@ -21,6 +21,10 @@
         $data = array_merge($data,  getOverTimeData());
     }
 
+    if (isset($_GET['overTimeData10mins'])) {
+        $data = array_merge($data,  getOverTimeData10mins());
+    }
+
     if (isset($_GET['topItems'])) {
         $data = array_merge($data,  getTopItems());
     }
@@ -58,7 +62,7 @@
 	    }
 	    return $sanArray;
     }
-    
+
     $data = filterArray($data);
     echo json_encode($data);
 ?>

--- a/data.php
+++ b/data.php
@@ -37,6 +37,20 @@
         );
     }
 
+    function getOverTimeData10mins() {
+        global $log;
+        $dns_queries = getDnsQueries($log);
+        $ads_blocked = getBlockedQueries($log);
+
+        $domains_over_time = overTime10mins($dns_queries);
+        $ads_over_time = overTime10mins($ads_blocked);
+        alignTimeArrays($ads_over_time, $domains_over_time);
+        return Array(
+            'domains_over_time' => $domains_over_time,
+            'ads_over_time' => $ads_over_time,
+        );
+    }
+
     function getTopItems() {
         global $log;
         $dns_queries = getDnsQueries($log);
@@ -247,6 +261,25 @@
             }
             else {
                 $byTime[$hour] = 1;
+            }
+        }
+        return $byTime;
+    }
+
+    function overTime10mins($entries) {
+        $byTime = array();
+        foreach ($entries as $entry) {
+            $time = date_create(substr($entry, 0, 16));
+            $hour = $time->format('G');
+            $minute = $time->format('i');
+
+            $time = $minute/6 + 6*$hour;
+
+            if (isset($byTime[$time])) {
+                $byTime[$time]++;
+            }
+            else {
+                $byTime[$time] = 1;
             }
         }
         return $byTime;

--- a/data.php
+++ b/data.php
@@ -273,7 +273,14 @@
             $hour = $time->format('G');
             $minute = $time->format('i');
 
-            $time = $minute/6 + 6*$hour;
+            // 00:00 - 00:09 -> 0
+            // 00:10 - 00:19 -> 1
+            // ...
+            // 12:00 - 12:10 -> 72
+            // ...
+            // 15:30 - 15:39 -> 93
+            // etc.
+            $time = ($minute-$minute%10)/10 + 6*$hour;
 
             if (isset($byTime[$time])) {
                 $byTime[$time]++;

--- a/index.php
+++ b/index.php
@@ -61,7 +61,7 @@
     <div class="col-md-12">
     <div class="box" id="queries-over-time">
         <div class="box-header with-border">
-          <h3 class="box-title">Queries per hour</h3>
+          <h3 class="box-title">Queries over time</h3>
         </div>
         <div class="box-body">
           <div class="chart">

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -1,6 +1,12 @@
 // Define global variables
 var timeLineChart, queryTypeChart, forwardDestinationChart, forwardDestinationChart;
 
+Number.prototype.pad = function(size) {
+    var s = String(this);
+    while (s.length < (size || 2)) {s = "0" + s;}
+    return s;
+}
+
 $(document).ready(function() {
 
     var isMobile = {
@@ -56,7 +62,18 @@ $(document).ready(function() {
         options: {
             tooltips: {
                 enabled: true,
-                mode: 'x-axis'
+                mode: 'x-axis',
+                position: 'nearest',
+                callbacks: {
+                    title: function(tooltipItem, data) {
+                        var idx = tooltipItem[0].index
+                        var h = Math.floor(idx/6);
+                        var m = 10*(idx%6);
+                        var from = h.pad(2)+":"+m.pad(2)+":00";
+                        var to = h.pad(2)+":"+(m+9).pad(2)+":59";
+                        return "Queries from "+from+" to "+to;
+                    }
+                }
             },
             legend: {
                 display: false

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -1,3 +1,6 @@
+// Define global variables
+var timeLineChart, queryTypeChart, forwardDestinationChart, forwardDestinationChart;
+
 $(document).ready(function() {
 
     var isMobile = {
@@ -165,7 +168,7 @@ function updateSummaryData(runOnce) {
 function updateQueriesOverTime() {
     $.getJSON("api.php?overTimeData10mins", function(data) {
         // Add data for each hour that is available
-        for (hour in data.ads_over_time) {
+        for (var hour in data.ads_over_time) {
             var d = new Date();
             d.setHours(Math.floor(hour/6),10*(hour%6),0,0);
             timeLineChart.data.labels.push(d);

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -165,6 +165,7 @@ function updateQueriesOverTime() {
             else
             {
                 timeLineChart.data.labels.push("");
+                //timeLineChart.data.labels.push(Math.floor(hour/6) + ":" + hour%6 +"0");
             }
             // Have to multiply the data by 6 to have again the correct units (per hour, not per 10min)
             timeLineChart.data.datasets[0].data.push(6*data.domains_over_time[hour]);

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -107,17 +107,17 @@ $(document).ready(function() {
 
     // Pull in data via AJAX
 
-//    updateSummaryData();
+    updateSummaryData();
 
     updateQueriesOverTime();
 
-//    updateQueryTypes();
+    updateQueryTypes();
 
-//    updateTopClientsChart();
+    updateTopClientsChart();
 
-//    updateForwardDestinations();
+    updateForwardDestinations();
 
-//    updateTopLists();
+    updateTopLists();
 });
 
 // Functions to update data in page

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -27,7 +27,7 @@ $(document).ready(function() {
     var animate = false;
     var ctx = document.getElementById("queryOverTimeChart").getContext("2d");
     timeLineChart = new Chart(ctx, {
-        type: 'line',
+        type: "line",
         data: {
             labels: [],
             datasets: [
@@ -41,7 +41,7 @@ $(document).ready(function() {
                     pointHoverRadius: 5,
                     data: [],
                     pointHitRadius: 5,
-                    cubicInterpolationMode: 'monotone'
+                    cubicInterpolationMode: "monotone"
                 },
                 {
                     label: "Blocked DNS Queries",
@@ -53,15 +53,14 @@ $(document).ready(function() {
                     pointHoverRadius: 5,
                     data: [],
                     pointHitRadius: 5,
-                    cubicInterpolationMode: 'monotone'
+                    cubicInterpolationMode: "monotone"
                 }
             ]
         },
         options: {
             tooltips: {
                 enabled: true,
-                mode: 'x-axis',
-                position: 'nearest',
+                mode: "x-axis",
                 callbacks: {
                     title: function(tooltipItem, data) {
                         var idx = tooltipItem[0].index
@@ -99,7 +98,7 @@ $(document).ready(function() {
 
     ctx = document.getElementById("queryTypeChart").getContext("2d");
     queryTypeChart = new Chart(ctx, {
-        type: 'doughnut',
+        type: "doughnut",
         data: {
             labels: [],
             datasets: [{ data: [] }]
@@ -117,7 +116,7 @@ $(document).ready(function() {
 
     ctx = document.getElementById("forwardDestinationChart").getContext("2d");
     forwardDestinationChart = new Chart(ctx, {
-        type: 'doughnut',
+        type: "doughnut",
         data: {
             labels: [],
             datasets: [{ data: [] }]

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -60,11 +60,11 @@ $(document).ready(function() {
             },
             scales: {
                 xAxes: [{
-                    type: 'time',
+                    type: "time",
                     time: {
-                        unit: 'hour',
+                        unit: "hour",
                         displayFormats: {
-                            hour: 'HH:mm'
+                            hour: "HH:mm"
                         }
                     }
                 }],

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -68,7 +68,8 @@ $(document).ready(function() {
                         unit: "hour",
                         displayFormats: {
                             hour: "HH:mm"
-                        }
+                        },
+                        tooltipFormat: "HH:mm"
                     }
                 }],
                 yAxes: [{

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -62,8 +62,8 @@ $(document).ready(function() {
                 enabled: true,
                 mode: "x-axis",
                 callbacks: {
-                    title: function(tooltipItem, data) {
-                        var idx = tooltipItem[0].index
+                    title(tooltipItem, data) {
+                        var idx = tooltipItem[0].index;
                         var h = Math.floor(idx/6);
                         var m = 10*(idx%6);
                         var from = padNumber(h)+":"+padNumber(m)+":00";

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -59,6 +59,15 @@ $(document).ready(function() {
                 display: false
             },
             scales: {
+                xAxes: [{
+                    type: 'time',
+                    time: {
+                        unit: 'hour',
+                        displayFormats: {
+                            hour: 'hh:mm'
+                        }
+                    }
+                }],
                 yAxes: [{
                     ticks: {
                         beginAtZero: true
@@ -157,16 +166,9 @@ function updateQueriesOverTime() {
     $.getJSON("api.php?overTimeData10mins", function(data) {
         // Add data for each hour that is available
         for (hour in data.ads_over_time) {
-            // Add x-axis label
-            if(hour%6 == 0)
-            {
-                timeLineChart.data.labels.push(hour/6 + ":00");
-            }
-            else
-            {
-                timeLineChart.data.labels.push("");
-                //timeLineChart.data.labels.push(Math.floor(hour/6) + ":" + hour%6 +"0");
-            }
+            var d = new Date();
+            d.setHours(Math.floor(hour/6),10*(hour%6),0,0);
+            timeLineChart.data.labels.push(d);
             // Have to multiply the data by 6 to have again the correct units (per hour, not per 10min)
             timeLineChart.data.datasets[0].data.push(6*data.domains_over_time[hour]);
             timeLineChart.data.datasets[1].data.push(6*data.ads_over_time[hour]);

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -174,9 +174,8 @@ function updateQueriesOverTime() {
             var d = new Date();
             d.setHours(Math.floor(hour/6),10*(hour%6),0,0);
             timeLineChart.data.labels.push(d);
-            // Have to multiply the data by 6 to have again the correct units (per hour, not per 10min)
-            timeLineChart.data.datasets[0].data.push(6*data.domains_over_time[hour]);
-            timeLineChart.data.datasets[1].data.push(6*data.ads_over_time[hour]);
+            timeLineChart.data.datasets[0].data.push(data.domains_over_time[hour]);
+            timeLineChart.data.datasets[1].data.push(data.ads_over_time[hour]);
         }
         $('#queries-over-time .overlay').remove();
         timeLineChart.update();

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -3,7 +3,7 @@ var timeLineChart, queryTypeChart, forwardDestinationChart, forwardDestinationCh
 
 function padNumber(num) {
     return ("00" + num).substr(-2,2);
-};
+}
 
 $(document).ready(function() {
 

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -33,7 +33,7 @@ $(document).ready(function() {
                     pointRadius: 1,
                     pointHoverRadius: 5,
                     data: [],
-                    pointHitRadius: 20,
+                    pointHitRadius: 5,
                     cubicInterpolationMode: 'monotone'
                 },
                 {
@@ -45,7 +45,7 @@ $(document).ready(function() {
                     pointRadius: 1,
                     pointHoverRadius: 5,
                     data: [],
-                    pointHitRadius: 20,
+                    pointHitRadius: 5,
                     cubicInterpolationMode: 'monotone'
                 }
             ]

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -5,7 +5,7 @@ Number.prototype.pad = function(size) {
     var s = String(this);
     while (s.length < (size || 2)) {s = "0" + s;}
     return s;
-}
+};
 
 $(document).ready(function() {
 
@@ -34,7 +34,7 @@ $(document).ready(function() {
             labels: [],
             datasets: [
                 {
-                    label: "All Queries",
+                    label: "Total DNS Queries",
                     fill: true,
                     backgroundColor: "rgba(220,220,220,0.5)",
                     borderColor: "rgba(0, 166, 90,.8)",
@@ -46,7 +46,7 @@ $(document).ready(function() {
                     cubicInterpolationMode: 'monotone'
                 },
                 {
-                    label: "Ad Queries",
+                    label: "Blocked DNS Queries",
                     fill: true,
                     backgroundColor: "rgba(0,192,239,0.5)",
                     borderColor: "rgba(0,192,239,1)",

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -1,10 +1,8 @@
 // Define global variables
 var timeLineChart, queryTypeChart, forwardDestinationChart, forwardDestinationChart;
 
-Number.prototype.pad = function(size) {
-    var s = String(this);
-    while (s.length < (size || 2)) {s = "0" + s;}
-    return s;
+function padNumber(num) {
+    return ("00" + num).substr(-2,2);
 };
 
 $(document).ready(function() {
@@ -69,8 +67,8 @@ $(document).ready(function() {
                         var idx = tooltipItem[0].index
                         var h = Math.floor(idx/6);
                         var m = 10*(idx%6);
-                        var from = h.pad(2)+":"+m.pad(2)+":00";
-                        var to = h.pad(2)+":"+(m+9).pad(2)+":59";
+                        var from = padNumber(h)+":"+padNumber(m)+":00";
+                        var to = padNumber(h)+":"+padNumber(m+9)+":59";
                         return "Queries from "+from+" to "+to;
                     }
                 }

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -107,17 +107,17 @@ $(document).ready(function() {
 
     // Pull in data via AJAX
 
-    updateSummaryData();
+//    updateSummaryData();
 
     updateQueriesOverTime();
 
-    updateQueryTypes();
+//    updateQueryTypes();
 
-    updateTopClientsChart();
+//    updateTopClientsChart();
 
-    updateForwardDestinations();
+//    updateForwardDestinations();
 
-    updateTopLists();
+//    updateTopLists();
 });
 
 // Functions to update data in page
@@ -154,13 +154,21 @@ function updateSummaryData(runOnce) {
 }
 
 function updateQueriesOverTime() {
-    $.getJSON("api.php?overTimeData", function(data) {
+    $.getJSON("api.php?overTimeData10mins", function(data) {
         // Add data for each hour that is available
         for (hour in data.ads_over_time) {
             // Add x-axis label
-            timeLineChart.data.labels.push(hour + ":00");
-            timeLineChart.data.datasets[0].data.push(data.domains_over_time[hour]);
-            timeLineChart.data.datasets[1].data.push(data.ads_over_time[hour]);
+            if(hour%6 == 0)
+            {
+                timeLineChart.data.labels.push(hour/6 + ":00");
+            }
+            else
+            {
+                timeLineChart.data.labels.push("");
+            }
+            // Have to multiply the data by 6 to have again the correct units (per hour, not per 10min)
+            timeLineChart.data.datasets[0].data.push(6*data.domains_over_time[hour]);
+            timeLineChart.data.datasets[1].data.push(6*data.ads_over_time[hour]);
         }
         $('#queries-over-time .overlay').remove();
         timeLineChart.update();

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -64,7 +64,7 @@ $(document).ready(function() {
                     time: {
                         unit: 'hour',
                         displayFormats: {
-                            hour: 'hh:mm'
+                            hour: 'HH:mm'
                         }
                     }
                 }],


### PR DESCRIPTION
Changes proposed in this pull request:

- Increase temporal resolution in main diagram from 1h to 10min.

Before:
![screenshot at 2016-11-09 15-19-08](https://cloud.githubusercontent.com/assets/16748619/20141413/878137e6-a690-11e6-99a6-e956ea67e13d.png)

Proposed:
![screenshot at 2016-11-09 15-53-58](https://cloud.githubusercontent.com/assets/16748619/20142419/edf41e40-a694-11e6-8305-2086d52aeec7.png)


I added a new API call in order to keep backwards-compatibility. There is no speed/memory drawback as the functions are very similar, the only difference being in the way they put intervals on the acquired data.

Numerical confirmation that everything works as it should:

api.php?overTimeData

> {"domains_over_time":["854","854","828","862","834","852","840","854","831","843","857","970","1399","1732","1033","391"],"ads_over_time":["2","0","1","0","3","0","1","0","1","0","2","15","82","194","46","9"]}

api.php?overTimeData10mins

> {"domains_over_time":["144","142","146","141","135","146","140","140","143","134","154","143","141","141","134","137","139","136","140","146","138","141","151","146","147","141","134","143","137","132","136","144","137","143","149","143","142","136","135","146","144","137","134","142","139","143","153","143","140","137","143","138","132","141","136","140","135","137","154","141","140","141","138","161","145","132","138","144","137","140","177","234","226","258","312","218","167","218","185","145","175","703","366","158","150","197","189","136","168","193","155","200","168","160","104"],"ads_over_time":["0","1","0","1","0","0","0","0","0","0","0","0","0","1","0","0","0","0","0","0","0","0","0","0","1","1","0","1","0","0","0","0","0","0","0","0","0","1","0","0","0","0","0","0","0","0","0","0","0","1","0","0","0","0","0","0","0","0","0","0","1","1","0","0","0","0","0","0","0","0","0","15","17","22","22","12","1","8","7","5","9","95","71","7","4","15","10","0","6","11","1","8","10","5","4"]}

Let me verify correctness for some of the data shown above

- 00:00 - 00:59
1 h resolution: 854
10min resolution: 144+142+146+141+135+146 = 854

- 02:00 - 02:59
1 h resolution: 828
10min resolution: 141+141+134+137+139+136 = 828

- 08:00 - 08:59
1 h resolution: 831
10min resolution: 140+137+143+138+132+141 = 831

- 13:00 - 13:59
1 h resolution: 1732
10min resolution: 185+145+175+703+366+158 = 1732


@pi-hole/dashboard
