### PR TITLE
Don't add glow property for percentage if not changed

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -378,7 +378,9 @@ function updateSummaryData(runOnce) {
 
         ["ads_blocked_today", "dns_queries_today", "ads_percentage_today"].forEach(function(today) {
             var todayElement = $("h3#" + today);
-            todayElement.text() !== data[today] && todayElement.addClass("glow");
+            todayElement.text() !== data[today] &&
+            todayElement.text() !== data[today] + "%" &&
+            todayElement.addClass("glow");
         });
 
         window.setTimeout(function() {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

---

On each update, the value of the fields in the statistics panels are compared to the new values received through the API. If they are different, they will be updated *and* the `glow` property is added for 0.5 seconds. However, as can be seen now that the update interval has been lowered to once per second,

![ezgif-2-d0c3ddb638](https://cloud.githubusercontent.com/assets/16748619/24322011/adf27558-115b-11e7-8949-d0d0ca5c30dc.gif)

the statistics field always gets the `glow` property added, since we add the percentage to the field, so the comparison will always show a difference (` "0.0" !== "0.0%").

This is fixed by this PR.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
