### PR TITLE
Move update checker from header into footer

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -39,6 +39,14 @@
             </div>
         </div>
     </div>
+<?php
+  // Flushes the system write buffers of PHP. This attempts to push everything we have so far all the way to the client's browser.
+  flush();
+  // Run update checker
+  //  - determines local branch each time,
+  //  - determines local and remote version every 30 minutes
+  require "scripts/pi-hole/php/update_checker.php";
+?>
     <!-- /.content-wrapper -->
     <footer class="main-footer">
 	<!-- Version Infos -->

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -9,7 +9,6 @@
 <?php
     require "scripts/pi-hole/php/auth.php";
     require "scripts/pi-hole/php/password.php";
-    require "scripts/pi-hole/php/update_checker.php";
 
     check_cors();
 

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -267,6 +267,7 @@ if($auth) {
                             <!-- Menu Footer -->
                             <li class="user-footer">
                                 <!-- Version Infos -->
+                                <?php /*
                                 <div class="<?php if(!isset($core_commit) && !isset($web_commit)) { ?>hidden-md <?php } ?>hidden-lg">
                                     <b>Pi-hole Version </b> <?php
                                     echo $core_current;
@@ -280,6 +281,7 @@ if($auth) {
                                     echo $FTL_current;
                                     if($FTL_update){ ?> <a class="alert-link lookatme btn-link" href="https://github.com/pi-hole/FTL/releases" target="_blank" style="background:none">(Update available!)</a><?php } ?><br><br>
                                 </div>
+                                */ ?>
                                 <!-- PayPal -->
                                 <div class="text-center">
                                     <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=3J2L3Z4DHW9UY" target="_blank" style="background:none">


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Removes any delays for me - the page loads and the footer is added in once the versions have been obtained. I tested with with an extra `sleep(10);` in `update_checker.php`.

Note that this change breaks the version displays in the dropdown menu (top right) as the version isn't available in the header anymore. This seems a fair compromise as the loading times of the dashboard are notably reduced on my Raspberry Pi B+ testing device.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
