### PR TITLE
remove problematic function that caused the settings page to crash on some systems

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -10,11 +10,6 @@ require "scripts/pi-hole/php/savesettings.php";
 // Reread ini file as things might have been changed
 $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
 
-function command_exist($cmd)
-{
-    return !empty(shell_exec(sprintf("which %s", escapeshellarg($cmd))));
-}
-
 ?>
 <style type="text/css">
     .tooltip-inner {
@@ -227,8 +222,8 @@ if (isset($setupVars["API_PRIVACY_MODE"])) {
 
 ?>
 
-<?php 
-if (in_array($_GET['tab'], array("sysadmin", "blocklists", "dns", "piholedhcp", "api", "teleporter"))) { 
+<?php
+if (in_array($_GET['tab'], array("sysadmin", "blocklists", "dns", "piholedhcp", "api", "teleporter"))) {
     $tab = $_GET['tab'];
 } else {
     $tab = "sysadmin";


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <github@decoy.email>

**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fixes #628

**How does this PR accomplish the above?:**

This function causes the error.  Removing it solves it.  There's likely a better solution, but the PR is here for review so feel free to hijack it @pi-hole/web 

**What documentation changes (if any) are needed to support this PR?:**

Unknown

> * `{Please delete this quoted section when opening your pull request}`
> * You must follow the template instructions. Failure to do so will result in your issue being closed.
> * Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
> * Detail helps us understand an issue quicker, but please ensure it's relevant.
