### PR TITLE
Fix output of API for overTimeData if there are 0 blocked queries

### DIFF
--- a/data.php
+++ b/data.php
@@ -68,6 +68,16 @@
 
         $domains_over_time = overTime10mins($dns_queries);
         $ads_over_time = overTime10mins($ads_blocked);
+
+        // Provide a minimal valid array if there have are no blocked
+        // queries at all. Otherwise the output of the API is inconsistent.
+        if(count($ads_blocked) == 0)
+        {
+            $ads_over_time = [1 => 0];
+        }
+
+        print_r($domains_over_time);
+
         alignTimeArrays($ads_over_time, $domains_over_time);
         return Array(
             'domains_over_time' => $domains_over_time,

--- a/data.php
+++ b/data.php
@@ -84,8 +84,6 @@
             $ads_over_time = [1 => 0];
         }
 
-        print_r($domains_over_time);
-
         alignTimeArrays($ads_over_time, $domains_over_time);
         return Array(
             'domains_over_time' => $domains_over_time,

--- a/data.php
+++ b/data.php
@@ -54,6 +54,14 @@
 
         $domains_over_time = overTime($dns_queries);
         $ads_over_time = overTime($ads_blocked);
+
+        // Provide a minimal valid array if there have are no blocked
+        // queries at all. Otherwise the output of the API is inconsistent.
+        if(count($ads_blocked) == 0)
+        {
+            $ads_over_time = [1 => 0];
+        }
+
         alignTimeArrays($ads_over_time, $domains_over_time);
         return Array(
             'domains_over_time' => $domains_over_time,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Provide a minimal valid array if there have are no blocked queries at all. Currently, the output of the API is inconsistent in this case preventing the main graph from showing any data at all.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
