### PR TITLE
fix versionCompare

### DIFF
--- a/js/pihole/footer.js
+++ b/js/pihole/footer.js
@@ -61,7 +61,8 @@ function versionCompare(left, right) {
             return -1;
         }
     }
-
+    return 0;
+}
 
 
 // Update check

--- a/js/pihole/footer.js
+++ b/js/pihole/footer.js
@@ -42,12 +42,16 @@ var piholeVersion = $("#piholeVersion").html();
 var webVersion = $("#webVersion").html();
 
 // Credit for following function: https://gist.github.com/alexey-bass/1115557
+// Modified to discard any possible "v" in the string
 function versionCompare(left, right) {
     if (typeof left + typeof right != 'stringstring')
         return false;
 
-    var a = left.split('.')
-        ,   b = right.split('.')
+    var aa = left.split("v"),
+        bb = right.split("v");
+
+    var a = aa[aa.length-1].split(".")
+        ,   b = bb[bb.length-1].split(".")
         ,   i = 0, len = Math.max(a.length, b.length);
 
     for (; i < len; i++) {
@@ -58,8 +62,7 @@ function versionCompare(left, right) {
         }
     }
 
-    return 0;
-}
+
 
 // Update check
 $.getJSON("https://api.github.com/repos/pi-hole/pi-hole/releases/latest", function(json) {


### PR DESCRIPTION
Consider our JS function `versionCompare`:

```
latest = "v2.9.6"
current = "v2.9.5"
versionCompare(current, latest)
```
##### Expected behavior
result `-1`, i.e. `current` version is **less than** `latest` version -> update available
##### Actual behavior
result `-1`, i.e. `current` version is **less than** `latest` version -> update available :white_check_mark: 

-----

```
latest = "v3.0"
current = "v2.9.5"
versionCompare(current, latest)
```
##### Expected behavior
result `-1`, i.e. `current` version is **less than** `latest` version -> update available
##### Actual behavior
result `1`, i.e. `current` version is **greater than** `latest` version -> no update available :x: 

The current version of this function fails as the version string starts with letter "v" which is handled incorrectly. This misbehavior will be fixed by this PR.

@pi-hole/dashboard

