### PR TITLE
Fix undefined variable when setting DNS servers

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -228,7 +228,7 @@ function isinserverlist($addr) {
 				if(!strlen($error))
 				{
 					$IPs = implode (",", $DNSservers);
-					exec("sudo pihole -a setdns ".$IPs." ".$extra);
+					$return = exec("sudo pihole -a setdns ".$IPs." ".$extra);
 					$success .= htmlspecialchars($return)."<br>";
 					$success .= "The DNS settings have been updated (using ".count($DNSservers)." DNS servers)";
 				}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

The variable was supposed to be the output of the save command. It's shown up on a few debug logs.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
