### PR TITLE
Add option to show *all* recent queries at once

### DIFF
--- a/js/pihole/queries.js
+++ b/js/pihole/queries.js
@@ -18,7 +18,8 @@ $(document).ready(function() {
             { "width" : "40%" },
             { "width" : "15%" },
             { "width" : "15%" }
-        ]
+        ],
+        "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
     })
 } );
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Add "All" as an option:
![untitled54614](https://cloud.githubusercontent.com/assets/16748619/20263901/2b7549ba-aa69-11e6-875a-2f2761605bc7.png)

At the bottom of the page, we now see
![screenshot at 2016-11-14 12-51-46](https://cloud.githubusercontent.com/assets/16748619/20263904/2ceffb96-aa69-11e6-8be3-0ca746d8dc2a.png)
ans there is only one page, as expected.

@pi-hole/dashboard

