### PR TITLE
Fail gracefully on database problems

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -62,20 +62,17 @@ if(!$db)
 
 if (isset($_GET['getAllQueries']) && $auth)
 {
-	if($_GET['getAllQueries'] === "empty")
-	{
-		$allQueries = array();
-	}
-	else
+	$allQueries = array();
+	if($_GET['getAllQueries'] !== "empty")
 	{
 		$from = intval($_GET["from"]);
 		$until = intval($_GET["until"]);
 		$results = $db->query('SELECT timestamp,type,domain,client,status FROM queries WHERE timestamp >= '.$from.' AND timestamp <= '.$until.' ORDER BY timestamp ASC');
-		$allQueries = array();
-		while ($row = $results->fetchArray())
-		{
-			$allQueries[] = [$row[0],$row[1] == 1 ? "IPv4" : "IPv6",$row[2],$row[3],$row[4]];
-		}
+		if(!is_bool($results))
+			while ($row = $results->fetchArray())
+			{
+				$allQueries[] = [$row[0],$row[1] == 1 ? "IPv4" : "IPv6",$row[2],$row[3],$row[4]];
+			}
 	}
 	$result = array('data' => $allQueries);
 	$data = array_merge($data, $result);
@@ -98,12 +95,15 @@ if (isset($_GET['topClients']) && $auth)
 		$limit = "WHERE timestamp <= ".$_GET["until"];
 	}
 	$results = $db->query('SELECT client,count(client) FROM queries '.$limit.' GROUP by client order by count(client) desc limit 10');
+
 	$clients = array();
-	while ($row = $results->fetchArray())
-	{
-		$clients[$row[0]] = intval($row[1]);
-		// var_dump($row);
-	}
+
+	if(!is_bool($results))
+		while ($row = $results->fetchArray())
+		{
+			$clients[$row[0]] = intval($row[1]);
+			// var_dump($row);
+		}
 	$result = array('top_sources' => $clients);
 	$data = array_merge($data, $result);
 }
@@ -125,11 +125,14 @@ if (isset($_GET['topDomains']) && $auth)
 		$limit = " AND timestamp <= ".$_GET["until"];
 	}
 	$results = $db->query('SELECT domain,count(domain) FROM queries WHERE (STATUS == 2 OR STATUS == 3)'.$limit.' GROUP by domain order by count(domain) desc limit 10');
+
 	$domains = array();
-	while ($row = $results->fetchArray())
-	{
-		$domains[$row[0]] = intval($row[1]);
-	}
+
+	if(!is_bool($results))
+		while ($row = $results->fetchArray())
+		{
+			$domains[$row[0]] = intval($row[1]);
+		}
 	$result = array('top_domains' => $domains);
 	$data = array_merge($data, $result);
 }
@@ -151,11 +154,14 @@ if (isset($_GET['topAds']) && $auth)
 		$limit = " AND timestamp <= ".$_GET["until"];
 	}
 	$results = $db->query('SELECT domain,count(domain) FROM queries WHERE (STATUS == 1 OR STATUS == 4)'.$limit.' GROUP by domain order by count(domain) desc limit 10');
+
 	$addomains = array();
-	while ($row = $results->fetchArray())
-	{
-		$addomains[$row[0]] = intval($row[1]);
-	}
+
+	if(!is_bool($results))
+		while ($row = $results->fetchArray())
+		{
+			$addomains[$row[0]] = intval($row[1]);
+		}
 	$result = array('top_ads' => $addomains);
 	$data = array_merge($data, $result);
 }
@@ -163,21 +169,36 @@ if (isset($_GET['topAds']) && $auth)
 if (isset($_GET['getMinTimestamp']) && $auth)
 {
 	$results = $db->query('SELECT MIN(timestamp) FROM queries');
-	$result = array('mintimestamp' => $results->fetchArray()[0]);
+
+	if(!is_bool($results))
+		$result = array('mintimestamp' => $results->fetchArray()[0]);
+	else
+		$result = array();
+
 	$data = array_merge($data, $result);
 }
 
 if (isset($_GET['getMaxTimestamp']) && $auth)
 {
 	$results = $db->query('SELECT MAX(timestamp) FROM queries');
-	$result = array('maxtimestamp' => $results->fetchArray()[0]);
+
+	if(!is_bool($results))
+		$result = array('maxtimestamp' => $results->fetchArray()[0]);
+	else
+		$result = array();
+
 	$data = array_merge($data, $result);
 }
 
 if (isset($_GET['getQueriesCount']) && $auth)
 {
 	$results = $db->query('SELECT COUNT(timestamp) FROM queries');
-	$result = array('count' => $results->fetchArray()[0]);
+
+	if(!is_bool($results))
+		$result = array('count' => $results->fetchArray()[0]);
+	else
+		$result = array();
+
 	$data = array_merge($data, $result);
 }
 
@@ -216,21 +237,27 @@ if (isset($_GET['getGraphData']) && $auth)
 
 	// Count permitted queries in intervals
 	$results = $db->query('SELECT (timestamp/'.$interval.')*'.$interval.' interval, COUNT(*) FROM queries WHERE (status == 2 OR status == 3)'.$limit.' GROUP by interval ORDER by interval');
+
 	$domains = array();
-	while ($row = $results->fetchArray())
-	{
-		$domains[$row[0]] = intval($row[1]);
-	}
+
+	if(!is_bool($results))
+		while ($row = $results->fetchArray())
+		{
+			$domains[$row[0]] = intval($row[1]);
+		}
 	$result = array('domains_over_time' => $domains);
 	$data = array_merge($data, $result);
 
 	// Count blocked queries in intervals
 	$results = $db->query('SELECT (timestamp/'.$interval.')*'.$interval.' interval, COUNT(*) FROM queries WHERE (status == 1 OR status == 4 OR status == 5)'.$limit.' GROUP by interval ORDER by interval');
+
 	$addomains = array();
-	while ($row = $results->fetchArray())
-	{
-		$addomains[$row[0]] = intval($row[1]);
-	}
+
+	if(!is_bool($results))
+		while ($row = $results->fetchArray())
+		{
+			$addomains[$row[0]] = intval($row[1]);
+		}
 	$result = array('ads_over_time' => $addomains);
 	$data = array_merge($data, $result);
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

This is a more general bugfix which may or not fix already existing bug reports. It addresses, in general, errors reported like this
```
FastCGI-stderr: PHP Fatal error: Uncaught Error: Call to a member function fetchArray() on boolean in /var/www/html/admin/api_db.php:75
```

**What does this PR aim to accomplish?:**

Check if `$results` is `bool` and use `fetchArray()` only if it isn't.

**How does this PR accomplish the above?:**

From the PHP/SQlite3 documentation (http://php.net/manual/en/sqlite3.query.php):
> public SQLite3Result SQLite3::query ( string $query )
> Returns an SQLite3Result object, or **FALSE** on failure.

Apparently, it can also return **TRUE** on simple queries, so we check for type `bool` in general instead of checking for `FALSE`.
