### PR TITLE
fix 'settings page crashing' if FTL is offline

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -1082,17 +1082,6 @@ if (in_array($_GET['tab'], array("sysadmin", "blocklists", "dns", "piholedhcp", 
                                 </div>
                             </div>
                         </div>
-                        <?php
-                        if ($FTL) {
-                            function get_FTL_data($arg)
-                            {
-                                global $FTLpid;
-                                return trim(exec("ps -p " . $FTLpid . " -o " . $arg));
-                            }
-
-                            $FTLversion = exec("/usr/bin/pihole-FTL version");
-                        }
-                        ?>
                         <div class="col-md-6">
                             <div class="box">
                                 <div class="box-header with-border">
@@ -1101,6 +1090,16 @@ if (in_array($_GET['tab'], array("sysadmin", "blocklists", "dns", "piholedhcp", 
                                 <div class="box-body">
                                     <div class="row">
                                         <div class="col-lg-12">
+                                            <?php
+                                            if ($FTL) {
+                                                function get_FTL_data($arg)
+                                                {
+                                                    global $FTLpid;
+                                                    return trim(exec("ps -p " . $FTLpid . " -o " . $arg));
+                                                }
+
+                                                $FTLversion = exec("/usr/bin/pihole-FTL version");
+                                            ?>
                                             <table class="table table-striped table-bordered dt-responsive nowrap">
                                                 <tbody>
                                                     <tr>
@@ -1135,6 +1134,9 @@ if (in_array($_GET['tab'], array("sysadmin", "blocklists", "dns", "piholedhcp", 
                                                     </tr>
                                                 </tbody>
                                             </table>
+                                            <?php } else { ?>
+                                            <div>The FTL service is offline!</div>
+                                            <?php } ?>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_5_

---
If `FTL` is not running (e.g. if crashed) then the settings page is not getting fully loaded.

Before this fix:
![settings_crash1](https://user-images.githubusercontent.com/28313514/32504015-0dbeb7b8-c3df-11e7-8f46-2f0231f6d296.gif)


After this fix:
![settings_crash2](https://user-images.githubusercontent.com/28313514/32503996-03237776-c3df-11e7-8b15-42cca9d97611.gif)

@DL6ER 
Or would you like to hide the 'FTL Information'-Box completely if `FTL` is not running?

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
