### PR TITLE
Added space between temperature reading and unit

### DIFF
--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -306,15 +306,15 @@
                                 echo "\"></i> Temp:&nbsp;";
                                 if($temperatureunit === "F")
                                 {
-                                    echo round($fahrenheit,1) . "&deg;F";
+                                    echo round($fahrenheit,1) . " &deg;F";
                                 }
                                 elseif($temperatureunit === "K")
                                 {
-                                    echo round($kelvin,1) . "K";
+                                    echo round($kelvin,1) . " K";
                                 }
                                 else
                                 {
-                                    echo round($celsius,1) . "&deg;C";
+                                    echo round($celsius,1) . " &deg;C";
                                 }
                                 echo "</a>";
                             }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_3_

---
_Updated the rendering of temperature readings to include a space between the reading and the unit as suggested in issue #422 _


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
