### PR TITLE
New gravity count logic

### DIFF
--- a/data.php
+++ b/data.php
@@ -6,7 +6,6 @@
 
     /*******   Public Members ********/
     function getSummaryData() {
-        global $log;
         $domains_being_blocked = gravityCount();
 
         $dns_queries_today = countDnsQueries();

--- a/data.php
+++ b/data.php
@@ -1,14 +1,13 @@
 <?php
     $log = array();
     $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
-    $divide =  $setupVars['IPV6_ADDRESS'] != "" && $setupVars['IPV4_ADDRESS'] != "";
     $hosts = file_exists("/etc/hosts") ? file("/etc/hosts") : array();
     $log = new \SplFileObject('/var/log/pihole.log');
 
     /*******   Public Members ********/
     function getSummaryData() {
-        global $log, $divide;
-        $domains_being_blocked = gravityCount() / ($divide ? 2 : 1);
+        global $log;
+        $domains_being_blocked = gravityCount();
 
         $dns_queries_today = countDnsQueries();
 
@@ -231,7 +230,9 @@
 
     /******** Private Members ********/
     function gravityCount() {
-        return exec("grep -c ^ /etc/pihole/gravity.list");
+        $preEventHorizon = exec("grep -c ^ /etc/pihole/list.preEventHorizon");
+        $blacklist = exec("grep -c ^ /etc/pihole/blacklist.txt");
+        return ($preEventHorizon + $blacklist);
     }
 
     function getDnsQueries(\SplFileObject $log) {


### PR DESCRIPTION
Changes proposed in this pull request:

- New gravity count logic

- New behavior: Count number of lines in
  - `/etc/pihole/list.preEventHorizon`, and
  - `/etc/pihole/blacklist.txt`

- Old behavior: Count number of lines in
  - `/etc/pihole/gravity.list`
where we had to decide if we use IPv6 or not

@pi-hole/dashboard

