### PR TITLE
Fix whitelisting when no password is set

### DIFF
--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -131,7 +131,7 @@ function check_domain() {
 }
 
 function list_verify($type) {
-    global $pwhash, $wrongpassword;
+    global $pwhash, $wrongpassword, $auth;
     if(!isset($_POST['domain']) || !isset($_POST['list']) || !(isset($_POST['pw']) || isset($_POST['token']))) {
         log_and_die("Missing POST variables");
     }

--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -144,11 +144,7 @@ function list_verify($type) {
     elseif(isset($_POST['pw']))
     {
         require("password.php");
-        if(strlen($pwhash) == 0)
-        {
-            log_and_die("No password set - ".htmlspecialchars($type)."listing without password not supported");
-        }
-        elseif($wrongpassword)
+        if($wrongpassword || !$auth)
         {
             log_and_die("Wrong password - ".htmlspecialchars($type)."listing of ${_POST['domain']} not permitted");
         }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Previously the only way to whitelist when no password was set was through the web interface because it used CSRF tokens. This PR will open up the lists to possibly unauthorized access because it doesn't require the CSRF token, but in that case the Pi-hole really should be protected by a password.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
