### PR TITLE
IPv6 upstream servers: Require IPv6 scope global address

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -126,17 +126,6 @@
 		</div>
 <?php
 	// Pi-Hole DHCP server
-
-	// Detect IPv6
-	$usingipv6 = false;
-	if(strlen($piHoleIPv6) > 0 && $piHoleIPv6 != "unknown")
-	{
-		if(substr($piHoleIPv6, 0, 4) != "fe80")
-		{
-			$usingipv6 = true;
-		}
-	}
-
 	if(isset($setupVars["DHCP_ACTIVE"]))
 	{
 		if($setupVars["DHCP_ACTIVE"] == 1)
@@ -171,7 +160,7 @@
 		}
 		else
 		{
-			$DHCPIPv6 = $usingipv6;
+			$DHCPIPv6 = false;
 		}
 
 	}
@@ -191,7 +180,7 @@
 			$DHCProuter = "";
 		}
 		$DHCPleasetime = 24;
-		$DHCPIPv6 = $usingipv6;
+		$DHCPIPv6 = false;
 	}
 	if(isset($setupVars["PIHOLE_DOMAIN"])){
 		$piHoleDomain = $setupVars["PIHOLE_DOMAIN"];

--- a/settings.php
+++ b/settings.php
@@ -74,7 +74,7 @@
 			{
 				// Convert HEX string to number
 				$hex = hexdec($hexstr);
-				if($hex === 0b0010)
+				if(($hex & 0b0111) === 0b0010)
 				{
 					// Scope global address detected
 					$IPv6connectivity = true;

--- a/settings.php
+++ b/settings.php
@@ -68,14 +68,13 @@
 	$IPv6connectivity = false;
 	if(isset($setupVars["IPV6_ADDRESS"])){
 		$piHoleIPv6 = $setupVars["IPV6_ADDRESS"];
-			// Get first hextet of IPv6 address
-			sscanf($piHoleIPv6, "%2[0-9a-f]", $hexstr);
-			// Try to analyze it only if we found a prefix
-			if(strlen($hexstr) == 2)
+			// Test if this address is within 2000::/3 address range (Global Unicast, RFC 4291)
+			sscanf($piHoleIPv6, "%1[0-9a-f]", $hexstr);
+			if(strlen($hexstr) == 1)
 			{
 				// Convert HEX string to number
 				$hex = hexdec($hexstr);
-				if($hex == 0x20)
+				if($hex === 0b0010)
 				{
 					// Scope global address detected
 					$IPv6connectivity = true;

--- a/settings.php
+++ b/settings.php
@@ -68,13 +68,16 @@
 	$IPv6connectivity = false;
 	if(isset($setupVars["IPV6_ADDRESS"])){
 		$piHoleIPv6 = $setupVars["IPV6_ADDRESS"];
-			// Test if this address is within 2000::/3 address range (Global Unicast, RFC 4291)
-			sscanf($piHoleIPv6, "%1[0-9a-f]", $hexstr);
-			if(strlen($hexstr) == 1)
+			sscanf($piHoleIPv6, "%2[0-9a-f]", $hexstr);
+			if(strlen($hexstr) == 2)
 			{
 				// Convert HEX string to number
 				$hex = hexdec($hexstr);
-				if(($hex & 0b0111) === 0b0010)
+				// Global Unicast Address (2000::/3, RFC 4291)
+				$GUA = (($hex & 0b01110000) === 0b00100000);
+				// Unique Local Address   (fc00::/7, RFC 4193)
+				$ULA = (($hex & 0b11111110) === 0b11111100);
+				if($GUA || $ULA)
 				{
 					// Scope global address detected
 					$IPv6connectivity = true;

--- a/settings.php
+++ b/settings.php
@@ -74,9 +74,9 @@
 				// Convert HEX string to number
 				$hex = hexdec($hexstr);
 				// Global Unicast Address (2000::/3, RFC 4291)
-				$GUA = (($hex & 0b01110000) === 0b00100000);
+				$GUA = (($hex & 0x70) === 0x20);
 				// Unique Local Address   (fc00::/7, RFC 4193)
-				$ULA = (($hex & 0b11111110) === 0b11111100);
+				$ULA = (($hex & 0xfe) === 0xfc);
 				if($GUA || $ULA)
 				{
 					// Scope global address detected

--- a/settings.php
+++ b/settings.php
@@ -65,8 +65,22 @@
 	} else {
 		$piHoleIPv4 = "unknown";
 	}
+	$IPv6connectivity = false;
 	if(isset($setupVars["IPV6_ADDRESS"])){
 		$piHoleIPv6 = $setupVars["IPV6_ADDRESS"];
+			// Get first hextet of IPv6 address
+			sscanf($piHoleIPv6, "%2[0-9a-f]", $hexstr);
+			// Try to analyze it only if we found a prefix
+			if(strlen($hexstr) == 2)
+			{
+				// Convert HEX string to number
+				$hex = hexdec($hexstr);
+				if($hex == 0x20)
+				{
+					// Scope global address detected
+					$IPv6connectivity = true;
+				}
+			}
 	} else {
 		$piHoleIPv6 = "unknown";
 	}
@@ -506,9 +520,9 @@
 							<?php if(isset($value["v4_2"])) { ?>
 							<td title="<?php echo $value["v4_2"];?>"><input type="checkbox" name="DNSserver<?php echo $value["v4_2"];?>" value="true" <?php if(in_array($value["v4_2"],$DNSactive)){ ?>checked<?php } ?> ></td><?php }else{ ?><td></td><?php } ?>
 							<?php if(isset($value["v6_1"])) { ?>
-							<td title="<?php echo $value["v6_1"];?>"><input type="checkbox" name="DNSserver<?php echo $value["v6_1"];?>" value="true" <?php if(in_array($value["v6_1"],$DNSactive)){ ?>checked<?php } ?> ></td><?php }else{ ?><td></td><?php } ?>
+							<td title="<?php echo $value["v6_1"];?>"><input type="checkbox" name="DNSserver<?php echo $value["v6_1"];?>" value="true" <?php if(in_array($value["v6_1"],$DNSactive) && $IPv6connectivity){ ?>checked<?php } if(!$IPv6connectivity){ ?> disabled <?php } ?> ></td><?php }else{ ?><td></td><?php } ?>
 							<?php if(isset($value["v6_2"])) { ?>
-							<td title="<?php echo $value["v6_2"];?>"><input type="checkbox" name="DNSserver<?php echo $value["v6_2"];?>" value="true" <?php if(in_array($value["v6_2"],$DNSactive)){ ?>checked<?php } ?> ></td><?php }else{ ?><td></td><?php } ?>
+							<td title="<?php echo $value["v6_2"];?>"><input type="checkbox" name="DNSserver<?php echo $value["v6_2"];?>" value="true" <?php if(in_array($value["v6_2"],$DNSactive) && $IPv6connectivity){ ?>checked<?php } if(!$IPv6connectivity){ ?> disabled <?php } ?> ></td><?php }else{ ?><td></td><?php } ?>
 							<td><?php echo $key;?></td>
 						</tr>
 						<?php } ?>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Allow selection of IPv6 upstream DNS servers only if IPv6 scope global address has been detected

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
