### PR TITLE
list.php: wrong path to footer.php if invalid list parameter is used

### DIFF
--- a/list.php
+++ b/list.php
@@ -11,7 +11,7 @@ $list = $_GET['l'];
 
 if($list !== "white" && $list !== "black"){
     echo "Invalid list parameter";
-    require "footer.php";
+    require "scripts/pi-hole/php/footer.php";
     die();
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_5_

---
<pre>if($list !== "white" && $list !== "black"){
    echo "Invalid list parameter";
    require "<b>scripts/pi-hole/php/</b>footer.php";
    die();
}</pre>

Fix path to `footer.php` if an invalid list parameter is used

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
