### PR TITLE
Elegantize 'Disable Custom time' modal

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -11,17 +11,16 @@
     </div>
     <!-- Modal for custom disable time -->
     <div class="modal fade" id="customDisableModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-        <div class="modal-dialog" role="document">
+        <div class="modal-dialog modal-sm" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title" id="myModalLabel">Custom disable timeout</h4>
                 </div>
                 <div class="modal-body">
-                    <div class="row">
-                        <div class="col-sm-3"><input id="customTimeout" class="form-control" type="number" value="60"></div>
-                        <div class="col-sm-9">
-                            <div class="btn-group" data-toggle="buttons">
+                    <div class="input-group">
+                        <input id="customTimeout" class="form-control" type="number" value="60">
+                            <div class="input-group-btn" data-toggle="buttons">
                                 <label class="btn btn-default">
                                     <input type="radio"/> Secs
                                 </label>
@@ -29,7 +28,6 @@
                                     <input type="radio"  /> Mins
                                 </label>
                             </div>
-                        </div>
                     </div>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_5_

---
Elegantize the _Custom disable timeout_ modal and make it smarter on small screens.

Here are two screenshots for direct comparing.
On each first the old styled modal is shown, and below the new style.

<img alt="lg" src="https://user-images.githubusercontent.com/28313514/29753331-9343ed3e-8b6f-11e7-809b-2e85dd07a77d.png" width="80%">
<img alt="xs" src="https://user-images.githubusercontent.com/28313514/29753333-984f0c3c-8b6f-11e7-80e3-b1bde141b580.png" width="30%">



_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._