### PR TITLE
Update auth.php

### DIFF
--- a/php/auth.php
+++ b/php/auth.php
@@ -20,6 +20,8 @@ if(!isset($_POST['domain'], $_POST['list'], $_POST['token'])) {
 
 $AUTHORIZED_HOSTNAMES = array(
     'http://' . $_SERVER['SERVER_ADDR'],
+    'http://' . $_SERVER['HTTP_HOST'],
+    'https://' . $_SERVER['HTTP_HOST'],
     'http://pi.hole',
     'http://localhost'
 );


### PR DESCRIPTION
Fixes issue where Pi-hole installs with a domain name are unable to perform admin functions such as whitelisting & blacklisting.

Changes proposed in this pull request:

- Add `http://' . $_SERVER['HTTP_HOST'],` for insecure domains

- Add `https://' . $_SERVER['HTTP_HOST'],` for secure domains

@pi-hole/dashboard

Add $_SERVER['HTTP_HOST'] to auth.php so installs with a proper domain name can perform admin functions.