### PR TITLE
Pi-hole beta releases

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -610,6 +610,19 @@ function readAdlists()
 
 				break;
 
+			case "betaversions":
+				if(isset($_POST["betaversions"]))
+				{
+					exec("sudo pihole -a beta true");
+					$success = "You will be notified about Pi-hole beta releases. Thank you for participating in making Pi-hole an even better software!";
+				}
+				else
+				{
+					exec("sudo pihole -a beta false");
+					$success = "You will not be notified about Pi-hole beta releases.";
+				}
+				break;
+
 			default:
 				// Option not found
 				$debug = true;

--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -5,6 +5,13 @@ $localbranches = "/etc/pihole/localbranches";
 $GitHubVersions = "/etc/pihole/GitHubVersions";
 $GitHubPreRelease = "/etc/pihole/GitHubPreRelease";
 
+// Do we want to notify on availability of beta versions?
+if (isset($setupVars["USE_BETA"])) {
+    $useBeta = $setupVars["USE_BETA"];
+} else {
+    $useBeta = false;
+}
+
 if(!is_readable($localversions)  || !is_readable($localbranches) ||
    !is_readable($GitHubVersions) || !is_readable($GitHubPreRelease))
 {
@@ -59,6 +66,9 @@ else
 	$core_latest = $GitHubversions[0];
 	$web_latest = $GitHubversions[1];
 	$FTL_latest = $GitHubversions[2];
+	$core_beta = $GitHubpreRelease[0];
+	$web_beta = $GitHubpreRelease[1];
+	$FTL_beta = $GitHubpreRelease[2];
 
 	// Core version comparison
 	if($core_current !== "vDev")
@@ -66,7 +76,10 @@ else
 		// This logic allows the local core version to be newer than the upstream version
 		// The update indicator is only shown if the upstream version is NEWER
 		$core_update = (version_compare($core_current, $core_latest) < 0);
-		// isset($setupVars["USE_BETA"])
+
+		// If the most recent version is a beta version but the user doesn't want to see
+		// beta notifications, we don't display the update available notification
+		if(!$useBeta && $core_beta === "true") $core_update = false;
 	}
 	else
 	{
@@ -79,6 +92,10 @@ else
 		// This logic allows the local core version to be newer than the upstream version
 		// The update indicator is only shown if the upstream version is NEWER
 		$web_update = (version_compare($web_current, $web_latest) < 0);
+
+		// If the most recent version is a beta version but the user doesn't want to see
+		// beta notifications, we don't display the update available notification
+		if(!$useBeta && $web_beta === "true") $web_update = false;
 	}
 	else
 	{
@@ -91,6 +108,10 @@ else
 	if($FTL_current !== "vDev")
 	{
 		$FTL_update = (version_compare($FTL_current, $FTL_latest) < 0);
+
+		// If the most recent version is a beta version but the user doesn't want to see
+		// beta notifications, we don't display the update available notification
+		if(!$useBeta && $FTL_beta === "true") $FTL_update = false;
 	}
 	else
 	{

--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -3,8 +3,10 @@
 $localversions = "/etc/pihole/localversions";
 $localbranches = "/etc/pihole/localbranches";
 $GitHubVersions = "/etc/pihole/GitHubVersions";
+$GitHubPreRelease = "/etc/pihole/GitHubPreRelease";
 
-if(!is_readable($localversions) || !is_readable($localbranches) || !is_readable($GitHubVersions))
+if(!is_readable($localversions)  || !is_readable($localbranches) ||
+   !is_readable($GitHubVersions) || !is_readable($GitHubPreRelease))
 {
 	$core_branch = "master";
 	$core_current = "N/A";
@@ -20,6 +22,7 @@ else
 	$versions = explode(" ", file_get_contents($localversions));
 	$branches = explode(" ", file_get_contents($localbranches));
 	$GitHubversions = explode(" ", file_get_contents($GitHubVersions));
+	$GitHubpreRelease = explode(" ", file_get_contents($GitHubPreRelease));
 
 	/********** Get Pi-hole core branch / version / commit **********/
 	// Check if on a dev branch
@@ -63,6 +66,7 @@ else
 		// This logic allows the local core version to be newer than the upstream version
 		// The update indicator is only shown if the upstream version is NEWER
 		$core_update = (version_compare($core_current, $core_latest) < 0);
+		// isset($setupVars["USE_BETA"])
 	}
 	else
 	{

--- a/settings.php
+++ b/settings.php
@@ -1042,6 +1042,13 @@ if (in_array($_GET['tab'], array("sysadmin", "blocklists", "dns", "piholedhcp", 
                     </div>
                 </div>
                 <!-- ######################################################### System admin ######################################################### -->
+<?php
+if (isset($setupVars["USE_BETA"])) {
+    $useBeta = $setupVars["USE_BETA"];
+} else {
+    $useBeta = false;
+}
+?>
                 <div id="sysadmin" class="tab-pane fade<?php if($tab === "sysadmin"){ ?> in active<?php } ?>">
                     <div class="row">
                         <div class="col-md-6">
@@ -1076,6 +1083,27 @@ if (in_array($_GET['tab'], array("sysadmin", "blocklists", "dns", "piholedhcp", 
                                     </div>
                                 </div>
                             </div>
+                            <div class="box">
+                                <form role="form" method="post">
+                                <input type="hidden" name="field" value="betaversions">
+                                <input type="hidden" name="token" value="<?php echo $token ?>">
+                                <div class="box-header with-border">
+                                    <h3 class="box-title">Pi-hole beta version notifications</h3>
+                                </div>
+                                <div class="box-body">
+                                    <div class="row">
+                                        <div class="col-md-6">
+                                            <div class="checkbox">
+                                                <label><input type="checkbox" name="betaversions" value="true" <?php if($useBeta) { ?>checked<?php } ?>>Notify on availability of Pi-hole beta releases</label>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <button type="submit" class="btn btn-primary pull-right">Save</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            </form>
                         </div>
                         <div class="col-md-6">
                             <div class="box">


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

We are investigating if we can use GitHub's Pre-Releases for "beta" releases. More details can be found here: https://github.com/pi-hole/pi-hole/pull/1841

This adds two changes to the web interface:

1. A new setting if the user wants to see Pi-hole beta releases or not. It defaults to `No`, i.e. users first have to enable beta updates.
![screenshot at 2017-12-12 21-22-27](https://user-images.githubusercontent.com/16748619/33906556-9382e5fe-df82-11e7-9bc6-4d281661d211.png)

2. If the user doesn't want to see beta releases and we marked a release as beta release, then the update notification is **not** shown.