### PR TITLE
No DNS prefetching

### DIFF
--- a/header.php
+++ b/header.php
@@ -89,7 +89,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://api.github.com; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'">
     <title>Pi-hole Admin Console</title>
-    <!-- Usually browsers proactively perform domain name resolution on both links that the user may choose to follow. We disable DNS prefetching here -->
+    <!-- Usually browsers proactively perform domain name resolution on links that the user may choose to follow. We disable DNS prefetching here -->
     <meta http-equiv="x-dns-prefetch-control" content="off">
     <!-- Tell the browser to be responsive to screen width -->
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">

--- a/header.php
+++ b/header.php
@@ -89,6 +89,8 @@
     <meta charset="UTF-8">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://api.github.com; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'">
     <title>Pi-hole Admin Console</title>
+    <!-- Usually browsers proactively perform domain name resolution on both links that the user may choose to follow. We disable DNS prefetching here -->
+    <meta http-equiv="x-dns-prefetch-control" content="off">
     <!-- Tell the browser to be responsive to screen width -->
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
     <link rel="shortcut icon" href="img/favicon.png" type="image/x-icon" />


### PR DESCRIPTION
Fixes issue on [discourse](https://discourse.pi-hole.net/t/lots-of-queries-from-jacobsalmela-com/681/9).

Changes proposed in this pull request:

- Usually browsers proactively perform domain name resolution on both links that the user may choose to follow. We disable DNS prefetching here.

Test on `devel`:
- Cleared Chrome's DNS cache
- Loaded main page
![screenshot at 2016-12-17 17-52-48](https://cloud.githubusercontent.com/assets/16748619/21288379/d2ba3b40-c481-11e6-8c39-f667c605f7c3.png)

Test on `noDNSprefetching`:
- Cleared Chrome's DNS cache
- Loaded main page
![screenshot at 2016-12-17 17-53-52](https://cloud.githubusercontent.com/assets/16748619/21288382/d8f3ebc8-c481-11e6-808f-a70e1f862895.png)

@pi-hole/dashboard
