### PR TITLE
Skip last datapoint in main diagram

### DIFF
--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -156,6 +156,8 @@ function updateSummaryData(runOnce) {
 function updateQueriesOverTime() {
     $.getJSON("api.php?overTimeData", function(data) {
         // Add data for each hour that is available
+        // remove last data point since it not representative
+        data.ads_over_time.splice(-1,1);
         for (hour in data.ads_over_time) {
             // Add x-axis label
             timeLineChart.data.labels.push(hour + ":00");


### PR DESCRIPTION
Changes proposed in this pull request:

- Skip last datapoint in main diagram.

We collect the number of DNS queries in intervals. Let's say the current time is "14:02". Then the last datapoint will only contain the queries within the most recent two minutes, pulling down the line quite significantly:
![screenshot at 2016-11-17 14-01-18](https://cloud.githubusercontent.com/assets/16748619/20390261/5c6f4a36-acce-11e6-8908-d756ef5e6645.png)

It seems to make much more sense to remove the last data point entirely (since it is not final anyhow):
![screenshot at 2016-11-17 14-03-23](https://cloud.githubusercontent.com/assets/16748619/20390326/a49a8ca8-acce-11e6-97e8-3b5f70368fee.png)


The drawback is that the data lacks one time step behind. However, after merging PR #191 this will go unnoticed, I suppose.

@pi-hole/dashboard

