### PR TITLE
Switch location of 'Restart dnsmasq' and 'Disable query logging'

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -1154,10 +1154,6 @@ if (isset($setupVars["API_PRIVACY_MODE"])) {
                                 <div class="box-body">
                                     <div class="row">
                                         <div class="col-md-4">
-                                            <button type="button" class="btn btn-warning confirm-restartdns form-control">Restart dnsmasq</button>
-                                        </div>
-                                        <p class="hidden-md hidden-lg"></p>
-                                        <div class="col-md-4 col-md-offset-4">
                                             <?php if ($piHoleLogging) { ?>
                                                 <button type="button" class="btn btn-warning confirm-disablelogging form-control">Disable query logging</button>
                                             <?php } else { ?>
@@ -1168,6 +1164,10 @@ if (isset($setupVars["API_PRIVACY_MODE"])) {
                                                     <button type="submit" class="btn btn-success form-control">Enable query logging</button>
                                                 </form>
                                             <?php } ?>
+                                        </div>
+                                        <p class="hidden-md hidden-lg"></p>
+                                        <div class="col-md-4 col-md-offset-4">
+                                            <button type="button" class="btn btn-warning confirm-restartdns form-control">Restart dnsmasq</button>
                                         </div>
                                     </div>
                                     <br/>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Switch the locations of the 'Restart dnsmasq' and 'Disable query logging' buttons in the 'Danger Zone' to match them closer to the relevant buttons.

Old:
![screenshot from 2017-11-04 21-18-31](https://user-images.githubusercontent.com/4417660/32411038-1a306ee0-c1a7-11e7-8c47-ba7a4e5c8919.png)

New:
![screenshot from 2017-11-04 21-29-20](https://user-images.githubusercontent.com/4417660/32411046-441816a4-c1a7-11e7-8b07-96ec40c0da8a.png)

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
