### PR TITLE
Add button to Gravity page

### DIFF
--- a/gravity.php
+++ b/gravity.php
@@ -16,7 +16,8 @@
     Success!
 </div>
 
-<pre id="output" style="width: 100%; height: 100%;"></pre>
+<button class="btn btn-lg btn-primary btn-block" id="gravityBtn">Update Lists</button>
+<pre id="output" style="width: 100%; height: 100%;" hidden="true"></pre>
 
 <?php
     require "footer.php";

--- a/js/pihole/gravity.js
+++ b/js/pihole/gravity.js
@@ -1,9 +1,11 @@
-function eventsourcetest() {
+function eventsource() {
     var alInfo = $("#alInfo");
     var alSuccess = $("#alSuccess");
-    var ta = document.getElementById("output");
+    var ta = $("#output");
     var source = new EventSource("php/gravity.sh.php");
 
+    ta.html("");
+    ta.show();
     alInfo.show();
     alSuccess.hide();
 
@@ -13,7 +15,7 @@ function eventsourcetest() {
             alSuccess.show();
         }
 
-        ta.innerHTML += e.data;
+        ta.append(e.data);
 
     }, false);
 
@@ -21,11 +23,13 @@ function eventsourcetest() {
     source.addEventListener("error", function(e) {
         alInfo.delay(1000).fadeOut(2000, function() { alInfo.hide(); });
         source.close();
+        $("#gravityBtn").removeAttr("disabled");
     }, false);
 }
 
-$(function(){
-   eventsourcetest();
+$("#gravityBtn").on("click", () => {
+    $("#gravityBtn").attr("disabled", true);
+    eventsource();
 });
 
 // Handle hiding of alerts


### PR DESCRIPTION
Changes proposed in this pull request:

- This makes sure that the user doesn't accidentally cause the lists
to update because they were curious and clicked the Update Lists
link on the sidebar. Also, they can update the lists multiple
times, if they so desire.

![Image](http://image.prntscr.com/image/610c214c89be488796262ca6d33d76c6.png)
![Image](http://image.prntscr.com/image/5c7e81e25f5c40b9825068da1bc0796a.png)
![Image](http://image.prntscr.com/image/69ec0efd9b2e44fea238d95af006c8a1.png)

@pi-hole/dashboard