### PR TITLE
Display the name of the blocklist URL

### DIFF
--- a/scripts/pi-hole/php/queryads.php
+++ b/scripts/pi-hole/php/queryads.php
@@ -58,7 +58,7 @@ else
     $exact = "";
 }
 
-$proc = popen("sudo pihole -q ".$url." ".$exact, 'r');
+$proc = popen("sudo pihole -q -adlist ".$url." ".$exact, 'r');
 while (!feof($proc)) {
     echoEvent(fread($proc, 4096));
 }


### PR DESCRIPTION
added -adlist arg to command

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

This aims to accomplish a more detailed view of which blocklist the queried domain is coming from. Prior, the query would display the domain of the block list and a number (unhelpful if you have multiple blocklists pulled from the same domain).

**How does this PR accomplish the above?:**

adds an existing flag -adlist to the pihole query command

**What documentation changes (if any) are needed to support this PR?:**

I don't believe any documentation changes are needed

