### PR TITLE
Sort IPs in DHCP Table numerically instead of lexicographically

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -554,7 +554,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                         <tr data-placement="auto" data-container="body" data-toggle="tooltip"
                                                             title="Lease type: IPv<?php echo $lease["type"]; ?><br/>Remaining lease time: <?php echo $lease["TIME"]; ?><br/>DHCP UID: <?php echo $lease["clid"]; ?>">
                                                             <td id="MAC"><?php echo $lease["hwaddr"]; ?></td>
-                                                            <td id="IP"><?php echo $lease["IP"]; ?></td>
+                                                            <td id="IP" data-order="<?php echo bin2hex(inet_pton($lease["IP"])); ?>"><?php echo $lease["IP"]; ?></td>
                                                             <td id="HOST"><?php echo $lease["host"]; ?></td>
                                                             <td>
                                                                 <button class="btn btn-warning btn-xs" type="button" id="button" data-static="alert">
@@ -583,7 +583,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                         <?php foreach ($dhcp_static_leases as $lease) { ?>
                                                         <tr>
                                                             <td><?php echo $lease["hwaddr"]; ?></td>
-                                                            <td><?php echo $lease["IP"]; ?></td>
+                                                            <td data-order="<?php echo bin2hex(inet_pton($lease["IP"])); ?>"><?php echo $lease["IP"]; ?></td>
                                                             <td><?php echo $lease["host"]; ?></td>
                                                             <td><?php if (strlen($lease["hwaddr"]) > 0) { ?>
                                                                 <button class="btn btn-danger btn-xs" type="submit" name="removestatic"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

DataTables sorts IPs lexicographically, i.e. like this:  
* 192.168.1
* 192.168.101
* 192.168.1.2
* ...
But it should be sorted numerically like this:
* 192.168.1
* 192.168.2
* 192.168.1.101
* ...

**How does this PR accomplish the above?:**

DataTables supports the HTML5 `data-order` attribute so the row will be sorted based on the attribute value rather than the cell value.  
To accomplish this IPs are getting converted to hex using [`inet_pton`](http://php.net/manual/en/function.inet-pton.php) and [`bin2hex`](http://php.net/manual/en/function.bin2hex.php).

**What documentation changes (if any) are needed to support this PR?:**

None