### PR TITLE
Fix off-by-one display of month

### DIFF
--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -182,7 +182,7 @@ $(document).ready(function() {
                     title: function(tooltipItem, data) {
                         var label = tooltipItem[0].xLabel;
                         var time = new Date(label);
-                        var date = time.getFullYear()+"-"+padNumber(time.getMonth())+"-"+padNumber(time.getDate());
+                        var date = time.getFullYear()+"-"+padNumber(time.getMonth()+1)+"-"+padNumber(time.getDate());
                         var h = time.getHours();
                         var m = time.getMinutes();
                         var from = padNumber(h)+":"+padNumber(m)+":00";


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix #625 

**How does this PR accomplish the above?:**

The month comes from [`Date.getMonth()`](https://github.com/pi-hole/AdminLTE/blob/master/scripts/pi-hole/js/db_graph.js#L185) which returns [an integer from 0-11](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth). We're not expecting months to start from zero, so just add 1.

![chrome_2017-12-09_01-08-04](https://user-images.githubusercontent.com/370525/33794282-8301bffa-dc7d-11e7-81e7-9ae761e97db9.png)

**What documentation changes (if any) are needed to support this PR?:**

No documentation changes necessary.