### PR TITLE
Decrease doughnut animation time on first load

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -830,7 +830,7 @@ $(document).ready(function() {
                     }
                 },
                 animation: {
-                    duration: 2000
+                    duration: 750
                 },
                 cutoutPercentage: 0
             }
@@ -868,7 +868,7 @@ $(document).ready(function() {
                     }
                 },
                 animation: {
-                    duration: 2000
+                    duration: 750
                 },
                 cutoutPercentage: 0
             }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

3

---

Decrease first-load animation of the dashboard doughnuts to feel faster fluid, without making it feel like it's so fast that it wasn't worth having at all.

The gifs don't do it much justice, but I've made some up anyway -

Old:
![oldload](https://user-images.githubusercontent.com/3049142/31017446-d2757110-a56b-11e7-9431-3bde66877d62.gif)

New:
![newload](https://user-images.githubusercontent.com/3049142/31017447-d27a6850-a56b-11e7-90ee-a5426d430ce5.gif)
