### PR TITLE
Show DHCP leases table always

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -391,7 +391,7 @@ readStaticLeasesFile();
 								<tr><td><input type="text" name="AddMAC"></td><td><input type="text" name="AddIP"></td><td><input type="text" name="AddHostname" value=""></td><td><button class="btn btn-success btn-xs" type="submit" name="addstatic"><span class="glyphicon glyphicon-plus"></span></button></td></tr>
 							</tfoot>
 						</table>
-						<p>Specifying the MAC address is mandatory and only one entry per MAC address is allowed. If the IP address is omitted and a host name is given, the IP address will still be generated dynamically and the specified host name will be used. If the host name is omitted, only a static release will be added.</p>
+						<p>Specifying the MAC address is mandatory and only one entry per MAC address is allowed. If the IP address is omitted and a host name is given, the IP address will still be generated dynamically and the specified host name will be used. If the host name is omitted, only a static lease will be added.</p>
 					</div>
 					</div>
 				</div>

--- a/settings.php
+++ b/settings.php
@@ -272,14 +272,14 @@ if(isset($_POST["submit"])) {
 						</div>
 					</div>
 					</div>
-<?php if($DHCP) {
-
+<?php
+$dhcp_leases = array();
+if($DHCP) {
 	// Read leases file
 	$leasesfile = true;
 	$dhcpleases = @fopen('/etc/pihole/dhcp.leases', 'r');
-	if(!is_resource($dhcpleases ))
+	if(!is_resource($dhcpleases))
 		$leasesfile = false;
-	$dhcp_leases  = array();
 
 	function convertseconds($argument) {
 		$seconds = round($argument);
@@ -299,7 +299,7 @@ if(isset($_POST["submit"])) {
 		{
 			return sprintf('%dd %dh %dm %ds', ($seconds/86400), ($seconds/3600%24),($seconds/60%60), ($seconds%60));
 		}
-}
+	}
 
 	while(!feof($dhcpleases) && $leasesfile)
 	{
@@ -346,10 +346,10 @@ if(isset($_POST["submit"])) {
 			array_push($dhcp_leases,["TIME"=>$time, "hwaddr"=>strtoupper($line[1]), "IP"=>$line[2], "host"=>$host, "clid"=>$clid, "type"=>$type]);
 		}
 	}
+}
 
-	readStaticLeasesFile();
-
-	?>
+readStaticLeasesFile();
+?>
 				<div class="col-md-12">
 				<div class="box box-warning <?php if(!isset($_POST["addstatic"])){ ?>collapsed-box<?php } ?>">
 					<div class="box-header with-border">
@@ -396,7 +396,6 @@ if(isset($_POST["submit"])) {
 					</div>
 				</div>
 				</div>
-<?php } ?>
 			</div>
 			<div class="box-footer">
 				<input type="hidden" name="field" value="DHCP">


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Show DHCP leases table (will be empty) and allow editing of static leases also when DHCP server is *not* enabled. A number of users have reported that they hesitated to migrate away from their router's DHCP server to Pi-hole's since they were not aware of the possibility to add static leases.

Now we show the table always. The dynamic leases table will be empty as long as the DHCP server is disabled.
![screenshot at 2017-04-21 23-46-57](https://cloud.githubusercontent.com/assets/16748619/25297381/bc4f0e98-26ed-11e7-907c-ecb124fe1f48.png)


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
