### PR TITLE
Allow whitelisting when correct passwort is given via POST

### DIFF
--- a/php/add.php
+++ b/php/add.php
@@ -1,35 +1,12 @@
 <?php
 require('auth.php');
 
-if(!isset($_POST['domain'], $_POST['list']) && !(isset($_POST['pw']) || isset($_POST['token']))) {
-	log_and_die("Missing POST variables");
-}
+$type = $_POST['list'];
 
-if(isset($_POST['token']))
-{
-	check_cors();
-	check_csrf($_POST['token']);
-}
-elseif(isset($_POST['pw']) && $_POST['list'] == "white")
-{
-	require("password.php");
-	if(strlen($pwhash) == 0)
-	{
-		log_and_die("No password set - whitelisting with password not supported");
-	}
-	elseif($wrongpassword)
-	{
-		log_and_die("Wrong password - whitelisting of ${_POST['domain']} not permitted");
-	}
-}
-else
-{
-	log_and_die("Not allowed!");
-}
-check_domain();
+// All of the verification for list editing
+list_verify($type);
 
-
-switch($_POST['list']) {
+switch($type) {
 	case "white":
 		echo exec("sudo pihole -w -q ${_POST['domain']}");
 		break;

--- a/php/add.php
+++ b/php/add.php
@@ -7,12 +7,12 @@ $type = $_POST['list'];
 list_verify($type);
 
 switch($type) {
-	case "white":
-		echo exec("sudo pihole -w -q ${_POST['domain']}");
-		break;
-	case "black":
-		echo exec("sudo pihole -b -q ${_POST['domain']}");
-		break;
+    case "white":
+        echo exec("sudo pihole -w -q ${_POST['domain']}");
+        break;
+    case "black":
+        echo exec("sudo pihole -b -q ${_POST['domain']}");
+        break;
 }
 
 ?>

--- a/php/add.php
+++ b/php/add.php
@@ -1,7 +1,7 @@
 <?php
 require('auth.php');
 
-if(!isset($_POST['domain'], $_POST['list'], $_POST['token']) && !isset($_POST['domain'], $_POST['list'], $_POST['pw'])) {
+if(!isset($_POST['domain'], $_POST['list']) && !(isset($_POST['pw']) || isset($_POST['token']))) {
 	log_and_die("Missing POST variables");
 }
 

--- a/php/add.php
+++ b/php/add.php
@@ -1,7 +1,7 @@
 <?php
 require('auth.php');
 
-if(!isset($_POST['domain'], $_POST['list'], $_POST['token']) || !isset($_POST['domain'], $_POST['list'], $_POST['pw'])) {
+if(!isset($_POST['domain'], $_POST['list'], $_POST['token']) && !isset($_POST['domain'], $_POST['list'], $_POST['pw'])) {
 	log_and_die("Missing POST variables");
 }
 

--- a/php/add.php
+++ b/php/add.php
@@ -1,21 +1,36 @@
 <?php
 require('auth.php');
 
-if(!isset($_POST['domain'], $_POST['list'], $_POST['token'])) {
-    log_and_die("Missing POST variables");
+if(!isset($_POST['domain'], $_POST['list'], $_POST['token']) || !isset($_POST['domain'], $_POST['list'], $_POST['pw'])) {
+	log_and_die("Missing POST variables");
 }
 
-check_cors();
-check_csrf($_POST['token']);
+if(isset($_POST['token']))
+{
+	check_cors();
+	check_csrf($_POST['token']);
+}
+elseif(isset($_POST['pw']) && $_POST['list'] == "white")
+{
+	require("password.php");
+	if(strlen($pwhash) == 0)
+	{
+		log_and_die("No password specified - whitelisting with password not supported");
+	}
+	elseif($wrongpassword)
+	{
+		log_and_die("Wrong password - whitelisting of ${_POST['domain']} not permitted");
+	}
+}
 check_domain();
 
 switch($_POST['list']) {
-    case "white":
-        echo exec("sudo pihole -w -q ${_POST['domain']}");
-        break;
-    case "black":
-        echo exec("sudo pihole -b -q ${_POST['domain']}");
-        break;
+	case "white":
+		echo exec("sudo pihole -w -q ${_POST['domain']}");
+		break;
+	case "black":
+		echo exec("sudo pihole -b -q ${_POST['domain']}");
+		break;
 }
 
 ?>

--- a/php/add.php
+++ b/php/add.php
@@ -22,7 +22,12 @@ elseif(isset($_POST['pw']) && $_POST['list'] == "white")
 		log_and_die("Wrong password - whitelisting of ${_POST['domain']} not permitted");
 	}
 }
+else
+{
+	log_and_die("Not allowed!");
+}
 check_domain();
+
 
 switch($_POST['list']) {
 	case "white":

--- a/php/add.php
+++ b/php/add.php
@@ -15,7 +15,7 @@ elseif(isset($_POST['pw']) && $_POST['list'] == "white")
 	require("password.php");
 	if(strlen($pwhash) == 0)
 	{
-		log_and_die("No password specified - whitelisting with password not supported");
+		log_and_die("No password set - whitelisting with password not supported");
 	}
 	elseif($wrongpassword)
 	{

--- a/php/auth.php
+++ b/php/auth.php
@@ -105,4 +105,33 @@ function check_domain() {
         }
     }
 }
+
+function list_verify($type) {
+    if(!isset($_POST['domain'], $_POST['list']) && !(isset($_POST['pw']) || isset($_POST['token']))) {
+        log_and_die("Missing POST variables");
+    }
+
+    if(isset($_POST['token']))
+    {
+        check_cors();
+        check_csrf($_POST['token']);
+    }
+    elseif(isset($_POST['pw']) && $_POST['list'] == "white")
+    {
+        require("password.php");
+        if(strlen($pwhash) == 0)
+        {
+            log_and_die("No password set - ${type}listing with password not supported");
+        }
+        elseif($wrongpassword)
+        {
+            log_and_die("Wrong password - ${type}listing of ${_POST['domain']} not permitted");
+        }
+    }
+    else
+    {
+        log_and_die("Not allowed!");
+    }
+    check_domain();
+}
 ?>

--- a/php/auth.php
+++ b/php/auth.php
@@ -116,7 +116,7 @@ function list_verify($type) {
         check_cors();
         check_csrf($_POST['token']);
     }
-    elseif(isset($_POST['pw']) && $_POST['list'] == "white")
+    elseif(isset($_POST['pw']))
     {
         require("password.php");
         if(strlen($pwhash) == 0)

--- a/php/auth.php
+++ b/php/auth.php
@@ -107,7 +107,7 @@ function check_domain() {
 }
 
 function list_verify($type) {
-    if(!isset($_POST['domain'], $_POST['list']) && !(isset($_POST['pw']) || isset($_POST['token']))) {
+    if(!isset($_POST['domain']) || !isset($_POST['list']) || !(isset($_POST['pw']) || isset($_POST['token']))) {
         log_and_die("Missing POST variables");
     }
 

--- a/php/sub.php
+++ b/php/sub.php
@@ -1,15 +1,12 @@
 <?php
 require('auth.php');
 
-if(!isset($_POST['domain'], $_POST['list'], $_POST['token'])) {
-    log_and_die("Missing POST variables");
-}
+$type = $_POST['list'];
 
-check_cors();
-check_csrf($_POST['token']);
-check_domain();
+// All of the verification for list editing
+list_verify($type);
 
-switch($_POST['list']) {
+switch($type) {
     case "white":
         exec("sudo pihole -w -q -d ${_POST['domain']}");
         break;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---
Allow whitelisting when correct passwort is sent via `$_POST["pw"]`

Due to the test in line 4, either `token` or `pw` (or both) have to be present. If both are present, then the current verification scheme (`token`) is chosen.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
