### PR TITLE
Make getAllQuerys possible to return ordered hashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ A read-only API can be accessed at `/admin/api.php`. With either no parameters o
 ```
 
 There are many more parameters, such as `summaryRaw`, `overTimeData`, `topItems`, `recentItems`, `getQueryTypes`, `getForwardDestinations`, `getQuerySources`, and finally `getAllQueries`.
+
+`getAllQueries` can optionally be set with one this values to return JSON hash ordered as value implies: `orderByClientDomainTime`. `orderByClientTimeDomain`, `orderByTimeClientDomain`, `orderByTimeDomainClient`, `orderByDomainClientTime` or `orderByDomainTimeClient`.

--- a/api.php
+++ b/api.php
@@ -58,7 +58,7 @@
     }
 
     if (isset($_GET['getAllQueries']) && $auth) {
-        $data = array_merge($data, getAllQueries());
+        $data = array_merge($data, getAllQueries($_GET['getAllQueries']));
     }
 
     if (isset($_GET['enable'], $_GET['token']) && $auth) {

--- a/data.php
+++ b/data.php
@@ -132,7 +132,7 @@
         );
     }
 
-    function getAllQueries() {
+    function getAllQueries($orderBy) {
         global $log;
         $allQueries = array("data" => array());
         $dns_queries = getDnsQueriesAll($log);
@@ -158,16 +158,29 @@
             }
 
             if ( $status != ""){
-              array_push($allQueries['data'], array(
-                $time->format('Y-m-d\TH:i:s'),
-                $type,
-                $domain,
-                hasHostName($client),
-                $status,
-                ""
-              ));
+              if($orderBy == "orderByClientDomainTime"){
+                $allQueries['data'][hasHostName($client)][$domain][$time->format('Y-m-d\TH:i:s')] = $status;
+              }elseif ($orderBy == "orderByClientTimeDomain"){
+                $allQueries['data'][hasHostName($client)][$time->format('Y-m-d\TH:i:s')][$domain] = $status;
+              }elseif ($orderBy == "orderByTimeClientDomain"){
+                $allQueries['data'][$time->format('Y-m-d\TH:i:s')][hasHostName($client)][$domain] = $status;
+              }elseif ($orderBy == "orderByTimeDomainClient"){
+                $allQueries['data'][$time->format('Y-m-d\TH:i:s')][$domain][hasHostName($client)] = $status;
+              }elseif ($orderBy == "orderByDomainClientTime"){
+                $allQueries['data'][$domain][hasHostName($client)][$time->format('Y-m-d\TH:i:s')] = $status;
+              }elseif ($orderBy == "orderByDomainTimeClient"){
+                $allQueries['data'][$domain][$time->format('Y-m-d\TH:i:s')][hasHostName($client)] = $status;
+              }else{
+                array_push($allQueries['data'], array(
+                  $time->format('Y-m-d\TH:i:s'),
+                  $type,
+                  $domain,
+                  hasHostName($client),
+                  $status,
+                  ""
+                ));
+              }
             }
-
 
         }
         return $allQueries;


### PR DESCRIPTION

Changes proposed in this pull request:

- When calling api.php with key getAllQuerys, optionally set it to an key of:
   
    * orderByClientDomainTime
    * orderByClientTimeDomain
    * orderByTimeClientDomain
    * orderByTimeDomainClient
    * orderByDomainClientTime
    * orderByDomainTimeClient
    * ANY THING ELSE
    
    If argument is one of orderBy* make getAllQueries() return with JSON
    hash that is structured by the way the argument sets.
 
     This make dataparsing from the api mush easier.

    This does not break the originally function.




@pi-hole/dashboard
