### PR TITLE
Add hostname to allowed domains

### DIFF
--- a/php/auth.php
+++ b/php/auth.php
@@ -18,6 +18,7 @@ function check_cors() {
     // Check CORS
     $AUTHORIZED_HOSTNAMES = array(
         'http://' . $_SERVER['SERVER_ADDR'],
+        'http://' . $_SERVER['SERVER_NAME'],
         'http://pi.hole',
         'http://localhost'
     );


### PR DESCRIPTION
Fixes issue from [discourse](https://discourse.pi-hole.net/t/blacklist-whitelist-do-not-work-via-the-web-admin-ui/847)

Changes proposed in this pull request:

- Add hostname of server as valid domain for requests

Before:
![screenshot at 2016-12-16 21-35-57](https://cloud.githubusercontent.com/assets/16748619/21277696/069d407e-c3d8-11e6-9d19-b7c18ce978f0.png)
Now:
![screenshot at 2016-12-16 21-36-13](https://cloud.githubusercontent.com/assets/16748619/21277704/0d950d80-c3d8-11e6-8abf-e0a69539c899.png)


@pi-hole/dashboard

