### PR TITLE
replace Alerts with Modal on queries.php page

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -93,7 +93,7 @@ if(strlen($showing) > 0)
     width: 250px;
     margin-left: auto;
     margin-right: auto;
-    word-break: break-word;
+    word-wrap: break-word;
     pointer-events: all;
 }
 
@@ -142,7 +142,7 @@ if(strlen($showing) > 0)
                         </div>
                     </span>
                     <div class="alProcessing">Adding <span id="alDomain"></span> to the <span id="alList"></span>...</div>
-                    <div class="alSuccess text-bold text-green" style="display: none"><span id="alDomain"></span> successfully added to the <span id="alList"></list></div>
+                    <div class="alSuccess text-bold text-green" style="display: none"><span id="alDomain"></span> successfully added to the <span id="alList"></span></div>
                     <div class="alFailure text-bold text-red" style="display: none">
                         <span id="alNetErr">Timeout or Network Connection Error!</span>
                         <span id="alCustomErr"></span>

--- a/queries.php
+++ b/queries.php
@@ -76,40 +76,6 @@ if(strlen($showing) > 0)
 	$showing = "(".$showing.")";
 }
 ?>
-<style type="text/css">
-.vertical-alignment-helper {
-    display: table;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-}
-
-.vertical-alignment-helper > .vertical-align-center {
-    display: table-cell;
-    vertical-align: middle;
-}
-
-.vertical-alignment-helper > .vertical-align-center > .modal-content {
-    width: 250px;
-    margin-left: auto;
-    margin-right: auto;
-    word-wrap: break-word;
-    pointer-events: all;
-}
-
-.alSpinner {
-    top: 0.1em;
-    left: 0.1em;
-    width: 0.8em;
-    height: 0.8em;
-    border-radius: 50%;
-    border: 4px solid silver;
-    border-right-color: transparent;
-    -webkit-animation: fa-spin 1s infinite linear;
-    animation: fa-spin 1s infinite linear;
-}
-</style>
-
 <!-- Send PHP info to JS -->
 <div id="token" hidden><?php echo $token ?></div>
 

--- a/queries.php
+++ b/queries.php
@@ -76,6 +76,40 @@ if(strlen($showing) > 0)
 	$showing = "(".$showing.")";
 }
 ?>
+<style type="text/css">
+.vertical-alignment-helper {
+    display: table;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
+.vertical-alignment-helper > .vertical-align-center {
+    display: table-cell;
+    vertical-align: middle;
+}
+
+.vertical-alignment-helper > .vertical-align-center > .modal-content {
+    width: 250px;
+    margin-left: auto;
+    margin-right: auto;
+    word-break: break-word;
+    pointer-events: all;
+}
+
+.alSpinner {
+    top: 0.1em;
+    left: 0.1em;
+    width: 0.8em;
+    height: 0.8em;
+    border-radius: 50%;
+    border: 4px solid silver;
+    border-right-color: transparent;
+    -webkit-animation: fa-spin 1s infinite linear;
+    animation: fa-spin 1s infinite linear;
+}
+</style>
+
 <!-- Send PHP info to JS -->
 <div id="token" hidden><?php echo $token ?></div>
 
@@ -88,18 +122,35 @@ if(strlen($showing) > 0)
 </div>
 -->
 
-<!-- Alerts -->
-<div id="alInfo" class="alert alert-info alert-dismissible fade in" role="alert" hidden="true">
-    <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    Adding <span id="alDomain"></span> to the <span id="alList"></span>...
-</div>
-<div id="alSuccess" class="alert alert-success alert-dismissible fade in" role="alert" hidden="true">
-    <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    Success!
-</div>
-<div id="alFailure" class="alert alert-danger alert-dismissible fade in" role="alert" hidden="true">
-    <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    Failure! Something went wrong.<span id="err"></span>
+<!-- Alert Modal -->
+<div id="alertModal" class="modal fade" role="dialog" data-backdrop="static" data-keyboard="false">
+    <div class="vertical-alignment-helper">
+        <div class="modal-dialog vertical-align-center">
+            <div class="modal-content">
+                <div class="modal-body text-center">
+                    <span class="fa-stack fa-2x" style="margin-bottom: 10px">
+                        <div class="alProcessing">
+                            <i class="fa-stack-2x alSpinner"></i>
+                        </div>
+                        <div class="alSuccess" style="display: none">
+                            <i class="fa fa-circle fa-stack-2x text-green"></i>
+                            <i class="fa fa-check fa-stack-1x fa-inverse"></i>
+                        </div>
+                        <div class="alFailure" style="display: none">
+                            <i class="fa fa-circle fa-stack-2x text-red"></i>
+                            <i class="fa fa-times fa-stack-1x fa-inverse"></i>
+                        </div>
+                    </span>
+                    <div class="alProcessing">Adding <span id="alDomain"></span> to the <span id="alList"></span>...</div>
+                    <div class="alSuccess text-bold text-green" style="display: none"><span id="alDomain"></span> successfully added to the <span id="alList"></list></div>
+                    <div class="alFailure text-bold text-red" style="display: none">
+                        <span id="alNetErr">Timeout or Network Connection Error!</span>
+                        <span id="alCustomErr"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div class="row">

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -32,14 +32,12 @@ function add(domain,list) {
     var alDomain = "#alDomain";
 
     // Run only if the Modal is closed (multiple running interlock)
-    if (alertModal.css("display") == "none") {
-        if(list === "white")
-        {
-            var listtype = "Whitelist";
-        }
-        else
-        {
-            var listtype = "Blacklist";
+    if (alertModal.css("display") === "none") {
+        var listtype;
+        if (list === "white") {
+            listtype = "Whitelist";
+        } else {
+            listtype = "Blacklist";
         }
         alProcessing.children(alDomain).html(domain);
         alProcessing.children(alList).html(listtype);
@@ -61,7 +59,7 @@ function add(domain,list) {
                         alNetworkErr.hide();
                         alCustomErr.html(response.replace("[✗]", ""));
                         alFailure.fadeIn(1000);
-                        setTimeout(function(){ alertModal.modal("hide") }, 3000);
+                        setTimeout(function() { alertModal.modal("hide"); }, 3000);
                     }
                     else
                     {
@@ -69,7 +67,7 @@ function add(domain,list) {
                         alSuccess.children(alDomain).html(domain);
                         alSuccess.children(alList).html(listtype);
                         alSuccess.fadeIn(1000);
-                        setTimeout(function(){ alertModal.modal("hide") }, 2000);
+                        setTimeout(function() { alertModal.modal("hide"); }, 2000);
                     }
                 },
                 error: function(jqXHR, exception) {
@@ -77,7 +75,7 @@ function add(domain,list) {
                     alProcessing.hide();
                     alNetworkErr.show();
                     alFailure.fadeIn(1000);
-                    setTimeout(function(){ alertModal.modal("hide") }, 3000);
+                    setTimeout(function() { alertModal.modal("hide"); }, 3000);
                 }
             });
         });
@@ -89,7 +87,7 @@ function add(domain,list) {
             alProcessing.add(alSuccess).children(alDomain).html("").end().children(alList).html("");
             alCustomErr.html("");
         });
-    };
+    }
 }
 
 function handleAjaxError( xhr, textStatus, error ) {

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -22,62 +22,76 @@ function refreshData() {
 
 function add(domain,list) {
     var token = $("#token").html();
-    var alInfo = $("#alInfo");
-    var alList = $("#alList");
-    var alDomain = $("#alDomain");
-    alDomain.html(domain);
-    var alSuccess = $("#alSuccess");
-    var alFailure = $("#alFailure");
-    var err = $("#err");
+    var alertModal = $("#alertModal");
+    var alProcessing = alertModal.find(".alProcessing");
+    var alSuccess = alertModal.find(".alSuccess");
+    var alFailure = alertModal.find(".alFailure");
+    var alNetworkErr = alertModal.find(".alFailure #alNetErr");
+    var alCustomErr = alertModal.find(".alFailure #alCustomErr");
+    var alList = "#alList";
+    var alDomain = "#alDomain";
 
-    if(list === "white")
-    {
-        alList.html("Whitelist");
-    }
-    else
-    {
-        alList.html("Blacklist");
-    }
-
-    alInfo.show();
-    alSuccess.hide();
-    alFailure.hide();
-    $.ajax({
-        url: "scripts/pi-hole/php/add.php",
-        method: "post",
-        data: {"domain":domain, "list":list, "token":token},
-        success: function(response) {
-            if (response.indexOf("not a valid argument") >= 0 || response.indexOf("is not a valid domain") >= 0)
-            {
-                alFailure.show();
-                err.html(response);
-                alFailure.delay(4000).fadeOut(2000, function() { alFailure.hide(); });
-            }
-            else
-            {
-                alSuccess.show();
-                alSuccess.delay(1000).fadeOut(2000, function() { alSuccess.hide(); });
-            }
-            alInfo.delay(1000).fadeOut(2000, function() {
-                alInfo.hide();
-                alList.html("");
-                alDomain.html("");
-            });
-        },
-        error: function(jqXHR, exception) {
-            alFailure.show();
-            err.html("");
-            alFailure.delay(1000).fadeOut(2000, function() {
-                alFailure.hide();
-            });
-            alInfo.delay(1000).fadeOut(2000, function() {
-                alInfo.hide();
-                alList.html("");
-                alDomain.html("");
-            });
+    // Run only if the Modal is closed (multiple running interlock)
+    if (alertModal.css("display") == "none") {
+        if(list === "white")
+        {
+            var listtype = "Whitelist";
         }
-    });
+        else
+        {
+            var listtype = "Blacklist";
+        }
+        alProcessing.children(alDomain).html(domain);
+        alProcessing.children(alList).html(listtype);
+        alertModal.modal("show");
+
+        // add Domain to List after Modal has faded in
+        alertModal.one("shown.bs.modal", function() {
+            $.ajax({
+                url: "scripts/pi-hole/php/add.php",
+                method: "post",
+                data: {"domain":domain, "list":list, "token":token},
+                success: function(response) {
+                    alProcessing.hide();
+                    if (response.indexOf("not a valid argument") >= 0 ||
+                        response.indexOf("is not a valid domain") >= 0 ||
+                        response.indexOf("Wrong token") >= 0)
+                    {
+                        // Failure
+                        alNetworkErr.hide();
+                        alCustomErr.html(response.replace("[✗]", ""));
+                        alFailure.fadeIn(1000);
+                        setTimeout(function(){ alertModal.modal("hide") }, 3000);
+                    }
+                    else
+                    {
+                        // Success
+                        alSuccess.children(alDomain).html(domain);
+                        alSuccess.children(alList).html(listtype);
+                        alSuccess.fadeIn(1000);
+                        setTimeout(function(){ alertModal.modal("hide") }, 2000);
+                    }
+                },
+                error: function(jqXHR, exception) {
+                    // Network Error
+                    alProcessing.hide();
+                    alNetworkErr.show();
+                    alFailure.fadeIn(1000);
+                    setTimeout(function(){ alertModal.modal("hide") }, 3000);
+                }
+            });
+        });
+        
+        // Reset Modal after it has faded out
+        alertModal.one("hidden.bs.modal", function() {
+            alProcessing.show();
+            alSuccess.add(alFailure).hide();
+            alProcessing.add(alSuccess).children(alDomain).html("").end().children(alList).html("");
+            alCustomErr.html("");
+        });
+    };
 }
+
 function handleAjaxError( xhr, textStatus, error ) {
     if ( textStatus === "timeout" )
     {

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -31,63 +31,65 @@ function add(domain,list) {
     var alList = "#alList";
     var alDomain = "#alDomain";
 
-    // Run only if the Modal is closed (multiple running interlock)
-    if (alertModal.css("display") === "none") {
-        var listtype;
-        if (list === "white") {
-            listtype = "Whitelist";
-        } else {
-            listtype = "Blacklist";
-        }
-        alProcessing.children(alDomain).html(domain);
-        alProcessing.children(alList).html(listtype);
-        alertModal.modal("show");
+    // Exit the function here if the Modal is already shown (multiple running interlock)
+    if (alertModal.css("display") !== "none") {
+        return;
+    }
 
-        // add Domain to List after Modal has faded in
-        alertModal.one("shown.bs.modal", function() {
-            $.ajax({
-                url: "scripts/pi-hole/php/add.php",
-                method: "post",
-                data: {"domain":domain, "list":list, "token":token},
-                success: function(response) {
-                    alProcessing.hide();
-                    if (response.indexOf("not a valid argument") >= 0 ||
-                        response.indexOf("is not a valid domain") >= 0 ||
-                        response.indexOf("Wrong token") >= 0)
-                    {
-                        // Failure
-                        alNetworkErr.hide();
-                        alCustomErr.html(response.replace("[✗]", ""));
-                        alFailure.fadeIn(1000);
-                        setTimeout(function() { alertModal.modal("hide"); }, 3000);
-                    }
-                    else
-                    {
-                        // Success
-                        alSuccess.children(alDomain).html(domain);
-                        alSuccess.children(alList).html(listtype);
-                        alSuccess.fadeIn(1000);
-                        setTimeout(function() { alertModal.modal("hide"); }, 2000);
-                    }
-                },
-                error: function(jqXHR, exception) {
-                    // Network Error
-                    alProcessing.hide();
-                    alNetworkErr.show();
+    var listtype;
+    if (list === "white") {
+        listtype = "Whitelist";
+    } else {
+        listtype = "Blacklist";
+    }
+    alProcessing.children(alDomain).html(domain);
+    alProcessing.children(alList).html(listtype);
+    alertModal.modal("show");
+
+    // add Domain to List after Modal has faded in
+    alertModal.one("shown.bs.modal", function() {
+        $.ajax({
+            url: "scripts/pi-hole/php/add.php",
+            method: "post",
+            data: {"domain":domain, "list":list, "token":token},
+            success: function(response) {
+                alProcessing.hide();
+                if (response.indexOf("not a valid argument") >= 0 ||
+                    response.indexOf("is not a valid domain") >= 0 ||
+                    response.indexOf("Wrong token") >= 0)
+                {
+                    // Failure
+                    alNetworkErr.hide();
+                    alCustomErr.html(response.replace("[✗]", ""));
                     alFailure.fadeIn(1000);
                     setTimeout(function() { alertModal.modal("hide"); }, 3000);
                 }
-            });
+                else
+                {
+                    // Success
+                    alSuccess.children(alDomain).html(domain);
+                    alSuccess.children(alList).html(listtype);
+                    alSuccess.fadeIn(1000);
+                    setTimeout(function() { alertModal.modal("hide"); }, 2000);
+                }
+            },
+            error: function(jqXHR, exception) {
+                // Network Error
+                alProcessing.hide();
+                alNetworkErr.show();
+                alFailure.fadeIn(1000);
+                setTimeout(function() { alertModal.modal("hide"); }, 3000);
+            }
         });
+    });
         
-        // Reset Modal after it has faded out
-        alertModal.one("hidden.bs.modal", function() {
-            alProcessing.show();
-            alSuccess.add(alFailure).hide();
-            alProcessing.add(alSuccess).children(alDomain).html("").end().children(alList).html("");
-            alCustomErr.html("");
-        });
-    }
+    // Reset Modal after it has faded out
+    alertModal.one("hidden.bs.modal", function() {
+        alProcessing.show();
+        alSuccess.add(alFailure).hide();
+        alProcessing.add(alSuccess).children(alDomain).html("").end().children(alList).html("");
+        alCustomErr.html("");
+    });
 }
 
 function handleAjaxError( xhr, textStatus, error ) {

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -50,3 +50,33 @@ a.lookatme {
 	color: red;
 	font-weight: bold;
 }
+
+.vertical-alignment-helper {
+    display: table;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+.vertical-alignment-helper > .vertical-align-center {
+    display: table-cell;
+    vertical-align: middle;
+}
+.vertical-alignment-helper > .vertical-align-center > .modal-content {
+    width: 250px;
+    margin-left: auto;
+    margin-right: auto;
+    word-wrap: break-word;
+    pointer-events: all;
+}
+
+.alSpinner {
+    top: 0.1em;
+    left: 0.1em;
+    width: 0.8em;
+    height: 0.8em;
+    border-radius: 50%;
+    border: 4px solid silver;
+    border-right-color: transparent;
+    -webkit-animation: fa-spin 1s infinite linear;
+    animation: fa-spin 1s infinite linear;
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_5_

---
Replace the Status Alerts on `queries.php` with an vertically centered Modal.

At the same time, I have added `Wrong token` to the failure check in `queries.js`.

The Result is as shown in https://github.com/pi-hole/AdminLTE/issues/546#issuecomment-336985352

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._