### PR TITLE
Temporarily store the teleporter file

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -148,7 +148,7 @@ if(isset($_POST["action"]))
 else
 {
 	$filename = "pi-hole-teleporter_".date("Y-m-d_h-i-s").".zip";
-	$archive_file_name = "/var/www/html/".$filename;
+	$archive_file_name = "/etc/pihole/".$filename;
 	$zip = new ZipArchive();
 	touch($archive_file_name);
 	$res = $zip->open($archive_file_name, ZipArchive::CREATE | ZipArchive::OVERWRITE);
@@ -174,6 +174,8 @@ else
 	header("Expires: 0");
 	if(ob_get_length() > 0) ob_end_clean();
 	readfile($archive_file_name);
+	ignore_user_abort(true);
+	unlink($archive_file_name);
 	exit;
 }
 

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -148,7 +148,7 @@ if(isset($_POST["action"]))
 else
 {
 	$filename = "pi-hole-teleporter_".date("Y-m-d_h-i-s").".zip";
-	$archive_file_name = "/etc/pihole/".$filename;
+	$archive_file_name = tempnam("/tmp", "Teleporter");
 	$zip = new ZipArchive();
 	touch($archive_file_name);
 	$res = $zip->open($archive_file_name, ZipArchive::CREATE | ZipArchive::OVERWRITE);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Fixes #467 
Stores the teleporter file under `/etc/pihole` instead of `/var/www/html` and deletes the file after it is sent to the browser.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
