### PR TITLE
Adding a Help Center to the Web UI

### DIFF
--- a/header.php
+++ b/header.php
@@ -256,6 +256,12 @@
                         <i class="fa fa-paypal"></i> <span>Donate</span>
                     </a>
                 </li>
+                <!-- Help -->
+                <li>
+                    <a href="help.php">
+                        <i class="fa fa-question-circle"></i> <span>Help</span>
+                    </a>
+                </li>
             </ul>
         </section>
         <!-- /.sidebar -->

--- a/header.php
+++ b/header.php
@@ -8,6 +8,20 @@
       $refer = $_SERVER['HTTP_REFERER'];
       header("location:$refer");
     }
+
+    // Web based change of temperature unit
+    if (isset($_GET['tempunit']))
+    {
+        if($_GET['tempunit'] == "fahrenheit")
+        {
+            exec('sudo pihole -a -f');
+        }
+        else
+        {
+            exec('sudo pihole -a -c');
+        }
+    }
+
     $cmd = "echo $((`cat /sys/class/thermal/thermal_zone0/temp | cut -c1-2`))";
     $output = shell_exec($cmd);
     $celsius = str_replace(array("\r\n","\r","\n"),"", $output);

--- a/header.php
+++ b/header.php
@@ -253,7 +253,7 @@
                 <!-- Run gravity.sh -->
                 <li>
                     <a href="gravity.php">
-                        <i class="fa fa-arrow-circle-down"></i> <span>Update lists</span>
+                        <i class="fa fa-arrow-circle-down"></i> <span>Update Lists</span>
                     </a>
                 </li>
                 <!-- Toggle -->

--- a/help.php
+++ b/help.php
@@ -9,6 +9,25 @@
     <div class="col-md-12">
     <h2>Header</h2>
     <h3>Top left: Status display</h3>
+    <p>Shows different status messages:</p>
+    <ul>
+        <li>Status (Active, Offline, Starting) of the Pi-hole</li>
+        <li>Current CPU temperature
+        <?php
+        if($temperatureunit != "F"){
+        ?>
+        (switch unit to <a href="help.php?tempunit=fahrenheit">Fahrenheit</a>)
+        <?php
+        }
+        else
+        {
+        ?>
+        (switch unit to <a href="help.php?tempunit=celsius">Celsius</a>)
+        <?php
+        }
+        ?></li>
+        <li></li>
+    </ul>
     <h3>Top right: About</h3>
     </div>
 </div>

--- a/help.php
+++ b/help.php
@@ -1,14 +1,11 @@
 <?php
     require "header.php";
 ?>
-<!-- Title -->
-<div class="page-header">
-    <h1>Help center</h1>
-</div>
 <div class="row">
     <div class="col-md-12">
+    <h1>Help center</h1>
     <h2>Header</h2>
-    <h3>Top left: Status display</h3>
+    <h4>Top left: Status display</h4>
     <p>Shows different status messages:</p>
     <ul>
         <li>Status: Current status of the Pi-hole - Active (<i class="fa fa-circle" style="color:#7FFF00"></i>), Offline (<i class="fa fa-circle" style="color:#FF0000"></i>), or Starting (<i class="fa fa-circle" style="color:#ff9900"></i>)</li>
@@ -29,7 +26,7 @@
         <li>Load: load averages for the last minute, 5 minutes and 15 minutes, respectively. A load average of 1 reflects the full workload of a single processor on the system. We show a red icon if the current load exceeds the number of available processors on this machine (which is <?php echo $nproc; ?>)</li>
         <li>Memory usage: Shows the percentage of memory acutally blocked by applications. We show a red icon if the memory usage exceeds 75%</li>
     </ul>
-    <h3>Top right: About</h3>
+    <h4>Top right: About</h4>
     <ul>
         <li>GitHub: Link to pi-hole repository</li>
         <li>Details: Link to Jacob Salmela's blog with some more details, describing also the concept of the Pi-hole</li>

--- a/help.php
+++ b/help.php
@@ -54,7 +54,6 @@
         </li>
         <li>Query Types: Shows to which upstream DNS the permitted requests have been forwarded to.</li>
         <li>Top Domains: Ranking of requested sites by number of DNS lookups.</li>
-        <li>Top Advertisers: Ranking of requested sites by number of DNS lookups.</li>
         <li>Top Advertisers: Ranking of requested advertisements by number of DNS lookups.</li>
         <li>Top Clients: Ranking of total DNS requests separated by clients on the local network.</li>
     </ul>

--- a/help.php
+++ b/help.php
@@ -88,6 +88,7 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Donate</h2>
+    If you like Pi-Hole, please consider a small donation. Keep in mind that Pi-hole is free, but powered by your donations
     </div>
 </div>
 <div class="row">

--- a/help.php
+++ b/help.php
@@ -64,6 +64,7 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Query Log</h2>
+    <p>Shows the recent queries after parsing the pi-hole log files. It is possible to search through the whole list by using the "Search" input field. If the status is reported as "OK", then the DNS request has been permitted. Otherwise ("Pi-holed") it has been blocked. By clicking on the buttons under "Action" the corresponding domains can quickly be added to the white-/blacklist. The status of this action will be reported on this page.</p>
     </div>
 </div>
 <div class="row">

--- a/help.php
+++ b/help.php
@@ -1,0 +1,60 @@
+<?php
+    require "header.php";
+?>
+<!-- Title -->
+<div class="page-header">
+    <h1>Help center</h1>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Header</h2>
+    <h3>Top left: Status display</h3>
+    <h3>Top right: About</h3>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Main page</h2>
+    <p>On the main page, various statistics of pi-hole are shown to the user.</p>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Query Log</h2>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>White- / Blacklist</h2>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Update lists</h2>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Disable / Enable</h2>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Donate</h2>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Help (this page)</h2>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Footer</h2>
+    </div>
+</div>
+
+
+<?php
+    require "footer.php";
+?>

--- a/help.php
+++ b/help.php
@@ -75,7 +75,8 @@
 </div>
 <div class="row">
     <div class="col-md-12">
-    <h2>Update lists</h2>
+    <h2>Update Lists</h2>
+    <p>Runs the command <pre>sudo pihole -g</pre> and prints the result transparently to the web UI. The gravity.sh script will update the list of ad-serving domains</p>
     </div>
 </div>
 <div class="row">

--- a/help.php
+++ b/help.php
@@ -48,6 +48,7 @@
                 <li>AAAA: IPv6 address lookup (most commonly used to map hostnames to an IP address of the host)</li>
                 <li>PTR: most common use is for implementing reverse DNS lookups</li>
                 <li>SRV: Service locator (often used by XMPP, SIP, and LDAP)</li>
+                <li>and others</li>
             </ul>
         </li>
         <li>Query Types: Shows to which upstream DNS the permitted requests have been forwarded to.</li>

--- a/help.php
+++ b/help.php
@@ -29,7 +29,7 @@
     </ul>
     <h4>Top right: About</h4>
     <ul>
-        <li>GitHub: Link to pi-hole repository</li>
+        <li>GitHub: Link to the Pi-hole repository</li>
         <li>Details: Link to Jacob Salmela's blog with some more details, describing also the concept of the Pi-hole</li>
         <li>Updates: Link to list of releases</li>
         <li>Update notifications: If updates are available, a link will be shown here.</li>
@@ -39,14 +39,14 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Main page</h2>
-    <p>On the main page, various statistics of pi-hole are shown to the user:</p>
+    <p>On the main page, you can see various Pi-hole statistics:</p>
     <ul>
-        <li>Summary: A summary of statistics showing how many out of how many total DNS queries have been blocked today, how that translates into a percentage and how many domains are on the blacklist. This graph is updated every 10 seconds. Changes are highlighted.</li>
-        <li>Queries over time: Diagram showing DNS queries (total and blocked) over 10 minute time intervals. More information can be acquired by hovering over the lines.</li>
-        <li>Query Types: Shows which types of query have been processed:
+        <li>Summary: A summary of statistics showing how many total DNS queries have been blocked today, what percentage of DNS queries have been blocked, and how many domains are in the compiled ad list. This summary is updated every 10 seconds.</li>
+        <li>Queries over time: Graph showing DNS queries (total and blocked) over 10 minute time intervals. More information can be acquired by hovering over the lines.</li>
+        <li>Query Types: Identifies the types of processed queries:
             <ul>
-                <li>A: IPv4 address lookup (most commonly used to map hostnames to an IP address of the host)</li>
-                <li>AAAA: IPv6 address lookup (most commonly used to map hostnames to an IP address of the host)</li>
+                <li>A: address lookup (most commonly used to map hostnames to an IPv4 address of the host)</li>
+                <li>AAAA: address lookup (most commonly used to map hostnames to an IPv6 address of the host)</li>
                 <li>PTR: most common use is for implementing reverse DNS lookups</li>
                 <li>SRV: Service locator (often used by XMPP, SIP, and LDAP)</li>
                 <li>and others</li>
@@ -55,14 +55,14 @@
         <li>Query Types: Shows to which upstream DNS the permitted requests have been forwarded to.</li>
         <li>Top Domains: Ranking of requested sites by number of DNS lookups.</li>
         <li>Top Advertisers: Ranking of requested advertisements by number of DNS lookups.</li>
-        <li>Top Clients: Ranking of total DNS requests separated by clients on the local network.</li>
+        <li>Top Clients: Ranking of how many DNS requests each client has made on the local network.</li>
     </ul>
     </div>
 </div>
 <div class="row">
     <div class="col-md-12">
     <h2>Query Log</h2>
-    <p>Shows the recent queries after parsing the pi-hole log files. It is possible to search through the whole list by using the "Search" input field. If the status is reported as "OK", then the DNS request has been permitted. Otherwise ("Pi-holed") it has been blocked. By clicking on the buttons under "Action" the corresponding domains can quickly be added to the white-/blacklist. The status of this action will be reported on this page.</p>
+    <p>Shows the recent queries by parsing Pi-hole's log. It is possible to search through the whole list by using the "Search" input field. If the status is reported as "OK", then the DNS request has been permitted. Otherwise ("Pi-holed") it has been blocked. By clicking on the buttons under "Action" the corresponding domains can quickly be added to the white-/blacklist. The status of the action will be reported on this page.</p>
     </div>
 </div>
 <div class="row">
@@ -80,13 +80,13 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Disable / Enable</h2>
-    Disables resp. enables Pi-Hole DNS Blocking completely. The change will be reflected by a changed status (top left)
+    Disables/enables Pi-Hole blocking completely. You may have to wait a few minutes for the changes to reach all of your devices. The change will be reflected by a changed status (top left)
     </div>
 </div>
 <div class="row">
     <div class="col-md-12">
     <h2>Donate</h2>
-    If you like Pi-Hole, please consider a small donation. Keep in mind that Pi-hole is free, but powered by your donations
+    Keep in mind that Pi-hole is free. If you like Pi-hole, please consider a small donation to help support its development
     </div>
 </div>
 <div class="row">
@@ -104,7 +104,7 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Emergency help</h2>
-    In case the web UI does not work properly anymore (i.e. timeout errors or diagrams not showing up) you can try to flush the Pi-hole config file by clicking <a href="#" id="flush">FLUSH</a>. Note that your statistics will be reset and you loose the statistics of the day until now.
+    In case the web UI does not work properly anymore (i.e. timeout errors or diagrams not showing up) you can try to flush the Pi-hole config file by clicking <a href="#" id="flush">FLUSH</a>. Note that your statistics will be reset and you lose the statistics up to this point.
     </div>
 </div>
 
@@ -112,10 +112,7 @@
     // Web based flushing of pi-hole log file
     if (isset($_GET["flush"]))
     {
-        if($_GET["flush"] == "true")
-        {
-            exec("sudo pihole -f");
-        }
+        exec("sudo pihole -f");
     }
 
     require "footer.php";

--- a/help.php
+++ b/help.php
@@ -41,7 +41,24 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Main page</h2>
-    <p>On the main page, various statistics of pi-hole are shown to the user.</p>
+    <p>On the main page, various statistics of pi-hole are shown to the user:</p>
+    <ul>
+        <li>Summary: A summary of statistics showing how many out of how many total DNS queries have been blocked today, how that translates into a percentage and how many domains are on the blacklist. This graph is updated every 10 seconds. Changes are highlighted.</li>
+        <li>Queries over time: Diagram showing DNS queries (total and blocked) over 10 minute time intervals. More information can be acquired by hovering over the lines.</li>
+        <li>Query Types: Shows which types of query have been processed:
+            <ul>
+                <li>A: IPv4 address lookup (most commonly used to map hostnames to an IP address of the host)</li>
+                <li>AAAA: IPv6 address lookup (most commonly used to map hostnames to an IP address of the host)</li>
+                <li>PTR: most common use is for implementing reverse DNS lookups</li>
+                <li>SRV: Service locator (often used by XMPP, SIP, and LDAP)</li>
+            </ul>
+        </li>
+        <li>Query Types: Shows to which upstream DNS the permitted requests have been forwarded to.</li>
+        <li>Top Domains: Ranking of requested sites by number of DNS lookups.</li>
+        <li>Top Advertisers: Ranking of requested sites by number of DNS lookups.</li>
+        <li>Top Advertisers: Ranking of requested advertisments by number of DNS lookups.</li>
+        <li>Top Clients: Ranking of total DNS requests separated by clients on the local network.</li>
+    </ul>
     </div>
 </div>
 <div class="row">

--- a/help.php
+++ b/help.php
@@ -94,6 +94,7 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Help (this page)</h2>
+    Shows information about what is happening behind the scenes and what can be done with this web user interface (web UI)
     </div>
 </div>
 <div class="row">

--- a/help.php
+++ b/help.php
@@ -100,6 +100,7 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Footer</h2>
+    Shows the currently installed Pi-hole and Web Interface version. If an update is available, this will be indicated here
     </div>
 </div>
 

--- a/help.php
+++ b/help.php
@@ -11,7 +11,7 @@
     <h3>Top left: Status display</h3>
     <p>Shows different status messages:</p>
     <ul>
-        <li>Status (Active, Offline, Starting) of the Pi-hole</li>
+        <li>Status (Active (<i class="fa fa-circle" style="color:#7FFF00"></i>), Offline (<i class="fa fa-circle" style="color:#FF0000"></i>), Starting (<i class="fa fa-circle" style="color:#ff9900"></i>)) of the Pi-hole</li>
         <li>Current CPU temperature
         <?php
         if($temperatureunit != "F"){
@@ -26,7 +26,8 @@
         <?php
         }
         ?></li>
-        <li></li>
+        <li>Load: load averages for the last minute, 5 minutes and 15 minutes, respectively. A load average of 1 reflects the full workload of a single processor on the system. We show a red icon if the current load exceeds the number of available processors on this machine (which is <?php echo $nproc; ?>)</li>
+        <li>Memory usage: Shows the percentage of memory acutally blocked by applications. We show a red icon if the memory usage exceeds 75%</li>
     </ul>
     <h3>Top right: About</h3>
     </div>

--- a/help.php
+++ b/help.php
@@ -1,6 +1,7 @@
 <?php
     require "header.php";
 ?>
+
 <div class="row">
     <div class="col-md-12">
     <h1>Help center</h1>
@@ -101,8 +102,24 @@
     Shows the currently installed Pi-hole and Web Interface version. If an update is available, this will be indicated here
     </div>
 </div>
-
+<div class="row">
+    <div class="col-md-12">
+    <h2>Emergency help</h2>
+    In case the web UI does not work properly anymore (i.e. timeout errors or diagrams not showing up) you can try to flush the Pi-hole config file by clicking <a href="#" id="flush">FLUSH</a>. Note that your statistics will be reset and you loose the statistics of the day until now.
+    </div>
+</div>
 
 <?php
+    // Web based flushing of pi-hole log file
+    if (isset($_GET['flush']))
+    {
+        if($_GET['flush'] == "true")
+        {
+            exec('sudo pihole -f');
+        }
+    }
+
     require "footer.php";
 ?>
+
+<script src="js/pihole/help.js"></script>

--- a/help.php
+++ b/help.php
@@ -111,11 +111,11 @@
 
 <?php
     // Web based flushing of pi-hole log file
-    if (isset($_GET['flush']))
+    if (isset($_GET["flush"]))
     {
-        if($_GET['flush'] == "true")
+        if($_GET["flush"] == "true")
         {
-            exec('sudo pihole -f');
+            exec("sudo pihole -f");
         }
     }
 

--- a/help.php
+++ b/help.php
@@ -82,6 +82,7 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Disable / Enable</h2>
+    Disables resp. enables Pi-Hole DNS Blocking completely. The change will be reflected by a changed status (top left)
     </div>
 </div>
 <div class="row">

--- a/help.php
+++ b/help.php
@@ -11,8 +11,8 @@
     <h3>Top left: Status display</h3>
     <p>Shows different status messages:</p>
     <ul>
-        <li>Status (Active (<i class="fa fa-circle" style="color:#7FFF00"></i>), Offline (<i class="fa fa-circle" style="color:#FF0000"></i>), Starting (<i class="fa fa-circle" style="color:#ff9900"></i>)) of the Pi-hole</li>
-        <li>Current CPU temperature
+        <li>Status: Current status of the Pi-hole - Active (<i class="fa fa-circle" style="color:#7FFF00"></i>), Offline (<i class="fa fa-circle" style="color:#FF0000"></i>), or Starting (<i class="fa fa-circle" style="color:#ff9900"></i>)</li>
+        <li>Temp: Current CPU temperature
         <?php
         if($temperatureunit != "F"){
         ?>
@@ -30,6 +30,12 @@
         <li>Memory usage: Shows the percentage of memory acutally blocked by applications. We show a red icon if the memory usage exceeds 75%</li>
     </ul>
     <h3>Top right: About</h3>
+    <ul>
+        <li>GitHub: Link to pi-hole repository</li>
+        <li>Details: Link to Jacob Salmela's blog with some more details, describing also the concept of the Pi-hole</li>
+        <li>Updates: Link to list of releases</li>
+        <li>Update notifications: If updates are available, a link will be shown here.</li>
+    </ul>
     </div>
 </div>
 <div class="row">

--- a/help.php
+++ b/help.php
@@ -24,7 +24,7 @@
         }
         ?></li>
         <li>Load: load averages for the last minute, 5 minutes and 15 minutes, respectively. A load average of 1 reflects the full workload of a single processor on the system. We show a red icon if the current load exceeds the number of available processors on this machine (which is <?php echo $nproc; ?>)</li>
-        <li>Memory usage: Shows the percentage of memory acutally blocked by applications. We show a red icon if the memory usage exceeds 75%</li>
+        <li>Memory usage: Shows the percentage of memory actually blocked by applications. We show a red icon if the memory usage exceeds 75%</li>
     </ul>
     <h4>Top right: About</h4>
     <ul>
@@ -54,7 +54,7 @@
         <li>Query Types: Shows to which upstream DNS the permitted requests have been forwarded to.</li>
         <li>Top Domains: Ranking of requested sites by number of DNS lookups.</li>
         <li>Top Advertisers: Ranking of requested sites by number of DNS lookups.</li>
-        <li>Top Advertisers: Ranking of requested advertisments by number of DNS lookups.</li>
+        <li>Top Advertisers: Ranking of requested advertisements by number of DNS lookups.</li>
         <li>Top Clients: Ranking of total DNS requests separated by clients on the local network.</li>
     </ul>
     </div>
@@ -68,7 +68,7 @@
 <div class="row">
     <div class="col-md-12">
     <h2>White- / Blacklist</h2>
-    <p>Add or remove domains (or subdomains) from the white-/blacklist. If a domain is added to e.g. the whitelist, any possible entry of the same domain will be automatically removed from the blacklist and vice versa. Adding wildcars is currently <em>not</em> supported.</p>
+    <p>Add or remove domains (or subdomains) from the white-/blacklist. If a domain is added to e.g. the whitelist, any possible entry of the same domain will be automatically removed from the blacklist and vice versa. Adding wildcards using the web UI is currently <em>not</em> supported.</p>
     </div>
 </div>
 <div class="row">

--- a/help.php
+++ b/help.php
@@ -70,6 +70,7 @@
 <div class="row">
     <div class="col-md-12">
     <h2>White- / Blacklist</h2>
+    <p>Add or remove domains (or subdomains) from the white-/blacklist. If a domain is added to e.g. the whitelist, any possible entry of the same domain will be automatically removed from the blacklist and vice versa. Adding wildcars is currently <em>not</em> supported.</p>
     </div>
 </div>
 <div class="row">

--- a/js/pihole/help.js
+++ b/js/pihole/help.js
@@ -1,6 +1,6 @@
 $( "#flush" ).click(function() {
-    if (confirm("Are you sure you want to flush the pi-hole log file?")) {
-        document.location.href="help.php?flush=true";
+    if (confirm("Are you sure you want to flush the Pi-hole log file?")) {
+        document.location.href="help.php?flush";
     } else {
         // Do nothing!
     }

--- a/js/pihole/help.js
+++ b/js/pihole/help.js
@@ -1,6 +1,6 @@
 $( "#flush" ).click(function() {
-    if (confirm('Are you sure you want to flush the pi-hole log file?')) {
-        document.location.href='help.php?flush=true';
+    if (confirm("Are you sure you want to flush the pi-hole log file?")) {
+        document.location.href="help.php?flush=true";
     } else {
         // Do nothing!
     }

--- a/js/pihole/help.js
+++ b/js/pihole/help.js
@@ -1,0 +1,7 @@
+$( "#flush" ).click(function() {
+    if (confirm('Are you sure you want to flush the pi-hole log file?')) {
+        document.location.href='help.php?flush=true';
+    } else {
+        // Do nothing!
+    }
+});


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds a **Help Center** with some explanations to interested users of the web UI.

- The units of the displayed temperature can be set from the web UI ( Issue #176 )

- The ability to change other settings via the web UI could be considered

- We can use this later to easily describe new features and how they work (e.g. PR #207 and PR #197 ). As this help page will always be updated along with the code, the user always sees a version that fits his currently installed version (instead of the wiki covering only the most recent release). This might also make our lives easier because we should also always have an up-to-date description.

![untitle564564](https://cloud.githubusercontent.com/assets/16748619/20524197/9cebc4b0-b0b9-11e6-9f19-c22d2773979a.png)

Since I'm not a native speaker, I would certainly need someone to make improvements to the text I wrote.

@pi-hole/dashboard
