### PR TITLE
Fix ad list section missing CSRF token

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -715,6 +715,7 @@ if(isset($_POST["submit"])) {
                 </div>
                 <div class="box-footer">
                     <input type="hidden" name="field" value="adlists">
+                    <input type="hidden" name="token" value="<?php echo $token ?>">
                     <button type="submit" class="btn btn-primary" name="submit" value="save">Save</button>
                     <button type="submit" class="btn btn-primary pull-right" name="submit" value="saveupdate">Save and Update</button>
                 </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Don't know how I missed that one. Fixes https://discourse.pi-hole.net/t/block-lists-on-dev-build/2557

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
