### PR TITLE
Moving ampersand fixes Query Adlists exact search

### DIFF
--- a/scripts/pi-hole/js/queryads.js
+++ b/scripts/pi-hole/js/queryads.js
@@ -62,7 +62,7 @@ function eventsource() {
     if(q.val() === "yes")
     {
         quiet = true;
-        exact = "&exact";
+        exact = "exact";
     }
 
     // IE does not support EventSource - load whole content at once
@@ -72,7 +72,7 @@ function eventsource() {
     }
 
     var host = window.location.host;
-    var source = new EventSource("/admin/scripts/pi-hole/php/queryads.php?domain="+domain.val().toLowerCase()+exact);
+    var source = new EventSource("/admin/scripts/pi-hole/php/queryads.php?domain="+domain.val().toLowerCase()+"&"+exact);
 
     // Reset and show field
     ta.empty();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

See title, not sure why this is happening - the ampersand seems not to be saved in the variable correctly, it worked in the past!

See [this topic](https://discourse.pi-hole.net/t/webui-cli-results-different-for-query-exact-domain/1631) on Discourse.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
