### PR TITLE
Improve Enable/Disable through API

### DIFF
--- a/api.php
+++ b/api.php
@@ -68,15 +68,31 @@
         $data = array_merge($data, getAllQueries($_GET['getAllQueries']));
     }
 
-    if (isset($_GET['enable'], $_GET['token']) && $auth) {
-        check_csrf($_GET['token']);
+    if (isset($_GET['enable']) && $auth) {
+        if(isset($_GET["auth"]))
+        {
+            if($_GET["auth"] !== $pwhash)
+                die("Not autorized!");
+        }
+        else
+        {
+            // Skip token validation if explicit auth string is given
+            check_csrf($_GET['token']);
+        }
         exec('sudo pihole enable');
-        $data = array_merge($data, Array(
-            "status" => "enabled"
-        ));
+        $data = array_merge($data, array("status" => "enabled"));
     }
-    elseif (isset($_GET['disable'], $_GET['token']) && $auth) {
-        check_csrf($_GET['token']);
+    elseif (isset($_GET['disable']) && $auth) {
+        if(isset($_GET["auth"]))
+        {
+            if($_GET["auth"] !== $pwhash)
+                die("Not autorized!");
+        }
+        else
+        {
+            // Skip token validation if explicit auth string is given
+            check_csrf($_GET['token']);
+        }
         $disable = intval($_GET['disable']);
         // intval returns the integer value on success, or 0 on failure
         if($disable > 0)
@@ -87,9 +103,7 @@
         {
             exec('sudo pihole disable');
         }
-        $data = array_merge($data, Array(
-            "status" => "disabled"
-        ));
+        $data = array_merge($data, array("status" => "disabled"));
     }
 
     if (isset($_GET['getGravityDomains'])) {

--- a/api.php
+++ b/api.php
@@ -72,7 +72,7 @@
         if(isset($_GET["auth"]))
         {
             if($_GET["auth"] !== $pwhash)
-                die("Not autorized!");
+                die("Not authorized!");
         }
         else
         {
@@ -86,7 +86,7 @@
         if(isset($_GET["auth"]))
         {
             if($_GET["auth"] !== $pwhash)
-                die("Not autorized!");
+                die("Not authorized!");
         }
         else
         {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Allow to disable/enable Pi-hole blocking through the API with a more simple frontend for users using the password hash:

Example: `api.php?disable&auth=183c1b634da0078fcf5b0af84bdcbb3e817708c3f22b329be84165f4bad1ae58`

```
{"status":"disabled"}
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
