### PR TITLE
Query Log: Show last 100 queries by default

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -230,6 +230,10 @@ if (isset($_GET['getAllQueries']) && $auth)
 		// Get specific client only
 		sendRequestFTL("getallqueries-client ".$_GET['client']);
 	}
+	else if(is_numeric($_GET['getAllQueries']))
+	{
+		sendRequestFTL("getallqueries (".$_GET['getAllQueries'].")");
+	}
 	else
 	{
 		// Get all queries

--- a/queries.php
+++ b/queries.php
@@ -19,47 +19,49 @@ if(isset($setupVars["API_QUERY_LOG_SHOW"]))
 {
 	if($setupVars["API_QUERY_LOG_SHOW"] === "all")
 	{
-		$showing = "showing all queries";
+		$showing = "showing";
 	}
 	elseif($setupVars["API_QUERY_LOG_SHOW"] === "permittedonly")
 	{
-		$showing = "showing permitted queries only";
+		$showing = "showing permitted";
 	}
 	elseif($setupVars["API_QUERY_LOG_SHOW"] === "blockedonly")
 	{
-		$showing = "showing blocked queries only";
+		$showing = "showing blocked";
 	}
 	elseif($setupVars["API_QUERY_LOG_SHOW"] === "nothing")
 	{
-		$showing = "showing no queries at all";
+		$showing = "showing no queries (due to setting)";
 	}
 }
 else
 {
 	// If filter variable is not set, we
 	// automatically show all queries
-	$showing = "showing all queries";
+	$showing = "showing queries";
 }
 
+$showall = false;
 if(isset($_GET["all"]))
 {
-	$showing .= " within the Pi-hole log";
+	$showing .= " all queries within the Pi-hole log";
 }
 else if(isset($_GET["client"]))
 {
-	$showing .= " for client ".htmlentities($_GET["client"]);
+	$showing .= " queries for client ".htmlentities($_GET["client"]);
 }
 else if(isset($_GET["domain"]))
 {
-	$showing .= " for domain ".htmlentities($_GET["domain"]);
+	$showing .= " queries for domain ".htmlentities($_GET["domain"]);
 }
-else if(isset($_GET["from"]) && isset($_GET["until"]))
+else if(isset($_GET["from"]) || isset($_GET["until"]))
 {
-	$showing .= " within limited time interval";
+	$showing .= " queries within specified time interval";
 }
 else
 {
-	$showing .= ", most recent 100, <a href=\"?all\">show all</a>";
+	$showing .= " up to 100 queries";
+	$showall = true;
 }
 
 if(isset($setupVars["API_PRIVACY_MODE"]))
@@ -74,6 +76,8 @@ if(isset($setupVars["API_PRIVACY_MODE"]))
 if(strlen($showing) > 0)
 {
 	$showing = "(".$showing.")";
+	if($showall)
+		$showing .= ", <a href=\"?all\">show all</a>";
 }
 ?>
 <!-- Send PHP info to JS -->

--- a/queries.php
+++ b/queries.php
@@ -59,7 +59,7 @@ else if(isset($_GET["from"]) && isset($_GET["until"]))
 }
 else
 {
-	$showing .= " within recent 10 minutes, <a href=\"?all\">show all</a>";
+	$showing .= ", most recent 100, <a href=\"?all\">show all</a>";
 }
 
 if(isset($setupVars["API_PRIVACY_MODE"]))

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -82,7 +82,7 @@ function add(domain,list) {
             }
         });
     });
-        
+
     // Reset Modal after it has faded out
     alertModal.one("hidden.bs.modal", function() {
         alProcessing.show();
@@ -122,27 +122,25 @@ $(document).ready(function() {
     location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1];});
 
     var APIstring = "api.php?getAllQueries";
-    var options = "";
 
     if("from" in GETDict && "until" in GETDict)
     {
-        options += "&from="+GETDict["from"];
+        APIstring += "&from="+GETDict["from"];
         APIstring += "&until="+GETDict["until"];
     }
     else if("client" in GETDict)
     {
-        options += "&client="+GETDict["client"];
+        APIstring += "&client="+GETDict["client"];
     }
     else if("domain" in GETDict)
     {
-        options += "&domain="+GETDict["domain"];
+        APIstring += "&domain="+GETDict["domain"];
     }
     // If we don't ask filtering and also not for all queries, just request the most recent 100 queries
     else if(!("all" in GETDict))
     {
         APIstring += "=100";
     }
-    APIstring += options;
 
     tableApi = $("#all-queries").DataTable( {
         "rowCallback": function( row, data, index ){

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -122,26 +122,27 @@ $(document).ready(function() {
     location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1];});
 
     var APIstring = "api.php?getAllQueries";
+    var options = "";
 
     if("from" in GETDict && "until" in GETDict)
     {
-        APIstring += "&from="+GETDict["from"];
+        options += "&from="+GETDict["from"];
         APIstring += "&until="+GETDict["until"];
     }
     else if("client" in GETDict)
     {
-        APIstring += "&client="+GETDict["client"];
+        options += "&client="+GETDict["client"];
     }
     else if("domain" in GETDict)
     {
-        APIstring += "&domain="+GETDict["domain"];
+        options += "&domain="+GETDict["domain"];
     }
+    // If we don't ask filtering and also not for all queries, just request the most recent 100 queries
     else if(!("all" in GETDict))
     {
-        var timestamp = Math.floor(Date.now() / 1000);
-        APIstring += "&from="+(timestamp - 600);
-        APIstring += "&until="+(timestamp + 100);
+        APIstring += "=100";
     }
+    APIstring += options;
 
     tableApi = $("#all-queries").DataTable( {
         "rowCallback": function( row, data, index ){


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

The query log page offers the queries from within the last 10 minutes by default. We change the default to the most recent 100 queries, instead.

**How does this PR accomplish the above?:**

Replace query from `from 10 minutes ago until now` to `most recent 100`. Also, we add the capability to specify the number of max. returned results to the `getAllQueries` API call. Previously, we had this already for all Top List entries.

**What documentation changes (if any) are needed to support this PR?:**

@jacobsalmela We will want to mention that in a blog post. However, I think it is something for after Pi-hole v3.3