### PR TITLE
Allow underscores in domain names

### DIFF
--- a/php/savesettings.php
+++ b/php/savesettings.php
@@ -26,7 +26,7 @@ function istrue($argument) {
 // Credit: http://stackoverflow.com/a/4694816/2087442
 function validDomain($domain_name)
 {
-	$validChars = preg_match("/^([a-z\d](-*[_a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $domain_name);
+	$validChars = preg_match("/^([_a-z\d](-*[_a-z\d])*)(\.([_a-z\d](-*[a-z\d])*))*(\.([a-z\d])*)+$/i", $domain_name);
 	$lengthCheck = preg_match("/^.{1,253}$/", $domain_name);
 	$labelLengthCheck = preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domain_name);
 	return ( $validChars && $lengthCheck && $labelLengthCheck ); //length of each label

--- a/php/savesettings.php
+++ b/php/savesettings.php
@@ -26,7 +26,7 @@ function istrue($argument) {
 // Credit: http://stackoverflow.com/a/4694816/2087442
 function validDomain($domain_name)
 {
-	$validChars = preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $domain_name);
+	$validChars = preg_match("/^([a-z\d](-*[_a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $domain_name);
 	$lengthCheck = preg_match("/^.{1,253}$/", $domain_name);
 	$labelLengthCheck = preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domain_name);
 	return ( $validChars && $lengthCheck && $labelLengthCheck ); //length of each label


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Fixes issue on [Discourse](https://discourse.pi-hole.net/t/invalid-ad-domain-entry/922).

Changes proposed in this PR:
- Allow underscore in subdomain and domain names. Prevent _ and - in TLD

Background: Host names are generally not allowed to have underscores in them (rules for ARPANET host names). Hence, our current validation scheme does not accept domains with underscores in them.

However, as has been pointed out by a user on [Discourse](https://discourse.pi-hole.net/t/invalid-ad-domain-entry/922), there are still (sub-)domains having underscores in them.

Even several well known Internet and technology companies have DNS records that use the underscore, including but not limited to

- _domainkey.yahoo.com
- beta._domainkey.google.com
- _domainkey.ebay.com
- _domainkey.cern.ch


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
