### PR TITLE
Remove CORS skip log message

### DIFF
--- a/php/auth.php
+++ b/php/auth.php
@@ -39,9 +39,7 @@ function check_cors() {
         }
         header("Access-Control-Allow-Origin: ${_SERVER['HTTP_ORIGIN']}");
     }
-    else {
-        pi_log("CORS skipped, unknown HTTP_ORIGIN");
-    }
+    // If there's no HTTP_ORIGIN, CORS should not be used
 }
 
 function check_csrf($token) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove the CORS skip log message, because it can fill up the error log really quickly, since this function is now used on all pages. Most of these pages are not able to be protected by CORS but can still be protected by the Host check.

@pi-hole/dashboard