### PR TITLE
Remove GitHub link in footer

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -61,7 +61,7 @@
             echo $FTL_current;
             if($FTL_update){ ?> <a class="alert-link lookatme" href="https://github.com/pi-hole/FTL/releases" target="_blank">(Update available!)</a><?php } ?>
         </div>
-        <div style="display: inline-block"><strong><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=3J2L3Z4DHW9UY" target="_blank"><i class="fa fa-paypal"></i> Donate</a></strong> if you found this useful.</div>
+        <div style="display: inline-block"><strong><a href="https://pi-hole.net/donate" target="_blank"><i class="fa fa-heart"></i> Donate</a></strong> if you found this useful.</div>
     </footer>
 </div>
 <!-- ./wrapper -->

--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -61,7 +61,7 @@
             echo $FTL_current;
             if($FTL_update){ ?> <a class="alert-link lookatme" href="https://github.com/pi-hole/FTL/releases" target="_blank">(Update available!)</a><?php } ?>
         </div>
-        <div style="display: inline-block"><a href="https://github.com/pi-hole" target="_blank"><i class="fa fa-github"></i></a> <strong><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=3J2L3Z4DHW9UY" target="_blank">Donate</a></strong> if you found this useful.</div>
+        <div style="display: inline-block"><strong><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=3J2L3Z4DHW9UY" target="_blank"><i class="fa fa-paypal"></i> Donate</a></strong> if you found this useful.</div>
     </footer>
 </div>
 <!-- ./wrapper -->


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

4

---
With the top image, it is not clear that the GitHub icon is one link, and that the PayPal text is another link.

![change](https://user-images.githubusercontent.com/3049142/31307946-32b44abc-abb9-11e7-9347-510fbd21c2b2.png)

This change removes the GitHub link, and replaces the logo with PayPal to ensure users don't get confused by a misclick.