### PR TITLE
Fix Query Log Wrong Status

### DIFF
--- a/api.php
+++ b/api.php
@@ -77,7 +77,7 @@
     }
 
     if (isset($_GET['getGravityDomains'])) {
-        $data = array_merge($data, getGravityDomains($gravity));
+        $data = array_merge($data, getGravity());
     }
 
     function filterArray(&$inArray) {

--- a/data.php
+++ b/data.php
@@ -188,11 +188,21 @@
         global $log,$gravity,$showBlocked,$showPermitted,$whitelist,$blacklist;
         $allQueries = array("data" => array());
         $dns_queries = getDnsQueriesAll($log);
-        $gravity_domains = getDomains($gravity, true);
-        $whitelist_domains = getDomains($whitelist, false);
-        $blacklist_domains = getDomains($blacklist, true);
+        $gravity_domains = getDomains($gravity);
+        $whitelist_domains = getDomains($whitelist);
+        $blacklist_domains = getDomains($blacklist);
 
-        $gravity_domains = array_merge($gravity_domains, $whitelist_domains, $blacklist_domains);
+        // Remove whitelisted domains
+        foreach($gravity_domains as $domain) {
+            if(isset($whitelist_domains[$domain])) {
+                unset($gravity_domains[$domain]);
+            }
+        }
+
+        // Add blacklisted domains if they aren't already there
+        foreach($blacklist_domains as $domain) {
+            $gravity_domains[$domain] = null;
+        }
 
 
         foreach ($dns_queries as $query) {
@@ -274,13 +284,13 @@
         return $lines;
     }
 
-    function getDomains($file, $default_value){
+    function getDomains($file){
         $file->rewind();
         $lines=[];
         foreach ($file as $line) {
             // Strip newline (and possibly carriage return) from end of string
             // using rtrim()
-            $lines[rtrim($line)] = $default_value;
+            $lines[rtrim($line)] = null;
         }
 
         return $lines;

--- a/data.php
+++ b/data.php
@@ -188,20 +188,22 @@
         global $log,$gravity,$showBlocked,$showPermitted,$whitelist,$blacklist;
         $allQueries = array("data" => array());
         $dns_queries = getDnsQueriesAll($log);
-        $gravity_domains = getDomains($gravity);
+
+        $gravity_domains   = getDomains($gravity);
         $whitelist_domains = getDomains($whitelist);
         $blacklist_domains = getDomains($blacklist);
 
-        // Remove whitelisted domains
-        foreach($gravity_domains as $domain) {
-            if(isset($whitelist_domains[$domain])) {
+        // Remove whitelisted domains if they exist in
+        // $gravity_domains
+        foreach($whitelist_domains as $domain) {
+            if(isset($gravity_domains[$domain])) {
                 unset($gravity_domains[$domain]);
             }
         }
 
-        // Add blacklisted domains if they aren't already there
+        // Add blacklisted domains (do not need to check if they are already there)
         foreach($blacklist_domains as $domain) {
-            $gravity_domains[$domain] = null;
+            $gravity_domains[$domain] = true;
         }
 
 
@@ -215,9 +217,7 @@
 
             if (substr($tmp, 0, 5) == "query")
             {
-                $status = isset($gravity_domains[$domain]) ?
-                    $gravity_domains[$domain] === true ? "Pi-holed" : "OK"
-                    : "OK";
+                $status = isset($gravity_domains[$domain]) ? "Pi-holed" : "OK";
                 if(($status === "Pi-holed" && $showBlocked) || ($status === "OK" && $showPermitted))
                 {
                     $type = substr($exploded[count($exploded)-4], 6, -1);
@@ -290,7 +290,7 @@
         foreach ($file as $line) {
             // Strip newline (and possibly carriage return) from end of string
             // using rtrim()
-            $lines[rtrim($line)] = null;
+            $lines[rtrim($line)] = true;
         }
 
         return $lines;

--- a/data.php
+++ b/data.php
@@ -279,14 +279,14 @@
             // (e.g. once in gravity list, once in blacklist)
             if($action && strlen($key) > 0)
             {
+                // $action is true (we want to add) *and* key is not empty
                 $array[$key] = true;
             }
-            elseif(isset($array[$key]))
+            elseif(!$action && isset($array[$key]))
             {
-                // $action is not true (we want to remove) *and* key is set
+                // $action is false (we want to remove) *and* key is set
                 unset($array[$key]);
             }
-            // else: Remove, but not set -> don't have to don anything
         }
     }
 

--- a/data.php
+++ b/data.php
@@ -271,7 +271,6 @@
 
     function getDomains($file, &$array, $action){
         $file->rewind();
-        $lines=[];
         foreach ($file as $line) {
             // Strip newline (and possibly carriage return) from end of key
             $key = rtrim($line);
@@ -280,17 +279,15 @@
             // (e.g. once in gravity list, once in blacklist)
             if($action && strlen($key) > 0)
             {
-                $lines[$key] = true;
+                $array[$key] = true;
             }
-            elseif(isset($lines[$key]))
+            elseif(isset($array[$key]))
             {
                 // $action is not true (we want to remove) *and* key is set
-                unset($lines[$key]);
+                unset($array[$key]);
             }
             // else: Remove, but not set -> don't have to don anything
         }
-
-        return $lines;
     }
 
     function getGravity() {


### PR DESCRIPTION
Changes proposed in this pull request:

- Make sure the query log takes into account the whitelist and blacklist, because whitelisted entries were showing up as blocked if they were in a list and the same idea for blacklisted entries.

@pi-hole/dashboard
