### PR TITLE
standalone mode for iOS

### DIFF
--- a/header.php
+++ b/header.php
@@ -47,6 +47,7 @@
     <link rel="icon" type="image/png" sizes="96x96" href="img/logo.svg">
     <meta name="msapplication-TileColor" content="#367fa9">
     <meta name="msapplication-TileImage" content="img/logo.svg">
+    <meta name="apple-mobile-web-app-capable" content="yes">
 
     <link href="bootstrap/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
     <link href="css/font-awesome-4.5.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Fixes #[none] .

Changes proposed in this pull request:

- This will make the admin page look more like a native iOS application when started from Home Screen on iOS. It also won't create a tab in iOS Safari and saves spacetime. See *Hiding Safari User Interface Components* on:
https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html

@pi-hole/dashboard
