### PR TITLE
Add the audit log to Teleporter

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -176,6 +176,7 @@ else
 	archive_add_file("/etc/pihole/","blacklist.txt");
 	archive_add_file("/etc/pihole/","adlists.list");
 	archive_add_file("/etc/pihole/","setupVars.conf");
+	archive_add_file("/etc/pihole/","auditlog.list");
 	archive_add_directory("/etc/dnsmasq.d/");
 
 	$archive["wildcardblocking.txt"] = getWildcardListContent();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Back up the audit log in Teleporter [as requested on Reddit](https://www.reddit.com/r/pihole/comments/7km2xw/can_we_have_the_auditloglist_in_the_teleporter/).

**How does this PR accomplish the above?:**

Adds the file to the archive in Teleporter.

**What documentation changes (if any) are needed to support this PR?:**

None