### PR TITLE
Ensure that $auth is always set

### DIFF
--- a/scripts/pi-hole/php/password.php
+++ b/scripts/pi-hole/php/password.php
@@ -21,6 +21,7 @@
     }
 
     $wrongpassword = false;
+    $auth = false;
 
     // Test if password is set
     if(strlen($pwhash) > 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

No functional change, but ensure that error like
```
2017-01-08 10:17:19: (mod_fastcgi.c.2702) FastCGI-stderr: PHP Notice:  Undefined variable: auth in /var/www/html/admin/scripts/pi-hole/php/header.php on line 86
2017-01-08 10:17:19: (mod_fastcgi.c.2702) FastCGI-stderr: PHP Notice:  Undefined variable: auth in /var/www/html/admin/scripts/pi-hole/php/header.php on line 175
2017-01-08 10:17:19: (mod_fastcgi.c.2702) FastCGI-stderr: PHP Notice:  Undefined variable: auth in /var/www/html/admin/scripts/pi-hole/php/header.php on line 219
2017-01-08 10:17:19: (mod_fastcgi.c.2702) FastCGI-stderr: PHP Notice:  Undefined variable: auth in /var/www/html/admin/scripts/pi-hole/php/header.php on line 351
2017-01-08 10:17:19: (mod_fastcgi.c.2702) FastCGI-stderr: PHP Notice:  Undefined variable: auth in /var/www/html/admin/scripts/pi-hole/php/header.php on line 455
2017-01-08 10:17:19: (mod_fastcgi.c.2702) FastCGI-stderr: PHP Notice:  Undefined variable: auth in /var/www/html/admin/scripts/pi-hole/php/header.php on line 468
2017-01-08 10:17:19: (mod_fastcgi.c.2702) FastCGI-stderr: PHP Notice:  Undefined variable: auth in /var/www/html/admin/scripts/pi-hole/php/header.php on line 494
```
don't appear if the entered password is wrong.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
