### PR TITLE
Reverse DNS lookup improvement for Top Clients Table

### DIFF
--- a/data.php
+++ b/data.php
@@ -116,7 +116,7 @@
             if($hostname)
             {
                 // Generate HOST entry
-                $hostarray[$hostname] = $value;
+                $hostarray["$hostname|$key"] = $value;
             }
             else
             {

--- a/js/pihole/index.js
+++ b/js/pihole/index.js
@@ -132,14 +132,22 @@ function escapeHtml(text) {
 function updateTopClientsChart() {
     $.getJSON("api.php?summaryRaw&getQuerySources", function(data) {
         var clienttable =  $("#client-frequency").find("tbody:last");
-        var domain, percentage;
+        var domain, percentage, domainname;
         for (domain in data.top_sources) {
 
             if ({}.hasOwnProperty.call(data.top_sources, domain)){
                 // Sanitize domain
                 domain = escapeHtml(domain);
+                if(domain.indexOf("|") > -1)
+                {
+                    domainname = domain.substr(0, domain.indexOf("|"));
+                }
+                else
+                {
+                    domainname = domain;
+                }
 
-                var url = "<a href=\"queries.php?client="+domain+"\">"+domain+"</a>";
+                var url = "<a href=\"queries.php?client="+domain+"\">"+domainname+"</a>";
                 percentage = data.top_sources[domain] / data.dns_queries_today * 100;
                 clienttable.append("<tr> <td>" + url +
                     "</td> <td>" + data.top_sources[domain] + "</td> <td> <div class=\"progress progress-sm\" title=\""+percentage.toFixed(1)+"%\"> <div class=\"progress-bar progress-bar-blue\" style=\"width: " +
@@ -162,6 +170,10 @@ function updateForwardDestinations() {
         $.each(data, function(key , value) {
             v.push(value);
             c.push(colors.shift());
+            if(key.indexOf("|") > -1)
+            {
+                key = key.substr(0, key.indexOf("|"));
+            }
             forwardDestinationChart.data.labels.push(key);
         });
         // Build a single dataset with the data to be pushed
@@ -179,7 +191,7 @@ function updateTopLists() {
     $.getJSON("api.php?summaryRaw&topItems", function(data) {
         var domaintable = $("#domain-frequency").find("tbody:last");
         var adtable = $("#ad-frequency").find("tbody:last");
-        var url, domain, percentage;
+        var url, domain, percentage, domainname;
 
         for (domain in data.top_queries) {
             if ({}.hasOwnProperty.call(data.top_queries,domain)){


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---
We have to include the IP addresses of the clients in the Top Clients Table -> Query Log links if the new reverse DNS lookup feature in enabled


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
