### PR TITLE
Log scroll

### DIFF
--- a/scripts/pi-hole/js/taillog-FTL.js
+++ b/scripts/pi-hole/js/taillog-FTL.js
@@ -14,14 +14,15 @@ function reloadData(){
     clearTimeout(timer);
     $.getJSON("scripts/pi-hole/php/tailLog.php?FTL&offset="+offset, function (data)
     {
-        offset = data["offset"];
         pre.append(data["lines"]);
+
+        if(scrolling && offset !== data["offset"]) {
+            pre.scrollTop(pre[0].scrollHeight);
+        }
+
+        offset = data["offset"];
     });
 
-    if(scrolling)
-    {
-        window.scrollTo(0,document.body.scrollHeight);
-    }
     timer = setTimeout(reloadData, interval);
 }
 

--- a/scripts/pi-hole/js/taillog.js
+++ b/scripts/pi-hole/js/taillog.js
@@ -14,14 +14,15 @@ function reloadData(){
     clearTimeout(timer);
     $.getJSON("scripts/pi-hole/php/tailLog.php?offset="+offset, function (data)
     {
-        offset = data["offset"];
         pre.append(data["lines"]);
+
+        if(scrolling && offset !== data["offset"]) {
+            pre.scrollTop(pre[0].scrollHeight);
+        }
+
+        offset = data["offset"];
     });
 
-    if(scrolling)
-    {
-        window.scrollTo(0,document.body.scrollHeight);
-    }
     timer = setTimeout(reloadData, interval);
 }
 

--- a/taillog-FTL.php
+++ b/taillog-FTL.php
@@ -13,7 +13,7 @@
 </div>
 
 <div class="checkbox"><label><input type="checkbox" name="active" checked id="chk1"> Automatic scrolling on update</label></div>
-<pre id="output" style="width: 100%; height: 100%;"></pre>
+<pre id="output" style="width: 100%; height: 100%; max-height:650px; overflow-y:scroll;"></pre>
 <div class="checkbox"><label><input type="checkbox" name="active" checked id="chk2"> Automatic scrolling on update</label></div>
 
 <?php

--- a/taillog.php
+++ b/taillog.php
@@ -13,7 +13,7 @@
 </div>
 
 <div class="checkbox"><label><input type="checkbox" name="active" checked id="chk1"> Automatic scrolling on update</label></div>
-<pre id="output" style="width: 100%; height: 100%;"></pre>
+<pre id="output" style="width: 100%; height: 100%; max-height:650px; overflow-y:scroll;"></pre>
 <div class="checkbox"><label><input type="checkbox" name="active" checked id="chk2"> Automatic scrolling on update</label></div>
 
 <?php


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
7
---
The following has been added to taillog and taillog-FTL in order to stop it from scrolling the screen down and prevent smaller devices (Phones / Tablets) from creating huge pages.

max-height:650px; overflow-y:scroll;

The outcome is this
![image](https://user-images.githubusercontent.com/7566941/30002484-7867b620-90a2-11e7-9cfe-567006ec9766.png) 
Compared to this.
![image](https://user-images.githubusercontent.com/7566941/30002496-a325be16-90a2-11e7-841c-1d39b28b85e8.png)

It also has the benefit of preventing the bug where you cannot scroll up past the last line if the log is still generating due to requests.

A problem I have encountered, is that this breaks the "Autoscroll" button that is added. Can this be tweaked to watch the "#output" rather than the page?

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
