### PR TITLE
Don't update audit list after each click

### DIFF
--- a/scripts/pi-hole/js/auditlog.js
+++ b/scripts/pi-hole/js/auditlog.js
@@ -67,8 +67,8 @@ function updateTopLists() {
 
         $("#domain-frequency .overlay").hide();
         $("#ad-frequency .overlay").hide();
-        // Update top lists data every 10 seconds
-        setTimeout(updateTopLists, 10000);
+        // Update top lists data every second
+        setTimeout(updateTopLists, 1000);
     });
 }
 
@@ -78,10 +78,7 @@ function add(domain,list) {
     $.ajax({
         url: "scripts/pi-hole/php/add.php",
         method: "post",
-        data: {"domain":domain, "list":list, "token":token, "auditlog":1},
-        success: function(response) {
-            setTimeout(updateTopLists, 300);
-        }
+        data: {"domain":domain, "list":list, "token":token, "auditlog":1}
     });
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Don't update audit list after each click but in regular intervals (once per second). If a user audits domains very fast (like I did), he can launch up to 10 concurrent `FTL` threads to update the list. Although that works without any problems. It puts an unnecessary load on the Pi-hole device.

Solution: Instead of updating shortly after each click, we should update/regenerate the lists in a quite frequent interval (e.g. once per second). This will then already consider the submitted changes and results in a CPU load of around 10% on my Raspberry Pi 3 as long as the user is on the Audit Log page. Note that I have a quite large log (16.000 queries) so I think that is acceptable.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
