### PR TITLE
Be able to pass filters to queries.php

### DIFF
--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -261,9 +261,9 @@ function updateTopLists() {
     $.getJSON("api.php?summaryRaw&topItems", function(data) {
         var domaintable = $('#domain-frequency').find('tbody:last');
         var adtable = $('#ad-frequency').find('tbody:last');
-        var url;
+        var url, domain;
 
-        for (var domain in data.top_queries) {
+        for (domain in data.top_queries) {
             if(domain !== "pi.hole")
             {
                 url = "<a href=\"queries.php?domain="+domain+"\">"+domain+"</a>";
@@ -276,7 +276,7 @@ function updateTopLists() {
                 '</td> <td>' + data.top_queries[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-green" style="width: ' +
                 data.top_queries[domain] / data.dns_queries_today * 100 + '%"></div> </div> </td> </tr> ');
         }
-        for (var domain in data.top_ads) {
+        for (domain in data.top_ads) {
             url = "<a href=\"queries.php?domain="+domain+"\">"+domain+"</a>";
             adtable.append("<tr> <td>" + url +
                 '</td> <td>' + data.top_ads[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-yellow" style="width: ' +

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -224,7 +224,8 @@ function updateTopClientsChart() {
     $.getJSON("api.php?summaryRaw&getQuerySources", function(data) {
         var clienttable =  $('#client-frequency').find('tbody:last');
         for (domain in data.top_sources) {
-            clienttable.append('<tr> <td>' + domain +
+            var url = '<a href="queries.php?client='+domain+'">'+domain+'</a>';
+            clienttable.append('<tr> <td>' + url +
                 '</td> <td>' + data.top_sources[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-blue" style="width: ' +
                 data.top_sources[domain] / data.dns_queries_today * 100 + '%"></div> </div> </td> </tr> ');
         }
@@ -260,14 +261,24 @@ function updateTopLists() {
     $.getJSON("api.php?summaryRaw&topItems", function(data) {
         var domaintable = $('#domain-frequency').find('tbody:last');
         var adtable = $('#ad-frequency').find('tbody:last');
+        var url;
 
         for (domain in data.top_queries) {
-            domaintable.append('<tr> <td>' + domain +
+            if(domain !== "pi.hole")
+            {
+                url = '<a href="queries.php?domain='+domain+'">'+domain+'</a>';
+            }
+            else
+            {
+                url = domain;
+            }
+            domaintable.append('<tr> <td>' + url +
                 '</td> <td>' + data.top_queries[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-green" style="width: ' +
                 data.top_queries[domain] / data.dns_queries_today * 100 + '%"></div> </div> </td> </tr> ');
         }
         for (domain in data.top_ads) {
-            adtable.append('<tr> <td>' + domain +
+            url = '<a href="queries.php?domain='+domain+'">'+domain+'</a>';
+            adtable.append('<tr> <td>' + url +
                 '</td> <td>' + data.top_ads[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-yellow" style="width: ' +
                 data.top_ads[domain] / data.ads_blocked_today * 100 + '%"></div> </div> </td> </tr> ');
         }

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -276,7 +276,7 @@ function updateTopLists() {
                 '</td> <td>' + data.top_queries[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-green" style="width: ' +
                 data.top_queries[domain] / data.dns_queries_today * 100 + '%"></div> </div> </td> </tr> ');
         }
-        for (domain in data.top_ads) {
+        for (var domain in data.top_ads) {
             url = "<a href=\"queries.php?domain="+domain+"\">"+domain+"</a>";
             adtable.append("<tr> <td>" + url +
                 '</td> <td>' + data.top_ads[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-yellow" style="width: ' +

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -223,11 +223,11 @@ function updateQueryTypes() {
 // Credit: http://stackoverflow.com/questions/1787322/htmlspecialchars-equivalent-in-javascript/4835406#4835406
 function escapeHtml(text) {
   var map = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#039;'
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;",
+    "\'": "&#039;"
   };
 
   return text.replace(/[&<>"']/g, function(m) { return map[m]; });

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -223,9 +223,9 @@ function updateQueryTypes() {
 function updateTopClientsChart() {
     $.getJSON("api.php?summaryRaw&getQuerySources", function(data) {
         var clienttable =  $('#client-frequency').find('tbody:last');
-        for (domain in data.top_sources) {
-            var url = '<a href="queries.php?client='+domain+'">'+domain+'</a>';
-            clienttable.append('<tr> <td>' + url +
+        for (var domain in data.top_sources) {
+            var url = url = "<a href=\"queries.php?client="+domain+"\">"+domain+"</a>";
+            clienttable.append("<tr> <td>" + url +
                 '</td> <td>' + data.top_sources[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-blue" style="width: ' +
                 data.top_sources[domain] / data.dns_queries_today * 100 + '%"></div> </div> </td> </tr> ');
         }
@@ -263,22 +263,22 @@ function updateTopLists() {
         var adtable = $('#ad-frequency').find('tbody:last');
         var url;
 
-        for (domain in data.top_queries) {
+        for (var domain in data.top_queries) {
             if(domain !== "pi.hole")
             {
-                url = '<a href="queries.php?domain='+domain+'">'+domain+'</a>';
+                url = "<a href=\"queries.php?domain="+domain+"\">"+domain+"</a>";
             }
             else
             {
                 url = domain;
             }
-            domaintable.append('<tr> <td>' + url +
+            domaintable.append("<tr> <td>" + url +
                 '</td> <td>' + data.top_queries[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-green" style="width: ' +
                 data.top_queries[domain] / data.dns_queries_today * 100 + '%"></div> </div> </td> </tr> ');
         }
         for (domain in data.top_ads) {
-            url = '<a href="queries.php?domain='+domain+'">'+domain+'</a>';
-            adtable.append('<tr> <td>' + url +
+            url = "<a href=\"queries.php?domain="+domain+"\">"+domain+"</a>";
+            adtable.append("<tr> <td>" + url +
                 '</td> <td>' + data.top_ads[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-yellow" style="width: ' +
                 data.top_ads[domain] / data.ads_blocked_today * 100 + '%"></div> </div> </td> </tr> ');
         }

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -236,7 +236,8 @@ function escapeHtml(text) {
 function updateTopClientsChart() {
     $.getJSON("api.php?summaryRaw&getQuerySources", function(data) {
         var clienttable =  $('#client-frequency').find('tbody:last');
-        for (var domain in data.top_sources) {
+        var domain;
+        for (domain in data.top_sources) {
             // Sanitize domain
             domain = escapeHtml(domain);
             var url = "<a href=\"queries.php?client="+domain+"\">"+domain+"</a>";

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -220,11 +220,26 @@ function updateQueryTypes() {
     });
 }
 
+// Credit: http://stackoverflow.com/questions/1787322/htmlspecialchars-equivalent-in-javascript/4835406#4835406
+function escapeHtml(text) {
+  var map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+
+  return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+}
+
 function updateTopClientsChart() {
     $.getJSON("api.php?summaryRaw&getQuerySources", function(data) {
         var clienttable =  $('#client-frequency').find('tbody:last');
         for (var domain in data.top_sources) {
-            var url = url = "<a href=\"queries.php?client="+domain+"\">"+domain+"</a>";
+            // Sanitize domain
+            domain = escapeHtml(domain);
+            var url = "<a href=\"queries.php?client="+domain+"\">"+domain+"</a>";
             clienttable.append("<tr> <td>" + url +
                 '</td> <td>' + data.top_sources[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-blue" style="width: ' +
                 data.top_sources[domain] / data.dns_queries_today * 100 + '%"></div> </div> </td> </tr> ');
@@ -264,6 +279,8 @@ function updateTopLists() {
         var url, domain;
 
         for (domain in data.top_queries) {
+            // Sanitize domain
+            domain = escapeHtml(domain);
             if(domain !== "pi.hole")
             {
                 url = "<a href=\"queries.php?domain="+domain+"\">"+domain+"</a>";
@@ -277,6 +294,8 @@ function updateTopLists() {
                 data.top_queries[domain] / data.dns_queries_today * 100 + '%"></div> </div> </td> </tr> ');
         }
         for (domain in data.top_ads) {
+            // Sanitize domain
+            domain = escapeHtml(domain);
             url = "<a href=\"queries.php?domain="+domain+"\">"+domain+"</a>";
             adtable.append("<tr> <td>" + url +
                 '</td> <td>' + data.top_ads[domain] + '</td> <td> <div class="progress progress-sm"> <div class="progress-bar progress-bar-yellow" style="width: ' +

--- a/js/pihole/queries.js
+++ b/js/pihole/queries.js
@@ -1,4 +1,14 @@
 var tableApi;
+
+function escapeRegex(text) {
+  var map = {
+    '(': '\\(',
+    ')': '\\)',
+    '.': '\\.',
+  };
+  return text.replace(/[().]/g, function(m) { return map[m]; });
+}
+
 $(document).ready(function() {
     tableApi = $('#all-queries').DataTable( {
         "rowCallback": function( row, data, index ){
@@ -47,26 +57,16 @@ $(document).ready(function() {
     location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1];});
     if("client" in GETDict)
     {
-        if(GETDict["client"] === "localhost(127.0.0.1)")
-        {
-            // Have to use normal search, as regexp of DataTable is broken
-            // It should be fixed in next release which might come up next
-            // year. In the meantime, we work around using normal search.
-            tableApi.column(3).search("localhost");
-        }
-        else
-        {
-            // Search in third column (zero indexed)
-            // Use regular expression to only show exact matches, i.e.
-            // don't show 192.168.0.100 when searching for 192.168.0.1
-            // true = use regex, false = don't use smart search
-            tableApi.column(3).search("^"+GETDict["client"]+"$",true,false);
-        }
+        // Search in third column (zero indexed)
+        // Use regular expression to only show exact matches, i.e.
+        // don't show 192.168.0.100 when searching for 192.168.0.1
+        // true = use regex, false = don't use smart search
+        tableApi.column(3).search("^"+escapeRegex(GETDict["client"])+"$",true,false);
     }
     if("domain" in GETDict)
     {
         // Search in second column (zero indexed)
-        tableApi.column(2).search("^"+GETDict["domain"]+"$",true,false);
+        tableApi.column(2).search("^"+escapeRegex(GETDict["domain"])+"$",true,false);
     }
 } );
 

--- a/js/pihole/queries.js
+++ b/js/pihole/queries.js
@@ -1,4 +1,5 @@
-$(document).ready(function() {
+var tableApi;
+(document).ready(function() {
     tableApi = $('#all-queries').DataTable( {
         "rowCallback": function( row, data, index ){
             if (data[4] == "Pi-holed") {
@@ -42,11 +43,11 @@ $(document).ready(function() {
     } );
 
     // Do we want to filter queries?
-    var GETDict = {}
-    location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1]})
+    var GETDict = {};
+    location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1]});
     if("client" in GETDict)
     {
-        if(GETDict["client"] == "localhost(127.0.0.1)")
+        if(GETDict["client"] === "localhost(127.0.0.1)")
         {
             // Have to use normal search, as regexp of DataTable is broken
             // It should be fixed in next release which might come up next

--- a/js/pihole/queries.js
+++ b/js/pihole/queries.js
@@ -1,5 +1,5 @@
 var tableApi;
-(document).ready(function() {
+$(document).ready(function() {
     tableApi = $('#all-queries').DataTable( {
         "rowCallback": function( row, data, index ){
             if (data[4] == "Pi-holed") {
@@ -44,7 +44,7 @@ var tableApi;
 
     // Do we want to filter queries?
     var GETDict = {};
-    location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1];});
+    location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1]});
     if("client" in GETDict)
     {
         if(GETDict["client"] === "localhost(127.0.0.1)")

--- a/js/pihole/queries.js
+++ b/js/pihole/queries.js
@@ -44,7 +44,7 @@ var tableApi;
 
     // Do we want to filter queries?
     var GETDict = {};
-    location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1]});
+    location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1];});
     if("client" in GETDict)
     {
         if(GETDict["client"] === "localhost(127.0.0.1)")

--- a/js/pihole/queries.js
+++ b/js/pihole/queries.js
@@ -40,6 +40,33 @@ $(document).ready(function() {
           add(data[2],"black");
         }
     } );
+
+    // Do we want to filter queries?
+    var GETDict = {}
+    location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1]})
+    if("client" in GETDict)
+    {
+        if(GETDict["client"] == "localhost(127.0.0.1)")
+        {
+            // Have to use normal search, as regexp of DataTable is broken
+            // It should be fixed in next release which might come up next
+            // year. In the meantime, we work around using normal search.
+            tableApi.column(3).search("localhost");
+        }
+        else
+        {
+            // Search in third column (zero indexed)
+            // Use regular expression to only show exact matches, i.e.
+            // don't show 192.168.0.100 when searching for 192.168.0.1
+            // true = use regex, false = don't use smart search
+            tableApi.column(3).search("^"+GETDict["client"]+"$",true,false);
+        }
+    }
+    if("domain" in GETDict)
+    {
+        // Search in second column (zero indexed)
+        tableApi.column(2).search("^"+GETDict["domain"]+"$",true,false);
+    }
 } );
 
 function refreshData() {

--- a/js/pihole/queries.js
+++ b/js/pihole/queries.js
@@ -44,7 +44,7 @@ $(document).ready(function() {
 
     // Do we want to filter queries?
     var GETDict = {};
-    location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1]});
+    location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1];});
     if("client" in GETDict)
     {
         if(GETDict["client"] === "localhost(127.0.0.1)")

--- a/js/pihole/queries.js
+++ b/js/pihole/queries.js
@@ -2,9 +2,9 @@ var tableApi;
 
 function escapeRegex(text) {
   var map = {
-    '(': '\\(',
-    ')': '\\)',
-    '.': '\\.',
+    "(": "\\(",
+    ")": "\\)",
+    ".": "\\.",
   };
   return text.replace(/[().]/g, function(m) { return map[m]; });
 }


### PR DESCRIPTION
Fixes #90 .

Changes proposed in this pull request:

- Be able to call queries.js with preset filters like `queries.php?client=10.100.0.1` or `queries.php?domain=github.com`

- Automatically provide links in all three tables on the main page to get the corresponding queries

![screenshot at 2016-11-21 17-36-30](https://cloud.githubusercontent.com/assets/16748619/20491435/aff90264-b011-11e6-9b25-606fdcb236b0.png)

Looking for a specific domain:
![screenshot at 2016-11-21 17-36-12](https://cloud.githubusercontent.com/assets/16748619/20491444/b7fb2c08-b011-11e6-845a-f0e17906726a.png)

Looking for a specific client:
![screenshot at 2016-11-21 17-41-55](https://cloud.githubusercontent.com/assets/16748619/20491495/de0c1d9e-b011-11e6-9141-659651485e5e.png)


@pi-hole/dashboard

