### PR TITLE
Add jsonForceObject flag to enable JSON_FORCE_OBJECT

### DIFF
--- a/api.php
+++ b/api.php
@@ -77,5 +77,13 @@
     }
 
     $data = filterArray($data);
-    echo json_encode($data);
+
+    if(isset($_GET["jsonForceObject"]))
+    {
+        echo json_encode($data, JSON_FORCE_OBJECT);
+    }
+    else
+    {
+        echo json_encode($data);
+    }
 ?>


### PR DESCRIPTION
Fixes #202 .

Changes proposed in this pull request:

- Add jsonForceObject flag to enable JSON_FORCE_OBJECT

- Default behavior of `api.php` is unchanged

@pi-hole/dashboard

