### PR TITLE
Hide size of log if logging is disabled

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -329,7 +329,7 @@
 ?>
 		<div class="box box-primary">
 			<div class="box-header with-border">
-				<h3 class="box-title">Query Logging (size of log <?php echo formatSizeUnits(filesize("/var/log/pihole.log")); ?>)</h3>
+				<h3 class="box-title">Query Logging<?php if($piHoleLogging) { ?> (size of log <?php echo formatSizeUnits(filesize("/var/log/pihole.log")); ?>)<?php } ?></h3>
 			</div>
 			<div class="box-body">
 				<p>Current status:


### PR DESCRIPTION
Changes proposed in this pull request:

- Hide size of log if logging is disabled for the sake of convenience. Since `dnsmasq` will still print some general status messages, the log will appear non-empty to the user (might be even several KBs) although he disabled logging. He might think that something fishy might be going on.

New behavior:
![screenshot at 2016-12-15 15-31-24](https://cloud.githubusercontent.com/assets/16748619/21227849/d8be2850-c2db-11e6-991f-d2d5cbea3b1b.png)
![screenshot at 2016-12-15 15-31-32](https://cloud.githubusercontent.com/assets/16748619/21227852/da2c0eb4-c2db-11e6-9998-a86f0505f42f.png)


@pi-hole/dashboard

