### PR TITLE
Major overhaul of update checking

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -141,76 +141,6 @@ $("#pihole-disable-custom").on("click", function(e){
     piholeChange("disable",custVal);
 });
 
-
-var piholeVersion = $("#piholeVersion").html();
-var webVersion = $("#webVersion").html();
-var FTLVersion = $("#FTLVersion").html();
-
-// Credit for following function: https://gist.github.com/alexey-bass/1115557
-// Modified to discard any possible "v" in the string
-function versionCompare(left, right) {
-    if (typeof left + typeof right !== "stringstring")
-    {
-        return false;
-    }
-
-    // If we are on vDev then we assume that it is always
-    // newer than the latest online release, i.e. version
-    // comparison should return 1
-    if(left === "vDev")
-    {
-        return 1;
-    }
-
-    var aa = left.split("v"),
-        bb = right.split("v");
-
-    var a = aa[aa.length-1].split(".")
-        ,   b = bb[bb.length-1].split(".")
-        ,   i = 0, len = Math.max(a.length, b.length);
-
-    for (; i < len; i++) {
-        if ((a[i] && !b[i] && parseInt(a[i]) > 0) || (parseInt(a[i]) > parseInt(b[i]))) {
-            return 1;
-        } else if ((b[i] && !a[i] && parseInt(b[i]) > 0) || (parseInt(a[i]) < parseInt(b[i]))) {
-            return -1;
-        }
-    }
-    return 0;
-}
-
-
-// Update check
-$.getJSON("https://api.github.com/repos/pi-hole/pi-hole/releases/latest", function(json) {
-    if(versionCompare(piholeVersion, json.tag_name.slice(1)) < 0) {
-        // Alert user
-        $("#piholeVersion").html($("#piholeVersion").text() + " <a class=\"alert-link lookatme\" href=\"https://github.com/pi-hole/pi-hole/releases\">(Update available!)</a>");
-        $("#alPiholeUpdate").show();
-    }
-});
-$.getJSON("https://api.github.com/repos/pi-hole/AdminLTE/releases/latest", function(json) {
-    if(versionCompare(webVersion, json.tag_name.slice(1)) < 0) {
-        // Alert user
-        $("#webVersion").html($("#webVersion").text() + " <a class=\"alert-link lookatme\" href=\"https://github.com/pi-hole/adminLTE/releases\">(Update available!)</a>");
-        $("#alWebUpdate").show();
-    }
-});
-$.getJSON("https://api.github.com/repos/pi-hole/FTL/releases/latest", function(json) {
-    if(versionCompare(FTLVersion, json.tag_name.slice(1)) < 0) {
-        // Alert user
-        $("#FTLVersion").html($("#FTLVersion").text() + " <a class=\"alert-link lookatme\" href=\"https://github.com/pi-hole/FTL/releases\">(Update available!)</a>");
-        $("#alFTLUpdate").show();
-    }
-});
-
-/*
- * Make sure that Pi-hole is updated to at least v2.7, since that is needed to use the sudo
- * features of the interface. Skip if on dev
- */
-if(versionCompare(piholeVersion, "v2.7") < 0) {
-    alert("Pi-hole needs to be updated to at least v2.7 before you can use features such as whitelisting/blacklisting from this web interface!");
-}
-
 // Session timer
 var sessionvalidity = parseInt(document.getElementById("sessiontimercounter").textContent);
 var start = new Date;
@@ -253,12 +183,6 @@ if(sessionvalidity > 0)
 else
 {
     document.getElementById("sessiontimer").style.display = "none";
-}
-
-// Hide "exact match" button on queryads.php page if version is 2.9.5 or lower
-if(versionCompare(piholeVersion, "v2.9.5") < 1)
-{
-    $("#btnSearchExact").hide();
 }
 
 // Handle Strg + Enter button on Login page

--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -41,30 +41,6 @@
     </div>
     <!-- /.content-wrapper -->
     <footer class="main-footer">
-            <?php
-            // Check if on a dev branch
-            $piholeBranch = exec("cd /etc/.pihole/ && git rev-parse --abbrev-ref HEAD");
-            $webBranch = exec("git rev-parse --abbrev-ref HEAD");
-
-            // Use vDev if not on master
-            if($piholeBranch !== "master") {
-                $piholeVersion = "vDev";
-                $piholeCommit = exec("cd /etc/.pihole/ && git describe --long --dirty --tags");
-            }
-            else {
-                $piholeVersion = exec("cd /etc/.pihole/ && git describe --tags --abbrev=0");
-            }
-
-            if($webBranch !== "master") {
-                $webVersion = "vDev";
-                $webCommit = exec("git describe --long --dirty --tags");
-            }
-            else {
-                $webVersion = exec("git describe --tags --abbrev=0");
-            }
-
-            $FTLVersion = exec("pihole-FTL version");
-            ?>
 <style type="text/css">
 	@-webkit-keyframes Pulse{
 		from {color:#630030;-webkit-text-shadow:0 0 9px #333;}
@@ -77,10 +53,18 @@
 		-webkit-animation-iteration-count: infinite;
 	}
 </style>
-        <div class="pull-right hidden-xs <?php if(isset($piholeCommit) || isset($webCommit)) { ?>hidden-md<?php } ?>">
-            <b>Pi-hole Version </b> <span id="piholeVersion"><?php echo $piholeVersion; ?></span><?php if(isset($piholeCommit)) { echo " (".$piholeBranch.", ".$piholeCommit.")"; } ?>
-            <b>Web Interface Version </b> <span id="webVersion"><?php echo $webVersion; ?></span><?php if(isset($webCommit)) { echo " (".$webBranch.", ".$webCommit.")"; } ?>
-            <b>FTL Version </b> <span id="FTLVersion"><?php echo $FTLVersion; ?></span>
+        <div class="pull-right hidden-xs <?php if(isset($core_commit) || isset($web_commit)) { ?>hidden-md<?php } ?>">
+            <b>Pi-hole Version </b> <?php
+            echo $core_current;
+            if(isset($core_commit)) { echo " (".$core_branch.", ".$core_commit.")"; }
+            if($core_update){ ?> <a class="alert-link lookatme" href="https://github.com/pi-hole/pi-hole/releases">(Update available!)</a><?php } ?>
+            <b>Web Interface Version </b><?php
+            echo $web_current;
+            if(isset($web_commit)) { echo " (".$web_branch.", ".$web_commit.")"; }
+            if($web_update){ ?> <a class="alert-link lookatme\" href="https://github.com/pi-hole/AdminLTE/releases">(Update available!)</a><?php } ?>
+            <b>FTL Version </b> <?php
+            echo $FTL_current;
+            if($FTL_update){ ?> <a class="alert-link lookatme" href="https://github.com/pi-hole/FTL/releases">(Update available!)</a><?php } ?>
         </div>
             <div><a href="https://github.com/pi-hole" target="_blank"><i class="fa fa-github"></i></a> <strong><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=3J2L3Z4DHW9UY" target="_blank">Donate</a></strong> if you found this useful.</div>
     </footer>

--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -61,7 +61,7 @@
             <b>Web Interface Version </b><?php
             echo $web_current;
             if(isset($web_commit)) { echo " (".$web_branch.", ".$web_commit.")"; }
-            if($web_update){ ?> <a class="alert-link lookatme\" href="https://github.com/pi-hole/AdminLTE/releases">(Update available!)</a><?php } ?>
+            if($web_update){ ?> <a class="alert-link lookatme" href="https://github.com/pi-hole/AdminLTE/releases">(Update available!)</a><?php } ?>
             <b>FTL Version </b> <?php
             echo $FTL_current;
             if($FTL_update){ ?> <a class="alert-link lookatme" href="https://github.com/pi-hole/FTL/releases">(Update available!)</a><?php } ?>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -273,7 +273,7 @@ if($auth) {
                                     <b>Web Interface Version </b><?php
                                     echo $web_current;
                                     if(isset($web_commit)) { echo "<br>(".$web_branch.", ".$web_commit.")"; }
-                                    if($web_update){ ?> <a class="alert-link lookatme\" href="https://github.com/                        pi-hole/AdminLTE/releases">(Update available!)</a><?php } ?><br>
+                                    if($web_update){ ?> <a class="alert-link lookatme" href="https://github.com/                        pi-hole/AdminLTE/releases">(Update available!)</a><?php } ?><br>
                                     <b>FTL Version </b> <?php
                                     echo $FTL_current;
                                     if($FTL_update){ ?> <a class="alert-link lookatme" href="https://github.com/                        pi-hole/FTL/releases">(Update available!)</a><?php } ?><br><br>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -9,6 +9,7 @@
 <?php
     require "scripts/pi-hole/php/auth.php";
     require "scripts/pi-hole/php/password.php";
+    require "scripts/pi-hole/php/update_checker.php";
 
     check_cors();
 
@@ -264,12 +265,21 @@ if($auth) {
                             <!-- Menu Footer -->
                             <li class="user-footer">
                                 <!-- Update alerts -->
-                                <div id="alPiholeUpdate" class="alert alert-info alert-dismissible fade in" role="alert" hidden>
+                                <?php if($core_update){ ?>
+                                <div id="alPiholeUpdate" class="alert alert-info alert-dismissible fade in" role="alert">
                                     <a class="alert-link" href="https://github.com/pi-hole/pi-hole/releases">There's an update available for this Pi-hole!</a>
                                 </div>
-                                <div id="alWebUpdate" class="alert alert-info alert-dismissible fade in" role="alert" hidden>
+                                <?php } ?>
+                                <?php if($web_update){ ?>
+                                <div id="alWebUpdate" class="alert alert-info alert-dismissible fade in" role="alert">
                                     <a class="alert-link" href="https://github.com/pi-hole/AdminLTE/releases">There's an update available for this Web Interface!</a>
                                 </div>
+                                <?php } ?>
+                                <?php if($FTL_update){ ?>
+                                <div id="alFTLUpdate" class="alert alert-info alert-dismissible fade in" role="alert">
+                                    <a class="alert-link" href="https://github.com/pi-hole/AdminLTE/releases">There's an update available for this FTL!</a>
+                                </div>
+                                <?php } ?>
 
                                 <!-- PayPal -->
                                 <div>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -265,21 +265,19 @@ if($auth) {
                             <!-- Menu Footer -->
                             <li class="user-footer">
                                 <!-- Update alerts -->
-                                <?php if($core_update){ ?>
-                                <div id="alPiholeUpdate" class="alert alert-info alert-dismissible fade in" role="alert">
-                                    <a class="alert-link" href="https://github.com/pi-hole/pi-hole/releases">There's an update available for this Pi-hole!</a>
+                                <div>
+                                    <b>Pi-hole Version </b> <?php
+                                    echo $core_current;
+                                    if(isset($core_commit)) { echo "<br>(".$core_branch.", ".$core_commit.")"; }
+                                    if($core_update){ ?> <a class="alert-link lookatme" href="https://github.com/                        pi-hole/pi-hole/releases">(Update available!)</a><?php } ?><br>
+                                    <b>Web Interface Version </b><?php
+                                    echo $web_current;
+                                    if(isset($web_commit)) { echo "<br>(".$web_branch.", ".$web_commit.")"; }
+                                    if($web_update){ ?> <a class="alert-link lookatme\" href="https://github.com/                        pi-hole/AdminLTE/releases">(Update available!)</a><?php } ?><br>
+                                    <b>FTL Version </b> <?php
+                                    echo $FTL_current;
+                                    if($FTL_update){ ?> <a class="alert-link lookatme" href="https://github.com/                        pi-hole/FTL/releases">(Update available!)</a><?php } ?><br><br>
                                 </div>
-                                <?php } ?>
-                                <?php if($web_update){ ?>
-                                <div id="alWebUpdate" class="alert alert-info alert-dismissible fade in" role="alert">
-                                    <a class="alert-link" href="https://github.com/pi-hole/AdminLTE/releases">There's an update available for this Web Interface!</a>
-                                </div>
-                                <?php } ?>
-                                <?php if($FTL_update){ ?>
-                                <div id="alFTLUpdate" class="alert alert-info alert-dismissible fade in" role="alert">
-                                    <a class="alert-link" href="https://github.com/pi-hole/AdminLTE/releases">There's an update available for this FTL!</a>
-                                </div>
-                                <?php } ?>
 
                                 <!-- PayPal -->
                                 <div>

--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -1,0 +1,118 @@
+<?php
+// Allow file_get_contents to read remote sources via URL
+ini_set("allow_url_fopen", 1);
+
+// Function that grabs latest tag from GitHub
+function get_github_version($url)
+{
+	// Have to fake the user agent to be able to query from Github's API
+	$context = stream_context_create(array("http" => array("user_agent" => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36")));
+
+	$json = file_get_contents($url, false, $context);
+	$result = json_decode($json);
+
+	return $result->tag_name;
+}
+
+/********** Get Pi-hole core branch / version / commit **********/
+// Check if on a dev branch
+$core_branch = exec("cd /etc/.pihole/ && git rev-parse --abbrev-ref HEAD");
+if($core_branch !== "master") {
+    $core_current = "vDev";
+    $core_commit = exec("cd /etc/.pihole/ && git describe --long --dirty --tags");
+}
+else {
+    $core_current = exec("cd /etc/.pihole/ && git describe --tags --abbrev=0");
+}
+
+/********** Get Pi-hole web branch / version / commit **********/
+$web_branch = exec("git rev-parse --abbrev-ref HEAD");
+if($web_branch !== "master") {
+    $web_current = "vDev";
+    $web_commit = exec("git describe --long --dirty --tags");
+}
+else {
+    $web_current = exec("git describe --tags --abbrev=0");
+}
+
+/********** Get Pi-hole FTL version (not a git repository) **********/
+$FTL_current = exec("pihole-FTL version");
+
+// can write only in the root web dir, i.e. /var/www/html
+$versionfile = "../versions";
+
+$check_version = false;
+
+// Check version if version buffer file does not exist
+if(is_readable($versionfile))
+{
+	// Obtain latest time stamp from buffer file
+	$versions = explode(",",file_get_contents($versionfile));
+	$date = date_create();
+	$timestamp = date_timestamp_get($date);
+
+	// Is last check for updates older than 30 minutes?
+	if($timestamp >= intval($versions[0]) + 1800)
+	{
+		// Yes: Retrieve new/updated version data
+		$check_version = true;
+	}
+	else
+	{
+		// No: We can use the buffered data
+		$check_version = false;
+	}
+}
+else
+{
+	// No buffer file or not readable: Request version data
+	$check_version = true;
+}
+
+// Get data from GitHub if requested
+if($check_version){
+	$core_latest = get_github_version("https://api.github.com/repos/pi-hole/pi-hole/releases/latest");
+	$web_latest = get_github_version("https://api.github.com/repos/pi-hole/AdminLTE/releases/latest");
+	$FTL_latest = get_github_version("https://api.github.com/repos/pi-hole/FTL/releases/latest");
+
+	// Save to buffer file
+	file_put_contents($versionfile, array($timestamp,",",$core_latest,",",$web_latest,",",$FTL_latest));
+}
+else
+{
+	// Use data from buffer file
+	$core_latest = $versions[1];
+	$web_latest = $versions[2];
+	$FTL_latest = $versions[3];
+}
+
+// Core version comparison
+if($core_current !== "vDev")
+{
+	// This logic allows the local core version to be newer than the upstream version
+	// The update indicator is only shown if the upstream version is NEWER
+	$core_update = (version_compare($core_current, $core_latest) < 0);
+}
+else
+{
+	$core_update = false;
+}
+
+// Web version comparison
+if($web_current !== "vDev")
+{
+	// This logic allows the local core version to be newer than the upstream version
+	// The update indicator is only shown if the upstream version is NEWER
+	$web_update = (version_compare($web_current, $web_latest) < 0);
+}
+else
+{
+	$web_update = false;
+}
+
+// FTL version comparison
+// This logic allows the local core version to be newer than the upstream version
+// The update indicator is only shown if the upstream version is NEWER
+$FTL_update = (version_compare($FTL_current, $FTL_latest) < 0);
+
+?>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Major overhaul of update checking on the dash board

Before this PR:
- Each browser refresh initiates a request to GitHub's API and queries the current version to compare it to the local version

With this PR:
- On the first page loading after you enabled this PR, the current versions are queried from GitHub and stored (along a time stamp of the request) in the file `/var/www/html/versions` (this is the only folder where `lighttpd` has unlimited write permissions by default). For the next 30 minutes, the upstream versions are queried from this file *instead* of reaching out to GitHub. If the version strings in the file are older than 30min, then PHP will query the data from GitHub's API and update the values in the `versions` file.
- If the file cannot be created/does not exist/is not writable, we fall back to the current behavior (query versions on every page load).

Note: This removes the update display dependence on Javascript *altogether*. Everything is now done server-side from PHP.

It also partially fixes #333 as it shows the versions/branches/update notifications in the dropdown menu.

Screenshot on PC (Vivaldi + Linux):
![da5f1247-681c-4807-9864-e85038720104](https://cloud.githubusercontent.com/assets/16748619/26754511/975d6cfa-487c-11e7-9315-62c2459a7319.png)

Screenshot an Android (Chrome Mobile):
![pi hole-admin-index php-login galaxy s5 2](https://cloud.githubusercontent.com/assets/16748619/26754528/c75b3d06-487c-11e7-9e6c-26477e83f242.png)


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
