### PR TITLE
Check for updates every two days

### DIFF
--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -51,8 +51,8 @@ if(is_readable($versionfile))
 	// Obtain latest time stamp from buffer file
 	$versions = explode(",",file_get_contents($versionfile));
 
-	// Is last check for updates older than 30 minutes?
-	if($timestamp >= intval($versions[0]) + 1800)
+	// Is last check for updates older than 48 hours?
+	if($timestamp >= intval($versions[0]) + 172800)
 	{
 		// Yes: Retrieve new/updated version data
 		$check_version = true;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

4

---
When first loading the Web Interface, it often takes me up to four whole seconds before the progress bar starts to move - once it's finished, loading new pages is blazingly fast. I've previously determined that this is due to `update_checker.php` which IMHO, checks *way* too frequently.

Since we can't easily make this check asyncronous (and that we don't release updates that frequently), I think it's fair to ensure this value is at a minimum of 48 hours.