### PR TITLE
Clean up formatting in settings page

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -786,14 +786,14 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                     <div class="checkbox">
                                                         <label><input type="checkbox" name="DNSrequiresFQDN" title="domain-needed"
                                                                       <?php if ($DNSrequiresFQDN){ ?>checked<?php }
-                                                                      ?>>never forward non-FQDNs</label>
+                                                                      ?>>Never forward non-FQDNs</label>
                                                     </div>
                                                 </div>
                                                 <div class="form-group">
                                                     <div class="checkbox">
                                                         <label><input type="checkbox" name="DNSbogusPriv" title="bogus-priv"
                                                                       <?php if ($DNSbogusPriv){ ?>checked<?php }
-                                                                      ?>>never forward reverse lookups for private IP ranges</label>
+                                                                      ?>>Never forward reverse lookups for private IP ranges</label>
                                                     </div>
                                                 </div>
                                                 <p>Note that enabling these two options may increase your privacy
@@ -1068,7 +1068,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                     <td><?php echo $piHoleIPv6; ?></td>
                                                 </tr>
                                                 <tr>
-                                                    <th scope="row">Pi-hole hostname</th>
+                                                    <th scope="row">Pi-hole hostname:</th>
                                                     <td><?php echo $hostname; ?></td>
                                                 </tr>
                                                 </tbody>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Make the hostname and DNS settings text in the Settings page consistent with the rest of the page.

**How does this PR accomplish the above?:**

Add a colon to the hostname on the settings page to be consistent with the other items in Settings. Change the case of the checkbox descriptions on the DNS settings page to be consistent with the other items in Settings.

**What documentation changes (if any) are needed to support this PR?:**

None