### PR TITLE
Added loading indicator for all queries page

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -96,8 +96,11 @@ if(isset($setupVars["API_PRIVACY_MODE"]))
                     </tfoot>
                 </table>
             </div>
-       </div>
+        </div>
         <!-- /.box-body -->
+        <div class="overlay">
+	    <i class="fa fa-refresh fa-spin"></i>
+	</div>
       </div>
       <!-- /.box -->
     </div>

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -14,7 +14,7 @@ var tableIsLoading=true;
 // shows loading indicator above table
 function setTableLoading(loading){
     // dont progress if queried state is already active
-    if(loading == tableIsLoading){
+    if(loading === tableIsLoading){
         return;
     }
     tableIsLoading=loading;
@@ -39,8 +39,9 @@ function add(row) {
     alDomain.html(rowData[2]);
     var alSuccess = $("#alSuccess");
     var alFailure = $("#alFailure");
-
-    if(rowData[4] == "Pi-holed"){
+  
+    list="unknown";
+    if(rowData[4] === "Pi-holed"){
         list="white";
         alList.html("Whitelist");
     }else{

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -40,7 +40,7 @@ function add(row) {
     var alSuccess = $("#alSuccess");
     var alFailure = $("#alFailure");
   
-    list="unknown";
+    var list="unknown";
     if(rowData[4] === "Pi-holed"){
         list="white";
         alList.html("Whitelist");


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_8_

---
_This PR adds a loading indicator that overlays the table of the queries-page everytime a network operation is pending like loading the initial data or black/white-listing a domain._


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
