### PR TITLE
Extend Help Center and fix some warnings

### DIFF
--- a/header.php
+++ b/header.php
@@ -29,6 +29,8 @@
     $celsius = str_replace(array("\r\n","\r","\n"),"", $output);
     $fahrenheit = round(str_replace(["\r\n","\r","\n"],"", $output*9./5)+32);
 
+    // Reparse setupVars.conf here, as we might have changes the temperature units
+    // above
     $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
     if(isset($setupVars['TEMPERATUREUNIT']))
     {

--- a/header.php
+++ b/header.php
@@ -28,7 +28,16 @@
     $output = shell_exec($cmd);
     $celsius = str_replace(array("\r\n","\r","\n"),"", $output);
     $fahrenheit = round(str_replace(["\r\n","\r","\n"],"", $output*9./5)+32);
-    $temperatureunit =  parse_ini_file("/etc/pihole/setupVars.conf")['TEMPERATUREUNIT'];
+
+    $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
+    if(isset($setupVars['TEMPERATUREUNIT']))
+    {
+        $temperatureunit = $setupVars['TEMPERATUREUNIT'];
+    }
+    else
+    {
+        $temperatureunit = "C";
+    }
 
     // Get load
     $loaddata = sys_getloadavg();

--- a/header.php
+++ b/header.php
@@ -29,8 +29,7 @@
     $celsius = str_replace(array("\r\n","\r","\n"),"", $output);
     $fahrenheit = round(str_replace(["\r\n","\r","\n"],"", $output*9./5)+32);
 
-    // Reparse setupVars.conf here, as we might have changes the temperature units
-    // above
+    // Reparse setupVars.conf here, as we might have switched temperature units above
     $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
     if(isset($setupVars['TEMPERATUREUNIT']))
     {

--- a/help.php
+++ b/help.php
@@ -126,7 +126,7 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Login / Logout</h2>
-    <p>Using the Login / Logout function, a user can initiate / terminate a login session. The login page will also always be shown if a user tries to access a protected page directly without haveing a valid login session</p>
+    <p>Using the Login / Logout function, a user can initiate / terminate a login session. The login page will also always be shown if a user tries to access a protected page directly without having a valid login session</p>
     </div>
 </div>
 <?php } ?>

--- a/help.php
+++ b/help.php
@@ -1,5 +1,14 @@
 <?php
     require "header.php";
+
+    if(strlen($pwhash) > 0)
+    {
+        $authenticationsystem = true;
+    }
+    else
+    {
+        $authenticationsystem = false;
+    }
 ?>
 
 <div class="row">
@@ -33,6 +42,9 @@
         <li>Details: Link to Jacob Salmela's blog with some more details, describing also the concept of the Pi-hole</li>
         <li>Updates: Link to list of releases</li>
         <li>Update notifications: If updates are available, a link will be shown here.</li>
+        <?php if($authenticationsystem){ ?>
+        <li>Session timer: Shows the time remaining until the current login session expires.</li>
+        <?php } ?>
     </ul>
     </div>
 </div>
@@ -57,6 +69,9 @@
         <li>Top Advertisers: Ranking of requested advertisements by number of DNS lookups.</li>
         <li>Top Clients: Ranking of how many DNS requests each client has made on the local network.</li>
     </ul>
+    <?php if($authenticationsystem){ ?>
+    <p><li>Note that the login session does <em>not</em> expire on the main page, as the summary is updated every 10 seconds which refreshes the session.</li></p>
+    <?php } ?>
     </div>
 </div>
 <div class="row">
@@ -79,6 +94,12 @@
 </div>
 <div class="row">
     <div class="col-md-12">
+    <h2>Query adlists</h2>
+    <p>Runs the command <pre>sudo pihole -q <i>searchstring</i></pre> and prints the result transparently to the web UI. This command can be used to scan for strings in the list of blocked domains, e.g., &quot;analytics&quot; will deliver all domains which *analytics*, where the asterisk (*) represents a number of characters or an empty string</p>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
     <h2>Disable / Enable</h2>
     Disables/enables Pi-Hole blocking completely. You may have to wait a few minutes for the changes to reach all of your devices. The change will be reflected by a changed status (top left)
     </div>
@@ -92,9 +113,23 @@
 <div class="row">
     <div class="col-md-12">
     <h2>Help (this page)</h2>
-    Shows information about what is happening behind the scenes and what can be done with this web user interface (web UI)
+    Shows information about what is happening behind the scenes and what can be done with this web user interface (web UI). The Help center will show details concerning the authentication system only if it is enabled
     </div>
 </div>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Authentication system (currently <?php if($authenticationsystem) { ?>enabled<?php } else { ?>disabled<?php } ?>)</h2>
+    <p>Using the command<pre>sudo pihole -a -p pa22w0rd</pre> where <em>pa22w0rd</em> is the password to be set in this example, one can enable the authentication system of this web interface. Thereafter, a login is required for most sites (the main page will show a limited amount of statistics). Note that the authentication system may be disabled again, by setting an empty password using the command shown above. The Help center will show more details concerning the authentication system only if it is enabled</p>
+    </div>
+</div>
+<?php if($authenticationsystem) { ?>
+<div class="row">
+    <div class="col-md-12">
+    <h2>Login / Logout</h2>
+    <p>Using the Login / Logout function, a user can initiate / terminate a login session. The login page will also always be shown if a user tries to access a protected page directly without haveing a valid login session</p>
+    </div>
+</div>
+<?php } ?>
 <div class="row">
     <div class="col-md-12">
     <h2>Footer</h2>

--- a/php/password.php
+++ b/php/password.php
@@ -1,7 +1,18 @@
 <?php
     // Start a new PHP session (or continue an existing one)
     session_start();
-    $pwhash =  parse_ini_file("/etc/pihole/setupVars.conf")['WEBPASSWORD'];
+
+    // Read setupVars.conf file
+    $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
+    // Try to read password hash from setupVars.conf
+    if(isset($setupVars['WEBPASSWORD']))
+    {
+        $pwhash = $setupVars['WEBPASSWORD'];
+    }
+    else
+    {
+        $pwhash = "";
+    }
 
     // If the user wants to log out, we free all session variables currently registered
     if(isset($_GET["logout"]))

--- a/queries.php
+++ b/queries.php
@@ -1,7 +1,6 @@
 <?php
     require "header.php";
 
-session_start();
 // Generate CSRF token
 if(empty($_SESSION['token'])) {
     $_SESSION['token'] = base64_encode(openssl_random_pseudo_bytes(32));


### PR DESCRIPTION
Fixes #212 and some warning reported in the `error.log` file of `lighttpd`.

Changes proposed in this pull request:

- Extended `Help Center` to reflect the various additional features through the recent merges. It can and should now be updated with each modification that is proposed here

- Check for existence of `WEBPASSWORD` and `TEMPERATUREUNIT` before trying to access it to prevent the reporting of warnings.

- Remove unnecessary `start_session();` in queries.php leading to a PHP warning. It loads header.php which requires password.php which will always do a `session_start();`.

@Mcat12 Please review my changes to `help.php` for linguistic correctness.

@pi-hole/dashboard
