### PR TITLE
Set maximum execution time to 10 minutes in api_db.php

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -12,6 +12,9 @@ require("scripts/pi-hole/php/password.php");
 require("scripts/pi-hole/php/auth.php");
 check_cors();
 
+// Set maximum execution time to 10 minutes
+ini_set("max_execution_time","600");
+
 $data = array();
 
 // Get posible non-standard location of FTL's database


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Mitigate timeout errors on extensive requests from the database on low-power devices

**How does this PR accomplish the above?:**

See title
