### PR TITLE
Show more detailed output of version if not on branch master

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -6,26 +6,28 @@
         <div class="pull-right hidden-xs">
             <?php
             // Check if on a dev branch
-            $piholeVersion = exec("cd /etc/.pihole/ && git rev-parse --abbrev-ref HEAD");
-            $webVersion = exec("git rev-parse --abbrev-ref HEAD");
+            $piholeBranch = exec("cd /etc/.pihole/ && git rev-parse --abbrev-ref HEAD");
+            $webBranch = exec("git rev-parse --abbrev-ref HEAD");
 
             // Use vDev if not on master
-            if($piholeVersion !== "master") {
+            if($piholeBranch !== "master") {
                 $piholeVersion = "vDev";
+                $piholeCommit = exec("cd /etc/.pihole/ && git describe --long --dirty --abbrev=10 --tags");
             }
             else {
                 $piholeVersion = exec("cd /etc/.pihole/ && git describe --tags --abbrev=0");
             }
 
-            if($webVersion !== "master") {
+            if($webBranch !== "master") {
                 $webVersion = "vDev";
+                $webCommit = exec("git describe --long --dirty --abbrev=10 --tags");
             }
             else {
                 $webVersion = exec("git describe --tags --abbrev=0");
             }
             ?>
-            <b>Pi-hole Version </b> <span id="piholeVersion"><?php echo $piholeVersion; ?></span>
-            <b>Web Interface Version </b> <span id="webVersion"><?php echo $webVersion; ?></span>
+            <b>Pi-hole Version </b> <span id="piholeVersion"><?php echo $piholeVersion; ?></span><?php if(isset($piholeCommit)) { echo " (".$piholeBranch.", ".$piholeCommit.")"; } ?>
+            <b>Web Interface Version </b> <span id="webVersion"><?php echo $webVersion; ?></span><?php if(isset($webCommit)) { echo " (".$webBranch.", ".$webCommit.")"; } ?>
         </div>
         <i class="fa fa-github"></i> <strong><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=3J2L3Z4DHW9UY">Donate</a></strong> if you found this useful.
     </footer>

--- a/footer.php
+++ b/footer.php
@@ -12,7 +12,7 @@
             // Use vDev if not on master
             if($piholeBranch !== "master") {
                 $piholeVersion = "vDev";
-                $piholeCommit = exec("cd /etc/.pihole/ && git describe --long --dirty --abbrev=10 --tags");
+                $piholeCommit = exec("cd /etc/.pihole/ && git describe --long --dirty --tags");
             }
             else {
                 $piholeVersion = exec("cd /etc/.pihole/ && git describe --tags --abbrev=0");
@@ -20,7 +20,7 @@
 
             if($webBranch !== "master") {
                 $webVersion = "vDev";
-                $webCommit = exec("git describe --long --dirty --abbrev=10 --tags");
+                $webCommit = exec("git describe --long --dirty --tags");
             }
             else {
                 $webVersion = exec("git describe --tags --abbrev=0");


### PR DESCRIPTION
Changes proposed in this pull request:

- On the web UI we show `vDev` instead of the version if not on master. With this commit a much more detailed output is added.

Exemplary output:
> **Pi-hole Version** vDev (development, v2.9.5-224-gb6639d9)
- on branch `development`
- last tag was `v2.9.5`
- my current commit is 224 commits behind this tag
- commit [b6639d9](https://github.com/pi-hole/pi-hole/commit/b6639d9e7e9f0d9973d027154a72bbe9e4989d24)
- no local changes

> **Web Interface Version** vDev (showbranch, v1.4.4.2-233-ge93f33b-dirty)
- on branch `showbranch` (this PR)
- last tag was `v1.4.4.2`
- currently 233 commits behind this tag
- commit [e93f33b](https://github.com/pi-hole/AdminLTE/pull/234/commits/e93f33bcf0ef763fa4716e4fbc8eaa501fb2a4ef)
- the working tree is dirty, i.e. I modified tracked files which are not yet committed

@pi-hole/dashboard

