### PR TITLE
Fix for escaped HTML characters in clients/domains names

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -262,7 +262,11 @@ function updateTopClientsChart() {
 
             if ({}.hasOwnProperty.call(data.top_sources, client)){
                 // Sanitize client
-                data.top_sources[escapeHtml(client)] = data.top_sources[client];
+                if(escapeHtml(client) !== client)
+                {
+                    // Make a copy with the escaped index
+                    data.top_sources[escapeHtml(client)] = data.top_sources[client];
+                }
                 client = escapeHtml(client);
                 if(client.indexOf("|") > -1)
                 {
@@ -308,6 +312,11 @@ function updateTopLists() {
         for (domain in data.top_queries) {
             if ({}.hasOwnProperty.call(data.top_queries,domain)){
                 // Sanitize domain
+                if(escapeHtml(domain) !== domain)
+                {
+                    // Make a copy with the escaped index
+                    data.top_queries[escapeHtml(domain)] = data.top_queries[domain];
+                }
                 domain = escapeHtml(domain);
                 url = "<a href=\"queries.php?domain="+domain+"\">"+domain+"</a>";
                 percentage = data.top_queries[domain] / data.dns_queries_today * 100;

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -264,7 +264,7 @@ function updateTopClientsChart() {
                 // Sanitize client
                 if(escapeHtml(client) !== client)
                 {
-                    // Make a copy with the escaped index
+                    // Make a copy with the escaped index if necessary
                     data.top_sources[escapeHtml(client)] = data.top_sources[client];
                 }
                 client = escapeHtml(client);
@@ -314,7 +314,7 @@ function updateTopLists() {
                 // Sanitize domain
                 if(escapeHtml(domain) !== domain)
                 {
-                    // Make a copy with the escaped index
+                    // Make a copy with the escaped index if necessary
                     data.top_queries[escapeHtml(domain)] = data.top_queries[domain];
                 }
                 domain = escapeHtml(domain);
@@ -337,7 +337,7 @@ function updateTopLists() {
                 // Sanitize domain
                 if(escapeHtml(domain) !== domain)
                 {
-                    // Make a copy with the escaped index
+                    // Make a copy with the escaped index if necessary
                     data.top_ads[escapeHtml(domain)] = data.top_ads[domain];
                 }
                 domain = escapeHtml(domain);

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -262,6 +262,7 @@ function updateTopClientsChart() {
 
             if ({}.hasOwnProperty.call(data.top_sources, client)){
                 // Sanitize client
+                data.top_sources[escapeHtml(client)] = data.top_sources[client];
                 client = escapeHtml(client);
                 if(client.indexOf("|") > -1)
                 {

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -335,6 +335,11 @@ function updateTopLists() {
         for (domain in data.top_ads) {
             if ({}.hasOwnProperty.call(data.top_ads,domain)){
                 // Sanitize domain
+                if(escapeHtml(domain) !== domain)
+                {
+                    // Make a copy with the escaped index
+                    data.top_ads[escapeHtml(domain)] = data.top_ads[domain];
+                }
                 domain = escapeHtml(domain);
                 url = "<a href=\"queries.php?domain="+domain+"\">"+domain+"</a>";
                 percentage = data.top_ads[domain] / data.ads_blocked_today * 100;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Fixes issue reported on [Discourse](https://discourse.pi-hole.net/t/added-ips-to-hosts/3509)

`/etc/hosts`:
```
127.0.0.1 localhost's_device
```

On branch `master` / `devel`:
![screenshot at 2017-06-04 13-37-02](https://cloud.githubusercontent.com/assets/16748619/26761182/110958b2-492b-11e7-829a-f273661f5858.png)

On this branch:
![screenshot at 2017-06-04 13-36-41](https://cloud.githubusercontent.com/assets/16748619/26761183/1736ee02-492b-11e7-8892-07734941376a.png)


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
