### PR TITLE
Fix blocked queries being zero

### DIFF
--- a/data.php
+++ b/data.php
@@ -343,7 +343,7 @@
     function countBlockedQueries() {
         global $logListName;
         $hostname = trim(file_get_contents("/etc/hostname"), "\x00..\x1F");
-        return exec("grep \"gravity.list\" $logListName | grep -v \"pi.hole\" | grep -v \" read \" | grep -v -c \"".$hostname."\"");
+        return exec("grep \"gravity.list\" $logListName | grep -v \"pi.hole\" | grep -v -c \" read \"");
     }
 
     function getForwards(\SplFileObject $log) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Caused by the hostname being contained within `/etc/pihole/gravity.list`, such as `pi` or `pihole`. Since those hostnames exist in the path, all blocked queries are ignored, making the resulting count 0. This last check doesn't matter and can be taken out, since the hostname should not be part of a blocked query.

I think these are the only lines that would contain the hostname (if raspberrypi is the hostname):
```
Dec 22 22:14:08 dnsmasq[13941]: query[A] raspberrypi from 127.0.0.1
Dec 22 22:14:08 dnsmasq[13941]: /etc/hosts raspberrypi is 127.0.1.1
Dec 22 22:14:08 dnsmasq[13941]: /etc/pihole/local.list raspberrypi is 192.168.1.128
```

@pi-hole/dashboard
