### PR TITLE
Dashboard: Clarify what the left table shows

### DIFF
--- a/index.php
+++ b/index.php
@@ -234,7 +234,7 @@ else
     <div class="<?php echo $tablelayout; ?>">
       <div class="box" id="domain-frequency">
         <div class="box-header with-border">
-          <h3 class="box-title">Top Domains</h3>
+          <h3 class="box-title">Top Permitted Domains</h3>
         </div>
         <!-- /.box-header -->
         <div class="box-body">


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Clarify what the left table shows. Assume we have a domain `abc.de` that is not blocked and was requested 1000 times. However, now the user chose to blacklist this domain (assume it get's requested 500 times more after this).

What do we see?
- Query Log (with filter `domain=abc.de`) will list 1,500 queries. 
- `Top Blocked Domains` will list `abc.de` with 500
- `Top Domains` will list  `abc.de` with 1,000 although the domain itself was requested 1,500 times in total.

The latter seems a bit inconsistent, hence I propose to simply change the label of this table.

**How does this PR accomplish the above?:**

Change title from `Top Domains` to `Top Permitted Domains`:
![screenshot at 2018-02-11 17-59-16](https://user-images.githubusercontent.com/16748619/36075903-4c7e6220-0f55-11e8-8865-3079e1780866.png)

The central table is already labelled `Top Blocked Domains`.