### PR TITLE
Improve speed of getSummaryData()

### DIFF
--- a/data.php
+++ b/data.php
@@ -9,7 +9,7 @@
         global $log, $divide;
         $domains_being_blocked = gravityCount() / ($divide ? 2 : 1);
 
-        $dns_queries_today = count(getDnsQueries($log));
+        $dns_queries_today = countDnsQueries();
 
         $ads_blocked_today = count(getBlockedQueries($log));
 
@@ -183,6 +183,7 @@
         return $swallowed;
 
     }
+
     function getDnsQueries(\SplFileObject $log) {
         $log->rewind();
         $lines = [];
@@ -193,6 +194,11 @@
         }
         return $lines;
     }
+
+    function countDnsQueries() {
+        return exec("grep -c \": query\\[\" /var/log/pihole.log");
+    }
+
     function getDnsQueriesAll(\SplFileObject $log) {
         $log->rewind();
         $lines = [];
@@ -203,6 +209,7 @@
         }
         return $lines;
     }
+
     function getBlockedQueries(\SplFileObject $log) {
         $log->rewind();
         $lines = [];
@@ -222,6 +229,7 @@
         }
         return $lines;
     }
+
     function getForwards(\SplFileObject $log) {
         $log->rewind();
         $lines = [];

--- a/data.php
+++ b/data.php
@@ -11,7 +11,7 @@
 
         $dns_queries_today = countDnsQueries();
 
-        $ads_blocked_today = count(getBlockedQueries($log));
+        $ads_blocked_today = countBlockedQueries();
 
         $ads_percentage_today = $dns_queries_today > 0 ? ($ads_blocked_today / $dns_queries_today * 100) : 0;
 
@@ -228,6 +228,11 @@
             }
         }
         return $lines;
+    }
+
+    function countBlockedQueries() {
+        $hostname = trim(file_get_contents("/etc/hostname"), "\x00..\x1F");
+        return exec("grep \"gravity.list\" /var/log/pihole.log | grep -v \"pi.hole\" | grep -v -c \"".$hostname."\"");
     }
 
     function getForwards(\SplFileObject $log) {

--- a/data.php
+++ b/data.php
@@ -226,7 +226,7 @@
 
     function countBlockedQueries() {
         $hostname = trim(file_get_contents("/etc/hostname"), "\x00..\x1F");
-        return exec("grep \"gravity.list\" /var/log/pihole.log | grep -v \"pi.hole\" | grep -v -c \"".$hostname."\"");
+        return exec("grep \"gravity.list\" /var/log/pihole.log | grep -v \"pi.hole\" | grep -v \" read \" | grep -v -c \"".$hostname."\"");
     }
 
     function getForwards(\SplFileObject $log) {

--- a/data.php
+++ b/data.php
@@ -175,13 +175,7 @@
 
     /******** Private Members ********/
     function gravityCount() {
-        //returns count of domains in blocklist.
-        $NGC4889 = new \SplFileObject('/etc/pihole/gravity.list');
-        $NGC4889->seek($NGC4889->getSize());
-        $swallowed = $NGC4889->key();
-
-        return $swallowed;
-
+        return exec("grep -c ^ /etc/pihole/gravity.list");
     }
 
     function getDnsQueries(\SplFileObject $log) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Improve speed of `api.php?summary` and `api.php?summaryRaw`

```
Execution time gravityCount() (OLD): 0.57 seconds
Execution time gravityCount() (NEW): 0.27 seconds
Execution time count(getDnsQueries()): 1.72 seconds (result: 13639 entries)
Execution time countDnsQueries(): 0.07 seconds (result: 13639 entries)
Execution time count(getBlockedQueries()): 7.71 seconds (result: 218 entries)
Execution time countBlockedQueries(): 0.09 seconds (result: 218 entries)
```

Time needed with PHP routines: more than 10 seconds, certainly worse on large logs
Time needed with this PR (`grep` routines): much less than 1 seconds

Note that the function `countBlockedQueries()` might need to be improved, because I'm not absolutely sure if I exclude all _wrong_ findings correctly.

@pi-hole/dashboard

