### PR TITLE
Some tweaks for the Pi-hole Teleporter

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -127,7 +127,8 @@ if($_POST["action"] == "in")
 }
 else
 {
-	$archive_file_name = "/var/www/html/pi-hole-teleporter_".microtime(true).".zip";
+	$filename = "pi-hole-teleporter_".date("Y-m-d_h-i-s").".zip";
+	$archive_file_name = "/var/www/html/".$filename;
 	$zip = new ZipArchive();
 	touch($archive_file_name);
 	$res = $zip->open($archive_file_name, ZipArchive::CREATE | ZipArchive::OVERWRITE);
@@ -146,7 +147,7 @@ else
 
 	header("Content-type: application/zip");
 	header('Content-Transfer-Encoding: binary');
-	header("Content-Disposition: attachment; filename=pi-hole-teleporter.zip");
+	header("Content-Disposition: attachment; filename=".$filename);
 	header("Content-length: " . filesize($archive_file_name));
 	header("Pragma: no-cache");
 	header("Expires: 0");

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -36,6 +36,22 @@ function add_to_zip($path,$name)
 		$zip->addFile($path.$name,$name);
 }
 
+function add_dir_to_zip($path)
+{
+	global $zip;
+	if($dir = opendir($path))
+	{
+		while(false !== ($entry = readdir($dir)))
+		{
+			if($entry !== "." && $entry !== "..")
+			{
+				$zip->addFile($path.$entry,$entry);
+			}
+		}
+		closedir($dir);
+	}
+}
+
 function check_domains($domains)
 {
 	foreach($domains as $domain)
@@ -141,6 +157,7 @@ else
 	add_to_zip("/etc/pihole/","blacklist.txt");
 	add_to_zip("/etc/pihole/","adlists.list");
 	add_to_zip("/etc/pihole/","setupVars.conf");
+	add_dir_to_zip("/etc/dnsmasq.d/");
 
 	$zip->addFromString("wildcardblocking.txt", getWildcardListContent());
 	$zip->close();

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -7,7 +7,9 @@
 *  Please see LICENSE file for your rights under this license. */
 
 require "password.php";
-if(!$auth) die("Not authorized");
+if (php_sapi_name() !== "cli") {
+	if(!$auth) die("Not authorized");
+}
 
 require('func.php');
 function process_zip($name)
@@ -83,9 +85,9 @@ function getWildcardListContent() {
 	return "";
 }
 
-if($_POST["action"] == "in")
+if(isset($_POST["action"]))
 {
-	if($_FILES["zip_file"]["name"])
+	if($_FILES["zip_file"]["name"] && $_POST["action"] == "in")
 	{
 		$filename = $_FILES["zip_file"]["name"];
 		$source = $_FILES["zip_file"]["tmp_name"];
@@ -138,7 +140,7 @@ if($_POST["action"] == "in")
 	}
 	else
 	{
-		die("No file transmitted.");
+		die("No file transmitted or parameter error.");
 	}
 }
 else
@@ -168,7 +170,7 @@ else
 	header("Content-length: " . filesize($archive_file_name));
 	header("Pragma: no-cache");
 	header("Expires: 0");
-	ob_end_clean();
+	if(ob_get_length() > 0) ob_end_clean();
 	readfile($archive_file_name);
 	exit;
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

- Add datetimestamp to filename (like `pi-hole-teleporter_2017-03-05_01-37-52.zip`)
- Include *all* files found in `/etc/dnsmasq.d` in the generated ZIP archive

![screenshot at 2017-03-05 13-54-27](https://cloud.githubusercontent.com/assets/16748619/23587430/dde14c18-01ab-11e7-85e0-b48979e3a640.png)


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
