### PR TITLE
Display CPU and I/O utilization (load)

### DIFF
--- a/header.php
+++ b/header.php
@@ -22,7 +22,9 @@
     $mem = explode(" ", $free_arr[1]);
     $mem = array_filter($mem);
     $mem = array_merge($mem);
-    $memory_usage = $mem[2]/$mem[1]*100;
+    $used = $mem[2] - $mem[5] - $mem[6];
+    $total = $mem[1];
+    $memory_usage = $used/$total*100;
 ?>
 
 <!DOCTYPE html>

--- a/header.php
+++ b/header.php
@@ -11,6 +11,9 @@
     $cmd = "echo $((`cat /sys/class/thermal/thermal_zone0/temp | cut -c1-2`))";
     $output = shell_exec($cmd);
     $output = str_replace(array("\r\n","\r","\n"),"", $output);
+
+    // Get load
+    $loaddata = sys_getloadavg();
 ?>
 
 <!DOCTYPE html>
@@ -153,6 +156,18 @@
                         } else {
                             echo '<a href="#"><i class="fa fa-fire" style="color:#3366FF"></i> Temp: ' . $output . '</a>';
                         }
+                    ?>
+                    <br/>
+                    <?php
+                    echo '<a href="#"><i class="fa fa-circle" style="color:';
+                        if ($loaddata[0] > 2.0) {
+                            echo '#FF0000';
+                        }
+                        else
+                        {
+                            echo '#3366FF';
+                        }
+                        echo '""></i> Load:&nbsp;&nbsp;' . $loaddata[0] . '&nbsp;&nbsp;' . $loaddata[1] . '&nbsp;&nbsp;'. $loaddata[2] . '</a>';
                     ?>
                 </div>
             </div>

--- a/header.php
+++ b/header.php
@@ -174,7 +174,7 @@
                     <br/>
                     <?php
                     echo '<a href="#"><i class="fa fa-circle" style="color:';
-                        if ($loaddata[0] > nproc) {
+                        if ($loaddata[0] > $nproc) {
                             echo '#FF0000';
                         }
                         else

--- a/header.php
+++ b/header.php
@@ -165,7 +165,7 @@
                         }
                         else
                         {
-                            echo '#3366FF';
+                            echo '#7FFF00';
                         }
                         echo '""></i> Load:&nbsp;&nbsp;' . $loaddata[0] . '&nbsp;&nbsp;' . $loaddata[1] . '&nbsp;&nbsp;'. $loaddata[2] . '</a>';
                     ?>

--- a/header.php
+++ b/header.php
@@ -14,6 +14,9 @@
 
     // Get load
     $loaddata = sys_getloadavg();
+    // Get number of processing units available to PHP
+    // (may be less than the number of online processors)
+    $nproc = shell_exec('nproc');
 
     // Get memory usage
     $free = shell_exec('free');
@@ -171,7 +174,7 @@
                     <br/>
                     <?php
                     echo '<a href="#"><i class="fa fa-circle" style="color:';
-                        if ($loaddata[0] > 2.0) {
+                        if ($loaddata[0] > nproc) {
                             echo '#FF0000';
                         }
                         else

--- a/header.php
+++ b/header.php
@@ -14,6 +14,15 @@
 
     // Get load
     $loaddata = sys_getloadavg();
+
+    // Get memory usage
+    $free = shell_exec('free');
+    $free = (string)trim($free);
+    $free_arr = explode("\n", $free);
+    $mem = explode(" ", $free_arr[1]);
+    $mem = array_filter($mem);
+    $mem = array_merge($mem);
+    $memory_usage = $mem[2]/$mem[1]*100;
 ?>
 
 <!DOCTYPE html>
@@ -168,6 +177,18 @@
                             echo '#7FFF00';
                         }
                         echo '""></i> Load:&nbsp;&nbsp;' . $loaddata[0] . '&nbsp;&nbsp;' . $loaddata[1] . '&nbsp;&nbsp;'. $loaddata[2] . '</a>';
+                    ?>
+                    <br/>
+                    <?php
+                    echo '<a href="#"><i class="fa fa-circle" style="color:';
+                        if ($memory_usage > 75) {
+                            echo '#FF0000';
+                        }
+                        else
+                        {
+                            echo '#7FFF00';
+                        }
+                        echo '""></i> Memory usage:&nbsp;&nbsp;' . sprintf("%.1f",$memory_usage) . '%</a>';
                     ?>
                 </div>
             </div>


### PR DESCRIPTION
Changes proposed in this pull request:
- Display load.
Color: green if load was small/equal to 2.0 during the last minute, red otherwise.

The three columns measure CPU and I/O utilization of the last one, five, and 15 minute periods and are commonly used in the Linux world.

![untitled24](https://cloud.githubusercontent.com/assets/16748619/20145352/1a335038-a6a0-11e6-882d-c6559b416912.png)

@pi-hole/dashboard