### PR TITLE
Re-add doughnut charts

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -164,7 +164,14 @@ if ((isset($_GET['topClients']) || isset($_GET['getQuerySources'])) && $auth)
 
 if (isset($_GET['getForwardDestinations']) && $auth)
 {
-	sendRequestFTL("forward-dest");
+	if($_GET['getForwardDestinations'] === "unsorted")
+	{
+		sendRequestFTL("forward-dest unsorted");
+	}
+	else
+	{
+		sendRequestFTL("forward-dest");
+	}
 	$return = getResponseFTL();
 	$forward_dest = array();
 	foreach($return as $line)

--- a/index.php
+++ b/index.php
@@ -90,9 +90,44 @@
   if($auth){ ?>
 <div class="row">
     <div class="col-md-12 col-lg-6">
+    <div class="box" id="query-types-pie">
+        <div class="box-header with-border">
+          <h3 class="box-title">Query Types (integrated)</h3>
+        </div>
+        <div class="box-body">
+          <div class="chart">
+            <canvas id="queryTypePieChart" width="400" height="150"></canvas>
+          </div>
+        </div>
+        <div class="overlay">
+          <i class="fa fa-refresh fa-spin"></i>
+        </div>
+        <!-- /.box-body -->
+      </div>
+    </div>
+    <div class="col-md-12 col-lg-6">
+    <div class="box" id="forward-destinations-pie">
+        <div class="box-header with-border">
+          <h3 class="box-title">Forward Destinations (integrated)</h3>
+        </div>
+        <div class="box-body">
+          <div class="chart">
+            <canvas id="forwardDestinationPieChart" width="400" height="150"></canvas>
+          </div>
+        </div>
+        <div class="overlay">
+          <i class="fa fa-refresh fa-spin"></i>
+        </div>
+        <!-- /.box-body -->
+      </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12 col-lg-6">
     <div class="box" id="query-types">
         <div class="box-header with-border">
-          <h3 class="box-title">Query Types over Time</h3>
+          <h3 class="box-title">Query Types (over time)</h3>
         </div>
         <div class="box-body">
           <div class="chart">
@@ -108,7 +143,7 @@
     <div class="col-md-12 col-lg-6">
     <div class="box" id="forward-destinations">
         <div class="box-header with-border">
-          <h3 class="box-title">Forward Destinations over Time</h3>
+          <h3 class="box-title">Forward Destinations (over time)</h3>
         </div>
         <div class="box-body">
           <div class="chart">

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -181,11 +181,8 @@ function updateQueryTypesPie() {
         queryTypePieChart.update();
         queryTypePieChart.chart.config.options.cutoutPercentage=50;
         queryTypePieChart.update();
-        // Don't use rotation animation for further updates
-        queryTypePieChart.options.animation.duration=0;
     }).done(function() {
         // Reload graph after minute
-        failures = 0;
         setTimeout(updateQueryTypesPie, 60000);
     });
 }
@@ -279,6 +276,12 @@ function updateForwardedOverTime() {
 
 function updateForwardDestinationsPie() {
     $.getJSON("api.php?getForwardDestinations", function(data) {
+
+        if("FTLnotrunning" in data)
+        {
+            return;
+        }
+
         var colors = [];
         // Get colors from AdminLTE
         $.each($.AdminLTE.options.colors, function(key, value) { colors.push(value); });
@@ -299,13 +302,12 @@ function updateForwardDestinationsPie() {
         forwardDestinationPieChart.data.labels = k;
         forwardDestinationPieChart.data.datasets[0] = dd;
         // and push it at once
-        $("#forward-destinations-pie .overlay").remove();
+        $("#forward-destinations-pie .overlay").hide();
         forwardDestinationPieChart.update();
         forwardDestinationPieChart.chart.config.options.cutoutPercentage=50;
         forwardDestinationPieChart.update();
     }).done(function() {
-        // Reload graph after minute
-        failures = 0;
+        // Reload graph after one minute
         setTimeout(updateForwardDestinationsPie, 60000);
     });
 }

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -262,7 +262,7 @@ function updateForwardedOverTime() {
         $("#forward-destinations .overlay").hide();
         forwardDestinationChart.update();
         // Don't use rotation animation for further updates
-        queryTypePieChart.options.animation.duration=0;
+        forwardDestinationChart.options.animation.duration=0;
     }).done(function() {
         // Reload graph after 10 minutes
         failures = 0;

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -6,6 +6,7 @@
 *  Please see LICENSE file for your rights under this license. */
 // Define global variables
 var timeLineChart, queryTypeChart, forwardDestinationChart;
+var forwardDestinationPieChart, forwardDestinationPieChart;
 
 function padNumber(num) {
     return ("00" + num).substr(-2,2);
@@ -145,6 +146,49 @@ function updateQueryTypesOverTime() {
         }
     });
 }
+function updateQueryTypesPie() {
+    $.getJSON("api.php?getQueryTypes", function(data) {
+
+        if("FTLnotrunning" in data)
+        {
+            return;
+        }
+
+        var colors = [];
+        // Get colors from AdminLTE
+        $.each($.AdminLTE.options.colors, function(key, value) { colors.push(value); });
+        var v = [], c = [], k = [], iter;
+        // Collect values and colors, and labels
+        if(data.hasOwnProperty("querytypes"))
+        {
+            iter = data.querytypes;
+        }
+        else
+        {
+            iter = data;
+        }
+        $.each(iter, function(key , value) {
+            v.push(value);
+            c.push(colors.shift());
+            k.push(key);
+        });
+        // Build a single dataset with the data to be pushed
+        var dd = {data: v, backgroundColor: c};
+        // and push it at once
+        queryTypePieChart.data.datasets[0] = dd;
+        queryTypePieChart.data.labels = k;
+        $("#query-types-pie .overlay").hide();
+        queryTypePieChart.update();
+        queryTypePieChart.chart.config.options.cutoutPercentage=50;
+        queryTypePieChart.update();
+        // Don't use rotation animation for further updates
+        queryTypePieChart.options.animation.duration=0;
+    }).done(function() {
+        // Reload graph after minute
+        failures = 0;
+        setTimeout(updateQueryTypesPie, 60000);
+    });
+}
 
 function updateForwardedOverTime() {
     $.getJSON("api.php?overTimeDataForwards&getForwardDestinationNames", function(data) {
@@ -230,6 +274,39 @@ function updateForwardedOverTime() {
             // than five times in a row
             setTimeout(updateForwardedOverTime, 60000);
         }
+    });
+}
+
+function updateForwardDestinationsPie() {
+    $.getJSON("api.php?getForwardDestinations", function(data) {
+        var colors = [];
+        // Get colors from AdminLTE
+        $.each($.AdminLTE.options.colors, function(key, value) { colors.push(value); });
+        var v = [], c = [], k = [];
+        // Collect values and colors, immediately push individual labels
+        $.each(data.forward_destinations, function(key , value) {
+            v.push(value);
+            c.push(colors.shift());
+            if(key.indexOf("|") > -1)
+            {
+                key = key.substr(0, key.indexOf("|"));
+            }
+            k.push(key);
+        });
+        // Build a single dataset with the data to be pushed
+        var dd = {data: v, backgroundColor: c};
+        // and push it at once
+        forwardDestinationPieChart.data.labels = k;
+        forwardDestinationPieChart.data.datasets[0] = dd;
+        // and push it at once
+        $("#forward-destinations-pie .overlay").remove();
+        forwardDestinationPieChart.update();
+        forwardDestinationPieChart.chart.config.options.cutoutPercentage=50;
+        forwardDestinationPieChart.update();
+    }).done(function() {
+        // Reload graph after minute
+        failures = 0;
+        setTimeout(updateForwardDestinationsPie, 60000);
     });
 }
 
@@ -437,59 +514,130 @@ function updateSummaryData(runOnce) {
 
 $(document).ready(function() {
 
-        var isMobile = {
-            Windows: function() {
-                return /IEMobile/i.test(navigator.userAgent);
-            },
-            Android: function() {
-                return /Android/i.test(navigator.userAgent);
-            },
-            BlackBerry: function() {
-                return /BlackBerry/i.test(navigator.userAgent);
-            },
-            iOS: function() {
-                return /iPhone|iPad|iPod/i.test(navigator.userAgent);
-            },
-            any: function() {
-                return (isMobile.Android() || isMobile.BlackBerry() || isMobile.iOS() || isMobile.Windows());
-            }
-        };
+    var isMobile = {
+        Windows: function() {
+            return /IEMobile/i.test(navigator.userAgent);
+        },
+        Android: function() {
+            return /Android/i.test(navigator.userAgent);
+        },
+        BlackBerry: function() {
+            return /BlackBerry/i.test(navigator.userAgent);
+        },
+        iOS: function() {
+            return /iPhone|iPad|iPod/i.test(navigator.userAgent);
+        },
+        any: function() {
+            return (isMobile.Android() || isMobile.BlackBerry() || isMobile.iOS() || isMobile.Windows());
+        }
+    };
 
-        // Pull in data via AJAX
+    // Pull in data via AJAX
 
-        updateSummaryData();
+    updateSummaryData();
 
-        var ctx = document.getElementById("queryOverTimeChart").getContext("2d");
-        timeLineChart = new Chart(ctx, {
+    var ctx = document.getElementById("queryOverTimeChart").getContext("2d");
+    timeLineChart = new Chart(ctx, {
+        type: "line",
+        data: {
+            labels: [],
+            datasets: [
+                {
+                    label: "Total DNS Queries",
+                    fill: true,
+                    backgroundColor: "rgba(220,220,220,0.5)",
+                    borderColor: "rgba(0, 166, 90,.8)",
+                    pointBorderColor: "rgba(0, 166, 90,.8)",
+                    pointRadius: 1,
+                    pointHoverRadius: 5,
+                    data: [],
+                    pointHitRadius: 5,
+                    cubicInterpolationMode: "monotone"
+                },
+                {
+                    label: "Blocked DNS Queries",
+                    fill: true,
+                    backgroundColor: "rgba(0,192,239,0.5)",
+                    borderColor: "rgba(0,192,239,1)",
+                    pointBorderColor: "rgba(0,192,239,1)",
+                    pointRadius: 1,
+                    pointHoverRadius: 5,
+                    data: [],
+                    pointHitRadius: 5,
+                    cubicInterpolationMode: "monotone"
+                }
+            ]
+        },
+        options: {
+            tooltips: {
+                enabled: true,
+                mode: "x-axis",
+                callbacks: {
+                    title: function(tooltipItem, data) {
+                        var label = tooltipItem[0].xLabel;
+                        var time = label.match(/(\d?\d):?(\d?\d?)/);
+                        var h = parseInt(time[1], 10);
+                        var m = parseInt(time[2], 10) || 0;
+                        var from = padNumber(h)+":"+padNumber(m-5)+":00";
+                        var to = padNumber(h)+":"+padNumber(m+4)+":59";
+                        return "Queries from "+from+" to "+to;
+                    },
+                    label: function(tooltipItems, data) {
+                        if(tooltipItems.datasetIndex === 1)
+                        {
+                            var percentage = 0.0;
+                            var total = parseInt(data.datasets[0].data[tooltipItems.index]);
+                            var blocked = parseInt(data.datasets[1].data[tooltipItems.index]);
+                            if(total > 0)
+                            {
+                                percentage = 100.0*blocked/total;
+                            }
+                            return data.datasets[tooltipItems.datasetIndex].label + ": " + tooltipItems.yLabel + " (" + percentage.toFixed(1) + "%)";
+                        }
+                        else
+                        {
+                            return data.datasets[tooltipItems.datasetIndex].label + ": " + tooltipItems.yLabel;
+                        }
+                    }
+                }
+            },
+            legend: {
+                display: false
+            },
+            scales: {
+                xAxes: [{
+                    type: "time",
+                    time: {
+                        unit: "hour",
+                        displayFormats: {
+                            hour: "HH:mm"
+                        },
+                        tooltipFormat: "HH:mm"
+                    }
+                }],
+                yAxes: [{
+                    ticks: {
+                        beginAtZero: true
+                    }
+                }]
+            },
+            maintainAspectRatio: false
+        }
+    });
+
+    // Pull in data via AJAX
+
+    updateQueriesOverTime();
+
+    // Create / load "Forward Destinations over Time" only if authorized
+    if(document.getElementById("forwardDestinationChart"))
+    {
+        ctx = document.getElementById("forwardDestinationChart").getContext("2d");
+        forwardDestinationChart = new Chart(ctx, {
             type: "line",
             data: {
                 labels: [],
-                datasets: [
-                    {
-                        label: "Total DNS Queries",
-                        fill: true,
-                        backgroundColor: "rgba(220,220,220,0.5)",
-                        borderColor: "rgba(0, 166, 90,.8)",
-                        pointBorderColor: "rgba(0, 166, 90,.8)",
-                        pointRadius: 1,
-                        pointHoverRadius: 5,
-                        data: [],
-                        pointHitRadius: 5,
-                        cubicInterpolationMode: "monotone"
-                    },
-                    {
-                        label: "Blocked DNS Queries",
-                        fill: true,
-                        backgroundColor: "rgba(0,192,239,0.5)",
-                        borderColor: "rgba(0,192,239,1)",
-                        pointBorderColor: "rgba(0,192,239,1)",
-                        pointRadius: 1,
-                        pointHoverRadius: 5,
-                        data: [],
-                        pointHitRadius: 5,
-                        cubicInterpolationMode: "monotone"
-                    }
-                ]
+                datasets: [{ data: [] }]
             },
             options: {
                 tooltips: {
@@ -503,24 +651,10 @@ $(document).ready(function() {
                             var m = parseInt(time[2], 10) || 0;
                             var from = padNumber(h)+":"+padNumber(m-5)+":00";
                             var to = padNumber(h)+":"+padNumber(m+4)+":59";
-                            return "Queries from "+from+" to "+to;
+                            return "Forward destinations from "+from+" to "+to;
                         },
                         label: function(tooltipItems, data) {
-                            if(tooltipItems.datasetIndex === 1)
-                            {
-                                var percentage = 0.0;
-                                var total = parseInt(data.datasets[0].data[tooltipItems.index]);
-                                var blocked = parseInt(data.datasets[1].data[tooltipItems.index]);
-                                if(total > 0)
-                                {
-                                    percentage = 100.0*blocked/total;
-                                }
-                                return data.datasets[tooltipItems.datasetIndex].label + ": " + tooltipItems.yLabel + " (" + percentage.toFixed(1) + "%)";
-                            }
-                            else
-                            {
-                                return data.datasets[tooltipItems.datasetIndex].label + ": " + tooltipItems.yLabel;
-                            }
+                            return data.datasets[tooltipItems.datasetIndex].label + ": " + (100.0*tooltipItems.yLabel).toFixed(1) + "%";
                         }
                     }
                 },
@@ -540,187 +674,180 @@ $(document).ready(function() {
                     }],
                     yAxes: [{
                         ticks: {
-                            beginAtZero: true
-                        }
+                            mix: 0.0,
+                            max: 1.0,
+                            beginAtZero: true,
+                            callback: function(value, index, values) {
+                                return Math.round(value*100) + " %";
+                            }
+                        },
+                        stacked: true
                     }]
                 },
-                maintainAspectRatio: false
+                maintainAspectRatio: true
             }
         });
 
         // Pull in data via AJAX
+        updateForwardedOverTime();
+    }
 
-        updateQueriesOverTime();
-
-        // Create / load "Forward Destinations over Time" only if authorized
-        if(document.getElementById("forwardDestinationChart"))
-        {
-            ctx = document.getElementById("forwardDestinationChart").getContext("2d");
-            forwardDestinationChart = new Chart(ctx, {
-                type: "line",
-                data: {
-                    labels: [],
-                    datasets: [{ data: [] }]
-                },
-                options: {
-                    tooltips: {
-                        enabled: true,
-                        mode: "x-axis",
-                        callbacks: {
-                            title: function(tooltipItem, data) {
-                                var label = tooltipItem[0].xLabel;
-                                var time = label.match(/(\d?\d):?(\d?\d?)/);
-                                var h = parseInt(time[1], 10);
-                                var m = parseInt(time[2], 10) || 0;
-                                var from = padNumber(h)+":"+padNumber(m-5)+":00";
-                                var to = padNumber(h)+":"+padNumber(m+4)+":59";
-                                return "Forward destinations from "+from+" to "+to;
-                            },
-                            label: function(tooltipItems, data) {
-                                return data.datasets[tooltipItems.datasetIndex].label + ": " + (100.0*tooltipItems.yLabel).toFixed(1) + "%";
-                            }
-                        }
+    // Create / load "Query Types over Time" only if authorized
+    if(document.getElementById("queryTypeChart"))
+    {
+        ctx = document.getElementById("queryTypeChart").getContext("2d");
+        queryTypeChart = new Chart(ctx, {
+            type: "line",
+            data: {
+                labels: [],
+                datasets: [
+                    {
+                        label: "A: IPv4 queries",
+                        pointRadius: 0,
+                        pointHitRadius: 5,
+                        pointHoverRadius: 5,
+                        data: []
                     },
-                    legend: {
-                        display: false
-                    },
-                    scales: {
-                        xAxes: [{
-                            type: "time",
-                            time: {
-                                unit: "hour",
-                                displayFormats: {
-                                    hour: "HH:mm"
-                                },
-                                tooltipFormat: "HH:mm"
-                            }
-                        }],
-                        yAxes: [{
-                            ticks: {
-                                mix: 0.0,
-                                max: 1.0,
-                                beginAtZero: true,
-                                callback: function(value, index, values) {
-                                    return Math.round(value*100) + " %";
-                                }
-                            },
-                            stacked: true
-                        }]
-                    },
-                    maintainAspectRatio: true
-                }
-            });
-
-            // Pull in data via AJAX
-            updateForwardedOverTime();
-        }
-
-        // Create / load "Query Types over Time" only if authorized
-        if(document.getElementById("queryTypeChart"))
-        {
-            ctx = document.getElementById("queryTypeChart").getContext("2d");
-            queryTypeChart = new Chart(ctx, {
-                type: "line",
-                data: {
-                    labels: [],
-                    datasets: [
-                        {
-                            label: "A: IPv4 queries",
-                            pointRadius: 0,
-                            pointHitRadius: 5,
-                            pointHoverRadius: 5,
-                            data: []
+                    {
+                        label: "AAAA: IPv6 queries",
+                        pointRadius: 0,
+                        pointHitRadius: 5,
+                        pointHoverRadius: 5,
+                        data: []
+                    }
+                ]
+            },
+            options: {
+                tooltips: {
+                    enabled: true,
+                    mode: "x-axis",
+                    callbacks: {
+                        title: function(tooltipItem, data) {
+                            var label = tooltipItem[0].xLabel;
+                            var time = label.match(/(\d?\d):?(\d?\d?)/);
+                            var h = parseInt(time[1], 10);
+                            var m = parseInt(time[2], 10) || 0;
+                            var from = padNumber(h)+":"+padNumber(m-5)+":00";
+                            var to = padNumber(h)+":"+padNumber(m+4)+":59";
+                            return "Query types from "+from+" to "+to;
                         },
-                        {
-                            label: "AAAA: IPv6 queries",
-                            pointRadius: 0,
-                            pointHitRadius: 5,
-                            pointHoverRadius: 5,
-                            data: []
+                        label: function(tooltipItems, data) {
+                            return data.datasets[tooltipItems.datasetIndex].label + ": " + (100.0*tooltipItems.yLabel).toFixed(1) + "%";
                         }
-                    ]
+                    }
                 },
-                options: {
-                    tooltips: {
-                        enabled: true,
-                        mode: "x-axis",
-                        callbacks: {
-                            title: function(tooltipItem, data) {
-                                var label = tooltipItem[0].xLabel;
-                                var time = label.match(/(\d?\d):?(\d?\d?)/);
-                                var h = parseInt(time[1], 10);
-                                var m = parseInt(time[2], 10) || 0;
-                                var from = padNumber(h)+":"+padNumber(m-5)+":00";
-                                var to = padNumber(h)+":"+padNumber(m+4)+":59";
-                                return "Query types from "+from+" to "+to;
+                legend: {
+                    display: false
+                },
+                scales: {
+                    xAxes: [{
+                        type: "time",
+                        time: {
+                            unit: "hour",
+                            displayFormats: {
+                                hour: "HH:mm"
                             },
-                            label: function(tooltipItems, data) {
-                                return data.datasets[tooltipItems.datasetIndex].label + ": " + (100.0*tooltipItems.yLabel).toFixed(1) + "%";
-                            }
+                            tooltipFormat: "HH:mm"
                         }
-                    },
-                    legend: {
-                        display: false
-                    },
-                    scales: {
-                        xAxes: [{
-                            type: "time",
-                            time: {
-                                unit: "hour",
-                                displayFormats: {
-                                    hour: "HH:mm"
-                                },
-                                tooltipFormat: "HH:mm"
+                    }],
+                    yAxes: [{
+                        ticks: {
+                            mix: 0.0,
+                            max: 1.0,
+                            beginAtZero: true,
+                            callback: function(value, index, values) {
+                                return Math.round(value*100) + " %";
                             }
-                        }],
-                        yAxes: [{
-                            ticks: {
-                                mix: 0.0,
-                                max: 1.0,
-                                beginAtZero: true,
-                                callback: function(value, index, values) {
-                                    return Math.round(value*100) + " %";
-                                }
-                            },
-                            stacked: true
-                        }]
-                    },
-                    maintainAspectRatio: true
-                }
-            });
-
-            // Pull in data via AJAX
-            updateQueryTypesOverTime();
-        }
-
-        // Create / load "Top Domains" and "Top Advertisers" only if authorized
-        if(document.getElementById("domain-frequency")
-            && document.getElementById("ad-frequency"))
-        {
-            updateTopLists();
-        }
-
-        // Create / load "Top Clients" only if authorized
-        if(document.getElementById("client-frequency"))
-        {
-            updateTopClientsChart();
-        }
-
-        $("#queryOverTimeChart").click(function(evt){
-            var activePoints = timeLineChart.getElementAtEvent(evt);
-            if(activePoints.length > 0)
-            {
-                //get the internal index of slice in pie chart
-                var clickedElementindex = activePoints[0]["_index"];
-
-                //get specific label by index
-                var label = timeLineChart.data.labels[clickedElementindex];
-
-                //get value by index
-                var from = label/1000 - 300;
-                var until = label/1000 + 300;
-                window.location.href = "queries.php?from="+from+"&until="+until;
+                        },
+                        stacked: true
+                    }]
+                },
+                maintainAspectRatio: true
             }
-            return false;
         });
+
+        // Pull in data via AJAX
+        updateQueryTypesOverTime();
+    }
+
+    // Create / load "Top Domains" and "Top Advertisers" only if authorized
+    if(document.getElementById("domain-frequency")
+        && document.getElementById("ad-frequency"))
+    {
+        updateTopLists();
+    }
+
+    // Create / load "Top Clients" only if authorized
+    if(document.getElementById("client-frequency"))
+    {
+        updateTopClientsChart();
+    }
+
+    $("#queryOverTimeChart").click(function(evt){
+        var activePoints = timeLineChart.getElementAtEvent(evt);
+        if(activePoints.length > 0)
+        {
+            //get the internal index of slice in pie chart
+            var clickedElementindex = activePoints[0]["_index"];
+
+            //get specific label by index
+            var label = timeLineChart.data.labels[clickedElementindex];
+
+            //get value by index
+            var from = label/1000 - 300;
+            var until = label/1000 + 300;
+            window.location.href = "queries.php?from="+from+"&until="+until;
+        }
+        return false;
     });
+
+    if(document.getElementById("queryTypePieChart"))
+    {
+        ctx = document.getElementById("queryTypePieChart").getContext("2d");
+        queryTypePieChart = new Chart(ctx, {
+            type: "doughnut",
+            data: {
+                labels: [],
+                datasets: [{ data: [] }]
+            },
+            options: {
+                legend: {
+                    display: true,
+                    position: "right"
+                },
+                animation: {
+                    duration: 2000
+                },
+                cutoutPercentage: 0
+            }
+        });
+
+        // Pull in data via AJAX
+        updateQueryTypesPie();
+    }
+
+    if(document.getElementById("forwardDestinationPieChart"))
+    {
+        ctx = document.getElementById("forwardDestinationPieChart").getContext("2d");
+        forwardDestinationPieChart = new Chart(ctx, {
+            type: "doughnut",
+            data: {
+                labels: [],
+                datasets: [{ data: [] }]
+            },
+            options: {
+                legend: {
+                    display: true,
+                    position: "right"
+                },
+                animation: {
+                    duration: 2000
+                },
+                cutoutPercentage: 0
+            }
+        });
+
+        // Pull in data via AJAX
+        updateForwardDestinationsPie();
+    }
+});

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -279,7 +279,7 @@ function updateForwardedOverTime() {
 }
 
 function updateForwardDestinationsPie() {
-    $.getJSON("api.php?getForwardDestinations", function(data) {
+    $.getJSON("api.php?getForwardDestinations=unsorted", function(data) {
 
         if("FTLnotrunning" in data)
         {

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -181,6 +181,8 @@ function updateQueryTypesPie() {
         queryTypePieChart.update();
         queryTypePieChart.chart.config.options.cutoutPercentage=50;
         queryTypePieChart.update();
+        // Don't use rotation animation for further updates
+        queryTypePieChart.options.animation.duration=0;
     }).done(function() {
         // Reload graph after minute
         setTimeout(updateQueryTypesPie, 60000);
@@ -259,6 +261,8 @@ function updateForwardedOverTime() {
         }
         $("#forward-destinations .overlay").hide();
         forwardDestinationChart.update();
+        // Don't use rotation animation for further updates
+        queryTypePieChart.options.animation.duration=0;
     }).done(function() {
         // Reload graph after 10 minutes
         failures = 0;

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -262,8 +262,6 @@ function updateForwardedOverTime() {
         }
         $("#forward-destinations .overlay").hide();
         forwardDestinationChart.update();
-        // Don't use rotation animation for further updates
-        forwardDestinationChart.options.animation.duration=0;
     }).done(function() {
         // Reload graph after 10 minutes
         failures = 0;
@@ -311,6 +309,8 @@ function updateForwardDestinationsPie() {
         forwardDestinationPieChart.update();
         forwardDestinationPieChart.chart.config.options.cutoutPercentage=50;
         forwardDestinationPieChart.update();
+        // Don't use rotation animation for further updates
+        forwardDestinationPieChart.options.animation.duration=0;
     }).done(function() {
         // Reload graph after one minute
         setTimeout(updateForwardDestinationsPie, 60000);

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -5,8 +5,9 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 // Define global variables
+/* global Chart */
 var timeLineChart, queryTypeChart, forwardDestinationChart;
-var forwardDestinationPieChart, forwardDestinationPieChart;
+var queryTypePieChart, forwardDestinationPieChart;
 
 function padNumber(num) {
     return ("00" + num).substr(-2,2);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

This has often been asked for (see e.g. [here](https://discourse.pi-hole.net/t/option-to-choose-between-timeline-graps-and-pie-charts/3685)), so we re-implement the time-integrated dognought charts for both Query Types and Forward Destinations.

![97bf3695-d12e-4342-aa4c-42d21fe36336](https://user-images.githubusercontent.com/16748619/27984962-f49e4c78-63e2-11e7-9f26-65ab672bab36.png)

Note that the colors in the forward destination graph dognought graph and the over time graph do not match. This, however, is caused by the sorting of the results and will be changed in the `FTL` engine, itself.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
