### PR TITLE
Display CPU temperature in Fahrenheit

### DIFF
--- a/header.php
+++ b/header.php
@@ -10,7 +10,9 @@
     }
     $cmd = "echo $((`cat /sys/class/thermal/thermal_zone0/temp | cut -c1-2`))";
     $output = shell_exec($cmd);
-    $output = str_replace(array("\r\n","\r","\n"),"", $output);
+    $celsius = str_replace(array("\r\n","\r","\n"),"", $output);
+    $fahrenheit = str_replace(["\r\n","\r","\n"],"", $output*9./5)+32;
+    $temperatureunit =  parse_ini_file("/etc/pihole/setupVars.conf")['temperatureunit'];
 ?>
 
 <!DOCTYPE html>
@@ -148,11 +150,20 @@
                         }
 
                         // CPU Temp
-                        if ($output > "45") {
-                            echo '<a href="#"><i class="fa fa-fire" style="color:#FF0000"></i> Temp: ' . $output . '</a>';
-                        } else {
-                            echo '<a href="#"><i class="fa fa-fire" style="color:#3366FF"></i> Temp: ' . $output . '</a>';
+                        echo '<a href="#" id="temperature"><i class="fa fa-fire" style="color:';
+                        if ($celsius > "45") {
+                            echo '#FF0000';
                         }
+                        else
+                        {
+                            echo '#3366FF';
+                        }
+                        echo '"></i> Temp:&nbsp;';
+                        if($temperatureunit != "F")
+                            echo $celsius . '&deg;C';
+                        else
+                            echo $fahrenheit . '&deg;F';
+                        echo '</a>';
                     ?>
                 </div>
             </div>

--- a/header.php
+++ b/header.php
@@ -12,7 +12,7 @@
     $output = shell_exec($cmd);
     $celsius = str_replace(array("\r\n","\r","\n"),"", $output);
     $fahrenheit = round(str_replace(["\r\n","\r","\n"],"", $output*9./5)+32);
-    $temperatureunit =  parse_ini_file("/etc/pihole/setupVars.conf")['temperatureunit'];
+    $temperatureunit =  parse_ini_file("/etc/pihole/setupVars.conf")['TEMPERATUREUNIT'];
 ?>
 
 <!DOCTYPE html>

--- a/header.php
+++ b/header.php
@@ -11,7 +11,7 @@
     $cmd = "echo $((`cat /sys/class/thermal/thermal_zone0/temp | cut -c1-2`))";
     $output = shell_exec($cmd);
     $celsius = str_replace(array("\r\n","\r","\n"),"", $output);
-    $fahrenheit = str_replace(["\r\n","\r","\n"],"", $output*9./5)+32;
+    $fahrenheit = round(str_replace(["\r\n","\r","\n"],"", $output*9./5)+32);
     $temperatureunit =  parse_ini_file("/etc/pihole/setupVars.conf")['temperatureunit'];
 ?>
 


### PR DESCRIPTION
Fixes #176 

Changes proposed in this pull request:

- Compute CPU temperature both in units Celsius and Fahrenheit. The units can be toggled by setting the flag `temperatureunit=F` in `/etc/pihole/setupVars.conf`

Celsius (shown if flag is missing or set to something different than `F`):
![celsius](https://cloud.githubusercontent.com/assets/16748619/20139574/22d9113c-a687-11e6-8336-032a6547837f.png)

Fahrenheit (shown if flag is set to `F`):
![fahrenheit](https://cloud.githubusercontent.com/assets/16748619/20139578/28f71276-a687-11e6-9baf-123f611cf01c.png)

Note that clicking on the temperature will have no effect, as it has been requested that the temperate unit should be stored in a config file.

@pi-hole/dashboard