### PR TITLE
Add DNS.WATCH and Quad9 to DNSSEC compatibility list

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -812,7 +812,7 @@ if (in_array($_GET['tab'], array("sysadmin", "blocklists", "dns", "piholedhcp", 
                                                 </div>
                                                 <p>Validate DNS replies and cache DNSSEC data. When forwarding DNS
                                                    queries, Pi-hole requests the DNSSEC records needed to validate
-                                                   the replies. Use Google, Norton or DNS.WATCH DNS servers when activating
+                                                   the replies. Use Google, Norton, DNS.WATCH or Quad9 DNS servers when activating
                                                    DNSSEC. Note that the size of your log might increase significantly
                                                    when enabling DNSSEC. A DNSSEC resolver test can be found
                                                    <a href="http://dnssec.vs.uni-due.de/" target="_blank">here</a>.</p>

--- a/settings.php
+++ b/settings.php
@@ -812,7 +812,7 @@ if (in_array($_GET['tab'], array("sysadmin", "blocklists", "dns", "piholedhcp", 
                                                 </div>
                                                 <p>Validate DNS replies and cache DNSSEC data. When forwarding DNS
                                                    queries, Pi-hole requests the DNSSEC records needed to validate
-                                                   the replies. Use Google or Norton DNS servers when activating
+                                                   the replies. Use Google, Norton or DNS.WATCH DNS servers when activating
                                                    DNSSEC. Note that the size of your log might increase significantly
                                                    when enabling DNSSEC. A DNSSEC resolver test can be found
                                                    <a href="http://dnssec.vs.uni-due.de/" target="_blank">here</a>.</p>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

1

---

Lets users know that DNS.WATCH servers are compatible with DNSSEC

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
