### PR TITLE
Increase critical CPU temperature value

### DIFF
--- a/header.php
+++ b/header.php
@@ -257,7 +257,7 @@
                         // CPU Temp
                         if ($celsius >= -273.15) {
                             echo "<a href=\"#\" id=\"temperature\"><i class=\"fa fa-fire\" style=\"color:";
-                            if ($celsius > 45) {
+                            if ($celsius > 60) {
                                 echo "#FF0000";
                             }
                             else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---
Change CPU temperature value when switching from green to red from 45 to 60°C. A normal working temperature for a Raspberry Pi (in a plastic case) is around 55°C. Hence, a lot of users (including me) always see the temperature icon in red. However, the Raspberry Pi can still operate fine at even higher temperatures (CPU frequency only gets throttled when surpassing 85°C).

From the Raspbery Pi FAQ:
>8. WHAT IS ITS OPERATING TEMPERATURE?
>The Raspberry Pi is built from commercial chips which are qualified to different temperature ranges; the LAN9512 is specified by the manufacturers as being qualified from 0°C to 70°C, while the AP is qualified from -40°C to 85°C. You may well find that the board will work outside those temperatures, but we’re not qualifying the board itself to these extremes.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
