### PR TITLE
Header disk usage

### DIFF
--- a/help.php
+++ b/help.php
@@ -22,6 +22,7 @@
         <li>Temp: Current CPU temperature</li>
         <li>Load: load averages for the last minute, 5 minutes and 15 minutes, respectively. A load average of 1 reflects the full workload of a single processor on the system. We show a red icon if the current load exceeds the number of available processors on this machine (which is <?php echo $nproc; ?>)</li>
         <li>Memory: Shows the percentage of memory actually blocked by applications. We show a red icon if the memory usage exceeds 75%</li>
+        <li>Disk: Shows the percentage of disk used (for the main partition "/"). A red icon is shown if the disk usage exceeds 79%</li>
     </ul>
     <h4>Top right: About</h4>
     <ul>

--- a/help.php
+++ b/help.php
@@ -21,7 +21,7 @@
         <li>Status: Current status of the Pi-hole - Active (<i class="fa fa-circle" style="color:#7FFF00"></i>), Offline (<i class="fa fa-circle" style="color:#FF0000"></i>), or Starting (<i class="fa fa-circle" style="color:#ff9900"></i>)</li>
         <li>Temp: Current CPU temperature</li>
         <li>Load: load averages for the last minute, 5 minutes and 15 minutes, respectively. A load average of 1 reflects the full workload of a single processor on the system. We show a red icon if the current load exceeds the number of available processors on this machine (which is <?php echo $nproc; ?>)</li>
-        <li>Memory usage: Shows the percentage of memory actually blocked by applications. We show a red icon if the memory usage exceeds 75%</li>
+        <li>Memory: Shows the percentage of memory actually blocked by applications. We show a red icon if the memory usage exceeds 75%</li>
     </ul>
     <h4>Top right: About</h4>
     <ul>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -318,11 +318,11 @@
                         }
                         if($memory_usage > 0.0)
                         {
-                            echo '""></i> Memory usage:&nbsp;&nbsp;' . sprintf("%.1f",100.0*$memory_usage) . '%</a>';
+                            echo '""></i> Memory:&nbsp;&nbsp;' . sprintf("%.1f",100.0*$memory_usage) . '%</a>';
                         }
                         else
                         {
-                            echo '""></i> Memory usage:&nbsp;&nbsp; N/A</a>';
+                            echo '""></i> Memory:&nbsp;&nbsp; N/A</a>';
                         }
                     ?>
                 </div>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -83,6 +83,9 @@
         $memory_usage = -1;
     }
 
+    // Get disk usage
+    $disk_usage = shell_exec("df -h | grep '/$' | awk {'print $5;'} | sed 's/%//g'");
+
 
     // For session timer
     $maxlifetime = ini_get("session.gc_maxlifetime");

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -324,6 +324,24 @@
                         {
                             echo '""></i> Memory:&nbsp;&nbsp; N/A</a>';
                         }
+
+                    echo '<a href="#"><i class="fa fa-circle" style="color:';
+                        if ($disk_usage > 80 || $disk_usage < 0) {
+                            echo '#FF0000';
+                        }
+                        else
+                        {
+                            echo '#7FFF00';
+                        }
+                        if($disk_usage > 0.0)
+                        {
+                            echo '""></i> Disk:&nbsp;&nbsp;' . sprintf("%.0f",$disk_usage) . '%</a>';
+                        }
+                        else
+                        {
+                            echo '""></i> Disk:&nbsp;&nbsp; N/A</a>';
+                        }
+
                     ?>
                 </div>
             </div>


### PR DESCRIPTION
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?** 8

---

### Disk usage integration

It provides a way to integrate the disk usage % inside the header.

#### Provided changes
* Disk usage is fetched using the _df_ binary, filtering the main ("/") partition, extracting the usage column and erasing the "%" unit.
* To provide a visual green/red indicator, the healthy threshold must be between 0 and 80%.
* To ensure a correct UX and reach more available space, the label "Memory usage" is replaced to "Memory"
* Disk usage label is shorted as "Disk", and the related data and indicator are placed next to "Disk"
* Help was updated to integrate the "Disk" check description and "Memory usage" was also shorted.

Fix #323 :: Feature Request: Add disk usage to the header