### PR TITLE
Show percentage of blocked queries in graph tooltip

### DIFF
--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -282,6 +282,23 @@ $(document).ready(function() {
                             var from = padNumber(h)+":"+padNumber(m)+":00";
                             var to = padNumber(h)+":"+padNumber(m+9)+":59";
                             return "Queries from "+from+" to "+to;
+                        },
+                        label(tooltipItems, data) {
+                            if(tooltipItems.datasetIndex === 1)
+                            {
+                                var percentage = 0.0;
+                                var total = parseInt(data.datasets[0].data[tooltipItems.index]);
+                                var blocked = parseInt(data.datasets[1].data[tooltipItems.index]);
+                                if(total > 0)
+                                {
+                                    percentage = 100.0*blocked/total;
+                                }
+                                return data.datasets[tooltipItems.datasetIndex].label + ": " + tooltipItems.yLabel + " (" + percentage.toFixed(1) + "%)";
+                            }
+                            else
+                            {
+                                return data.datasets[tooltipItems.datasetIndex].label + ": " + tooltipItems.yLabel;
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
Changes proposed in this pull request:

- Show percentage of blocked queries in graph tooltip

![untit564456465led](https://cloud.githubusercontent.com/assets/16748619/21350400/665979d8-c6b7-11e6-9184-489baac489c8.png)


@pi-hole/dashboard
