### PR TITLE
Allow "domains_being_blocked" and "status" to contains non-numeric values

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -32,7 +32,7 @@ if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET))
 	{
 		$tmp = explode(" ",$line);
 
-		if($tmp[0] === "domains_being_blocked" || $tmp[0] === "status")
+		if(($tmp[0] === "domains_being_blocked" && !is_numeric($tmp[1])) || $tmp[0] === "status")
 		{
 			$stats[$tmp[0]] = $tmp[1];
 			continue;

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -32,6 +32,12 @@ if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET))
 	{
 		$tmp = explode(" ",$line);
 
+		if($tmp[0] === "domains_being_blocked" || $tmp[0] === "status")
+		{
+			$stats[$tmp[0]] = $tmp[1];
+			continue;
+		}
+
 		if(isset($_GET['summary']))
 		{
 			if($tmp[0] !== "ads_percentage_today")


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

See title. Needed to allow the improvements of https://github.com/pi-hole/FTL/pull/143 to propagate through the `PHP` API.

Before (Blocking disabled):
<pre>
http://pi.hole/admin/api.php
{
  "domains_being_blocked":<b>0</b>,
  "dns_queries_today":14034,
  "ads_blocked_today":377,
  "ads_percentage_today":2.686333,
  "unique_domains":654,
  "queries_forwarded":5088,
  "queries_cached":8569,
  "clients_ever_seen":7,
  "unique_clients":7,
  "status":<b>0</b>
}
</pre>

After (Blocking disabled):
<pre>
http://pi.hole/admin/api.php
{
  "domains_being_blocked":<b>N/A</b>,
  "dns_queries_today":14034,
  "ads_blocked_today":377,
  "ads_percentage_today":2.686333,
  "unique_domains":654,
  "queries_forwarded":5088,
  "queries_cached":8569,
  "clients_ever_seen":7,
  "unique_clients":7,
  "status":<b>"disabled"</b>
}
</pre>


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
