### PR TITLE
set the mainbox wider on smaller screens

### DIFF
--- a/scripts/pi-hole/php/loginpage.php
+++ b/scripts/pi-hole/php/loginpage.php
@@ -6,7 +6,7 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */ ?>
 
-<div class="mainbox col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2">
+<div class="mainbox col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2" style="float:none">
   <div class="panel panel-default">
     <div class="panel-heading">
       <div style="text-align: center;"><img src="img/logo.svg" width="<?php if ($boxedlayout) { ?>50%<?php } else { ?>30%<?php } ?>"></div><br>

--- a/scripts/pi-hole/php/loginpage.php
+++ b/scripts/pi-hole/php/loginpage.php
@@ -6,7 +6,7 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */ ?>
 
-<div class="mainbox col-md-6 col-md-offset-3 col-sm-6 col-sm-offset-3">
+<div class="mainbox col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2">
   <div class="panel panel-default">
     <div class="panel-heading">
       <div style="text-align: center;"><img src="img/logo.svg" width="<?php if ($boxedlayout) { ?>50%<?php } else { ?>30%<?php } ?>"></div><br>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

2

---
Fixes partially issue #333 reported by @Marcellaoo:

> on some smaller devices/browser windows: the text is behind the "Log in" Button" (see screenshot2.png and screenshot3.png)


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
