### PR TITLE
New logic for API functions getBlockedQueries() and countBlockedQueries()

### DIFF
--- a/data.php
+++ b/data.php
@@ -282,7 +282,6 @@
         $lines = [];
         $hostname = trim(file_get_contents("/etc/hostname"), "\x00..\x1F");
         foreach ($log as $line) {
-            $line = preg_replace('/ {2,}/', ' ', $line);
             $exploded = explode(" ", $line);
             if(count($exploded) == 8) {
                 // Structure of data is currently like:

--- a/data.php
+++ b/data.php
@@ -299,7 +299,7 @@
                 $list = $exploded[4];
                 $is = $exploded[6];
                 // Consider only gravity.list as DNS source (not e.g. hostname.list)
-                if(substr($list, strlen($list) - 12, 12) == "gravity.list" && $is === "is") {
+                if(substr($list, strlen($list) - 12, 12) === "gravity.list" && $is === "is") {
                     $lines[] = $line;
                 };
             }

--- a/data.php
+++ b/data.php
@@ -285,11 +285,22 @@
             $line = preg_replace('/ {2,}/', ' ', $line);
             $exploded = explode(" ", $line);
             if(count($exploded) == 8) {
-                $tmp = $exploded[count($exploded) - 4];
-                $tmp2 = $exploded[count($exploded) - 5];
-                $tmp3 = $exploded[count($exploded) - 3];
-                //filter out bad names and host file reloads:
-                if(substr($tmp, strlen($tmp) - 12, 12) == "gravity.list" && $tmp2 != "read" && $tmp3 != "pi.hole" && $tmp3 != $hostname) {
+                // Structure of data is currently like:
+                // Array
+                // (
+                //     [0] => Dec
+                //     [1] => 19
+                //     [2] => 11:21:51
+                //     [3] => dnsmasq[2584]:
+                //     [4] => /etc/pihole/gravity.list
+                //     [5] => doubleclick.com
+                //     [6] => is
+                //     [7] => ip.of.pi.hole
+                // )
+                $list = $exploded[4];
+                $is = $exploded[6];
+                // Consider only gravity.list as DNS source (not e.g. hostname.list)
+                if(substr($list, strlen($list) - 12, 12) == "gravity.list" && $is === "is") {
                     $lines[] = $line;
                 };
             }

--- a/data.php
+++ b/data.php
@@ -280,7 +280,6 @@
     function getBlockedQueries(\SplFileObject $log) {
         $log->rewind();
         $lines = [];
-        $hostname = trim(file_get_contents("/etc/hostname"), "\x00..\x1F");
         foreach ($log as $line) {
             $exploded = explode(" ", $line);
             if(count($exploded) == 8) {

--- a/data.php
+++ b/data.php
@@ -310,7 +310,7 @@
 
     function countBlockedQueries() {
         $hostname = trim(file_get_contents("/etc/hostname"), "\x00..\x1F");
-        return exec("grep \"gravity.list\" /var/log/pihole.log | grep -v \"pi.hole\" | grep -v \" read \" | grep -v -c \"".$hostname."\"");
+        return exec("grep \"gravity.list\" /var/log/pihole.log | grep -c \" is \"");
     }
 
     function getForwards(\SplFileObject $log) {

--- a/data.php
+++ b/data.php
@@ -307,7 +307,6 @@
     }
 
     function countBlockedQueries() {
-        $hostname = trim(file_get_contents("/etc/hostname"), "\x00..\x1F");
         return exec("grep \"gravity.list\" /var/log/pihole.log | grep -c \" is \"");
     }
 

--- a/data.php
+++ b/data.php
@@ -282,7 +282,7 @@
         $lines = [];
         foreach ($log as $line) {
             $exploded = explode(" ", $line);
-            if(count($exploded) == 8) {
+            if(count($exploded) == 8 || count($exploded) == 10) {
                 // Structure of data is currently like:
                 // Array
                 // (
@@ -295,8 +295,22 @@
                 //     [6] => is
                 //     [7] => ip.of.pi.hole
                 // )
-                $list = $exploded[4];
-                $is = $exploded[6];
+                // with extra logging enabled
+                // Array
+                // (
+                //     [0] => Dec
+                //     [1] => 19
+                //     [2] => 11:21:51
+                //     [3] => dnsmasq[2584]:
+                //     [4] => 1 (identifier)
+                //     [5] => 1.2.3.4/12345
+                //     [6] => /etc/pihole/gravity.list
+                //     [7] => doubleclick.com
+                //     [8] => is
+                //     [9] => ip.of.pi.hole
+                // )
+                $list = $exploded[count($exploded)-4];
+                $is = $exploded[count($exploded)-2];
                 // Consider only gravity.list as DNS source (not e.g. hostname.list)
                 if(substr($list, strlen($list) - 12, 12) === "gravity.list" && $is === "is") {
                     $lines[] = $line;


### PR DESCRIPTION
Fixes https://github.com/pi-hole/pi-hole/issues/980

Changes proposed in this pull request:

- Simplify and improve `function getBlockedQueries()`

- Simplify `function countBlockedQueries()`

We are currently checking if:
* source is `gravity.list`
* fourth string is *not* `read`
* sixth string is *not* `pi.hole`
* sixth string is *not* `$hostname`

With this PR I want to change that to checking if:
* source is `*gravity.list`
* seventh string is `is`

<pre>
Dec 19 11:40:24 dnsmasq[3072]: query[A] googleads.g.doubleclick.net from 5.6.7.8
Dec 19 11:40:24 dnsmasq[3072]: /etc/pihole/<b>gravity.list</b> googleads.g.doubleclick.net <b>is</b> 1.2.3.4
</pre>

Also we don't have to check any more if `pi.hole` of `$hostname` is there, since those will be feeded by a different list:
<pre>
Dec 19 11:45:30 dnsmasq[3072]: query[A] pi.hole from 5.6.7.8
Dec 19 11:45:30 dnsmasq[3072]: /etc/pihole/<b>hostname.list</b> pi.hole is 1.2.3.4
[...]
Dec 19 11:21:58 dnsmasq[2584]: query[PTR] 1.2.3.4.in-addr.arpa from 127.0.0.1
Dec 19 11:21:58 dnsmasq[2584]: /etc/pihole/<b>hostname.list</b> 1.2.3.4 is pi.hole
</pre>

Note that the old logic might fail on a system with a non-English locale:
```
Dec 19 11:25:14 dnsmasq[3072]: /etc/hosts gelesen - 5 Adressen
Dec 19 11:25:14 dnsmasq[3072]: /etc/pihole/hostname.list gelesen - 2 Adressen
Dec 19 11:25:28 dnsmasq[3072]: /etc/pihole/gravity.list gelesen - 212262 Adressen
```
(there is only "gelesen" but not "read") Luckily, the usual output of `dnsmasq` (like shown above) is still in English.

@pi-hole/dashboard
