### PR TITLE
Start count down only if there is something to count down

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -91,8 +91,11 @@ function piholeChange(action, duration)
                 if(data.status === "disabled") {
                     btnStatus.html("");
                     piholeChanged("disabled");
-                    enaT.html(new Date().getTime() + duration * 1000);
-                    setTimeout(countDown,100);
+                    if(duration > 0)
+                    {
+                        enaT.html(new Date().getTime() + duration * 1000);
+                        setTimeout(countDown,100);
+                    }
                 }
             });
             break;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

If selecting `Disable` -> `Permanently` we start a count down with 0 seconds, i.e. status is switched to `active`, again. Note that this is only a displaying issue as the blocking will actually stay disabled.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
