### PR TITLE
Fix undefined variable $timestamp

### DIFF
--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -42,14 +42,14 @@ $FTL_current = exec("pihole-FTL version");
 $versionfile = "../versions";
 
 $check_version = false;
+$date = date_create();
+$timestamp = date_timestamp_get($date);
 
 // Check version if version buffer file does not exist
 if(is_readable($versionfile))
 {
 	// Obtain latest time stamp from buffer file
 	$versions = explode(",",file_get_contents($versionfile));
-	$date = date_create();
-	$timestamp = date_timestamp_get($date);
 
 	// Is last check for updates older than 30 minutes?
 	if($timestamp >= intval($versions[0]) + 1800)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
10

---

`master` error log snippet:
```
FastCGI-stderr: PHP Notice:  Undefined variable: timestamp in /var/www/html/admin/scripts/pi-hole/php/update_checker.php on line 79
```

`$timestamp` is only created if there's already a version file, so this error happens the first time it checks for the versions. I've seen it on a few error logs, often near the top of the lighttpd error log.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
