### PR TITLE
Use host names from FTLDNS

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -155,7 +155,10 @@ if ((isset($_GET['topClients']) || isset($_GET['getQuerySources'])) && $auth)
 	foreach($return as $line)
 	{
 		$tmp = explode(" ",$line);
-		$top_clients[resolveHostname($tmp[2],true)] = intval($tmp[1]);
+		if(count($tmp) > 2 && strlen($tmp[3]) > 0)
+			$top_clients[$tmp[3]."|".$tmp[2]] = intval($tmp[1]);
+		else
+			$top_clients[$tmp[2]] = intval($tmp[1]);
 	}
 
 	$result = array('top_sources' => $top_clients);
@@ -177,7 +180,10 @@ if (isset($_GET['getForwardDestinations']) && $auth)
 	foreach($return as $line)
 	{
 		$tmp = explode(" ",$line);
-		$forward_dest[resolveHostname($tmp[2],true)] = floatval($tmp[1]);
+		if(count($tmp) > 2 && strlen($tmp[3]) > 0)
+			$forward_dest[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
+		else
+			$forward_dest[$tmp[2]] = floatval($tmp[1]);
 	}
 
 	$result = array('forward_destinations' => $forward_dest);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Use host names returned by FTLDNS instead of trying to obtain them in PHP

**How does this PR accomplish the above?:**

Revert code to what it was in the pre-FTL v4.0 era as we are now again able to resolve host names within FTLDNS. Note that is only true after https://github.com/pi-hole/FTL/pull/253 has been merged.