### PR TITLE
Handle no IPv4 address when guessing initial DHCP

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -106,7 +106,7 @@
 	{
 		$DHCP = false;
 		// Try to guess initial settings
-		if($piHOleIPv4 !== "unknown") {
+		if($piHoleIPv4 !== "unknown") {
 			$DHCPdomain = explode(".",$piHoleIPv4);
 			$DHCPstart  = $DHCPdomain[0].".".$DHCPdomain[1].".".$DHCPdomain[2].".201";
 			$DHCPend    = $DHCPdomain[0].".".$DHCPdomain[1].".".$DHCPdomain[2].".251";

--- a/settings.php
+++ b/settings.php
@@ -106,10 +106,17 @@
 	{
 		$DHCP = false;
 		// Try to guess initial settings
-		$DHCPdomain = explode(".",$piHoleIPv4);
-		$DHCPstart  = $DHCPdomain[0].".".$DHCPdomain[1].".".$DHCPdomain[2].".201";
-		$DHCPend    = $DHCPdomain[0].".".$DHCPdomain[1].".".$DHCPdomain[2].".251";
-		$DHCProuter = $DHCPdomain[0].".".$DHCPdomain[1].".".$DHCPdomain[2].".1";
+		if($piHOleIPv4 !== "unknown") {
+			$DHCPdomain = explode(".",$piHoleIPv4);
+			$DHCPstart  = $DHCPdomain[0].".".$DHCPdomain[1].".".$DHCPdomain[2].".201";
+			$DHCPend    = $DHCPdomain[0].".".$DHCPdomain[1].".".$DHCPdomain[2].".251";
+			$DHCProuter = $DHCPdomain[0].".".$DHCPdomain[1].".".$DHCPdomain[2].".1";
+		}
+		else {
+			$DHCPstart  = "0.0.0.0";
+			$DHCPend    = "0.0.0.0";
+			$DHCProuter = "0.0.0.0";
+		}
 	}
 	if(isset($setupVars["PIHOLE_DOMAIN"])){
 		$piHoleDomain = $setupVars["PIHOLE_DOMAIN"];

--- a/settings.php
+++ b/settings.php
@@ -113,9 +113,9 @@
 			$DHCProuter = $DHCPdomain[0].".".$DHCPdomain[1].".".$DHCPdomain[2].".1";
 		}
 		else {
-			$DHCPstart  = "0.0.0.0";
-			$DHCPend    = "0.0.0.0";
-			$DHCProuter = "0.0.0.0";
+			$DHCPstart  = "";
+			$DHCPend    = "";
+			$DHCProuter = "";
 		}
 	}
 	if(isset($setupVars["PIHOLE_DOMAIN"])){


### PR DESCRIPTION
Changes proposed in this pull request:

- Set default DHCP values to 0.0.0.0 if there's no IPv4 address

I don't know if we want to completely disable the DHCP stuff from being enabled if there's no IPv4 address. Discuss.

@pi-hole/dashboard
