### PR TITLE
Fix Query Log "None" option

### DIFF
--- a/data.php
+++ b/data.php
@@ -163,7 +163,7 @@
                 $showBlocked = true;
                 $showPermitted = false;
             }
-            elseif($setupVars["API_QUERY_LOG_SHOW"] === "none")
+            elseif($setupVars["API_QUERY_LOG_SHOW"] === "nothing")
             {
                 $showBlocked = false;
                 $showPermitted = false;

--- a/php/savesettings.php
+++ b/php/savesettings.php
@@ -205,7 +205,7 @@ function validDomain($domain_name)
 				}
 				else
 				{
-					exec("sudo pihole -a setquerylog none");
+					exec("sudo pihole -a setquerylog nothing");
 					$success .= "No entries will be shown in Query Log";
 				}
 

--- a/queries.php
+++ b/queries.php
@@ -23,6 +23,10 @@ if(isset($setupVars["API_QUERY_LOG_SHOW"]))
 	{
 		$showing = "(showing blocked queries only)";
 	}
+	elseif($setupVars["API_QUERY_LOG_SHOW"] === "nothing")
+	{
+		$showing = "(showing no queries at all)";
+	}
 }
 
 ?>


### PR DESCRIPTION
Fixes: Unchecking all options didn't lead to the expected behavior that no queries are shown

Changes proposed in this pull request:

- Change keyword from `none` to `nothing` because `none` is handled strangely my `parse_ini_file`

@pi-hole/dashboard
