### PR TITLE
Several improvements for FTL API

### DIFF
--- a/api.php
+++ b/api.php
@@ -75,20 +75,13 @@ elseif (isset($_GET['disable']) && $auth)
 }
 
 // Other API functions
-if(!testFTL($FTL_IP) && !isset($_GET["PHP"]))
+if(!isset($_GET["PHP"]))
 {
-	$data = array_merge($data, array("FTLnotrunning" => true));
+	require("api_FTL.php");
 }
 else
 {
-	if(!isset($_GET["PHP"]))
-	{
-		require("api_FTL.php");
-	}
-	else
-	{
-		require("api_PHP.php");
-	}
+	require("api_PHP.php");
 }
 
 if(isset($_GET["jsonForceObject"]))

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -317,14 +317,17 @@ else
 	{
 		sendRequestFTL("client-names");
 		$return = getResponseFTL();
-		$forward_dest = array();
+		$client_names = array();
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
-			$forward_dest[resolveHostname($tmp[2],true)] = floatval($tmp[1]);
+			if(count($tmp) > 2 && strlen($tmp[3]) > 0)
+				$client_names[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
+			else
+				$client_names[$tmp[2]] = floatval($tmp[1]);
 		}
 
-		$result = array('clients' => $forward_dest);
+		$result = array('clients' => $client_names);
 		$data = array_merge($data, $result);
 	}
 

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -15,329 +15,336 @@ if(!isset($api))
 // $FTL_IP is defined in api.php
 $socket = connectFTL($FTL_IP);
 
-if (isset($_GET['type'])) {
-	$data["type"] = "FTL";
-}
-
-if (isset($_GET['version'])) {
-	$data["version"] = 3;
-}
-
-if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET))
+if(!is_resource($socket))
 {
-	sendRequestFTL("stats");
-	$return = getResponseFTL();
+	$data = array_merge($data, array("FTLnotrunning" => true));
+}
+else
+{
+	if (isset($_GET['type'])) {
+		$data["type"] = "FTL";
+	}
 
-	$stats = [];
-	foreach($return as $line)
+	if (isset($_GET['version'])) {
+		$data["version"] = 3;
+	}
+
+	if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET))
 	{
-		$tmp = explode(" ",$line);
+		sendRequestFTL("stats");
+		$return = getResponseFTL();
 
-		if(($tmp[0] === "domains_being_blocked" && !is_numeric($tmp[1])) || $tmp[0] === "status")
+		$stats = [];
+		foreach($return as $line)
 		{
-			$stats[$tmp[0]] = $tmp[1];
-			continue;
-		}
+			$tmp = explode(" ",$line);
 
-		if(isset($_GET['summary']))
-		{
-			if($tmp[0] !== "ads_percentage_today")
+			if(($tmp[0] === "domains_being_blocked" && !is_numeric($tmp[1])) || $tmp[0] === "status")
 			{
-				$stats[$tmp[0]] = number_format($tmp[1]);
+				$stats[$tmp[0]] = $tmp[1];
+				continue;
+			}
+
+			if(isset($_GET['summary']))
+			{
+				if($tmp[0] !== "ads_percentage_today")
+				{
+					$stats[$tmp[0]] = number_format($tmp[1]);
+				}
+				else
+				{
+					$stats[$tmp[0]] = number_format($tmp[1], 1, '.', '');
+				}
 			}
 			else
 			{
-				$stats[$tmp[0]] = number_format($tmp[1], 1, '.', '');
+				$stats[$tmp[0]] = floatval($tmp[1]);
 			}
 		}
-		else
+		$data = array_merge($data,$stats);
+	}
+
+	if (isset($_GET['overTimeData10mins']))
+	{
+		sendRequestFTL("overTime");
+		$return = getResponseFTL();
+
+		$domains_over_time = array();
+		$ads_over_time = array();
+		foreach($return as $line)
 		{
-			$stats[$tmp[0]] = floatval($tmp[1]);
+			$tmp = explode(" ",$line);
+			$domains_over_time[intval($tmp[0])] = intval($tmp[1]);
+			$ads_over_time[intval($tmp[0])] = intval($tmp[2]);
 		}
-	}
-	$data = array_merge($data,$stats);
-}
-
-if (isset($_GET['overTimeData10mins']))
-{
-	sendRequestFTL("overTime");
-	$return = getResponseFTL();
-
-	$domains_over_time = array();
-	$ads_over_time = array();
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		$domains_over_time[intval($tmp[0])] = intval($tmp[1]);
-		$ads_over_time[intval($tmp[0])] = intval($tmp[2]);
-	}
-	$result = array('domains_over_time' => $domains_over_time,
-	                'ads_over_time' => $ads_over_time);
-	$data = array_merge($data, $result);
-}
-
-if (isset($_GET['topItems']) && $auth)
-{
-	if($_GET['topItems'] === "audit")
-	{
-		sendRequestFTL("top-domains for audit");
-	}
-	else if(is_numeric($_GET['topItems']))
-	{
-		sendRequestFTL("top-domains (".$_GET['topItems'].")");
-	}
-	else
-	{
-		sendRequestFTL("top-domains");
+		$result = array('domains_over_time' => $domains_over_time,
+		                'ads_over_time' => $ads_over_time);
+		$data = array_merge($data, $result);
 	}
 
-	$return = getResponseFTL();
-	$top_queries = array();
-	foreach($return as $line)
+	if (isset($_GET['topItems']) && $auth)
 	{
-		$tmp = explode(" ",$line);
-		$top_queries[$tmp[2]] = intval($tmp[1]);
-	}
-
-	if($_GET['topItems'] === "audit")
-	{
-		sendRequestFTL("top-ads for audit");
-	}
-	else if(is_numeric($_GET['topItems']))
-	{
-		sendRequestFTL("top-ads (".$_GET['topItems'].")");
-	}
-	else
-	{
-		sendRequestFTL("top-ads");
-	}
-
-	$return = getResponseFTL();
-	$top_ads = array();
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		if(count($tmp) === 4)
-			$top_ads[$tmp[2]." (".$tmp[3].")"] = intval($tmp[1]);
-		else
-			$top_ads[$tmp[2]] = intval($tmp[1]);
-	}
-
-	$result = array('top_queries' => $top_queries,
-	                'top_ads' => $top_ads);
-
-	$data = array_merge($data, $result);
-}
-
-if ((isset($_GET['topClients']) || isset($_GET['getQuerySources'])) && $auth)
-{
-
-	if(isset($_GET['topClients']))
-	{
-		$number = $_GET['topClients'];
-	}
-	elseif(isset($_GET['getQuerySources']))
-	{
-		$number = $_GET['getQuerySources'];
-	}
-
-	if(is_numeric($number))
-	{
-		sendRequestFTL("top-clients (".$number.")");
-	}
-	else
-	{
-		sendRequestFTL("top-clients");
-	}
-
-	$return = getResponseFTL();
-	$top_clients = array();
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		if(count($tmp) > 2 && strlen($tmp[3]) > 0)
-			$top_clients[$tmp[3]."|".$tmp[2]] = intval($tmp[1]);
-		else
-			$top_clients[$tmp[2]] = intval($tmp[1]);
-	}
-
-	$result = array('top_sources' => $top_clients);
-	$data = array_merge($data, $result);
-}
-
-if (isset($_GET['getForwardDestinations']) && $auth)
-{
-	if($_GET['getForwardDestinations'] === "unsorted")
-	{
-		sendRequestFTL("forward-dest unsorted");
-	}
-	else
-	{
-		sendRequestFTL("forward-dest");
-	}
-	$return = getResponseFTL();
-	$forward_dest = array();
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		if(count($tmp) > 2 && strlen($tmp[3]) > 0)
-			$forward_dest[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
-		else
-			$forward_dest[$tmp[2]] = floatval($tmp[1]);
-	}
-
-	$result = array('forward_destinations' => $forward_dest);
-	$data = array_merge($data, $result);
-}
-
-if (isset($_GET['getQueryTypes']) && $auth)
-{
-	sendRequestFTL("querytypes");
-	$return = getResponseFTL();
-	$querytypes = array();
-	foreach($return as $ret)
-	{
-		$tmp = explode(": ",$ret);
-		$querytypes[$tmp[0]] = floatval($tmp[1]);
-	}
-
-	$result = array('querytypes' => $querytypes);
-	$data = array_merge($data, $result);
-}
-
-if (isset($_GET['getAllQueries']) && $auth)
-{
-	if(isset($_GET['from']) && isset($_GET['until']))
-	{
-		// Get limited time interval
-		sendRequestFTL("getallqueries-time ".$_GET['from']." ".$_GET['until']);
-	}
-	else if(isset($_GET['domain']))
-	{
-		// Get specific domain only
-		sendRequestFTL("getallqueries-domain ".$_GET['domain']);
-	}
-	else if(isset($_GET['client']))
-	{
-		// Get specific client only
-		sendRequestFTL("getallqueries-client ".$_GET['client']);
-	}
-	else if(is_numeric($_GET['getAllQueries']))
-	{
-		sendRequestFTL("getallqueries (".$_GET['getAllQueries'].")");
-	}
-	else
-	{
-		// Get all queries
-		sendRequestFTL("getallqueries");
-	}
-	$return = getResponseFTL();
-	$allQueries = array();
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		$tmp[3] = resolveHostname($tmp[3],false);
-		array_push($allQueries,$tmp);
-	}
-
-	$result = array('data' => $allQueries);
-	$data = array_merge($data, $result);
-}
-
-if(isset($_GET["recentBlocked"]))
-{
-	sendRequestFTL("recentBlocked");
-	die(getResponseFTL()[0]);
-	unset($data);
-}
-
-if (isset($_GET['overTimeDataForwards']) && $auth)
-{
-	sendRequestFTL("ForwardedoverTime");
-	$return = getResponseFTL();
-	$over_time = array();
-
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		for ($i=0; $i < count($tmp)-1; $i++) {
-			$over_time[intval($tmp[0])][$i] = floatval($tmp[$i+1]);
-		}
-	}
-	$result = array('over_time' => $over_time);
-	$data = array_merge($data, $result);
-}
-
-if (isset($_GET['getForwardDestinationNames']) && $auth)
-{
-	sendRequestFTL("forward-names");
-	$return = getResponseFTL();
-	$forward_dest = array();
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		if(count($tmp) == 4)
+		if($_GET['topItems'] === "audit")
 		{
-			$forward_dest[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
+			sendRequestFTL("top-domains for audit");
+		}
+		else if(is_numeric($_GET['topItems']))
+		{
+			sendRequestFTL("top-domains (".$_GET['topItems'].")");
 		}
 		else
 		{
-			$forward_dest[$tmp[2]] = floatval($tmp[1]);
+			sendRequestFTL("top-domains");
 		}
-	}
 
-	$result = array('forward_destinations' => $forward_dest);
-	$data = array_merge($data, $result);
-}
-
-if (isset($_GET['overTimeDataQueryTypes']) && $auth)
-{
-	sendRequestFTL("QueryTypesoverTime");
-	$return = getResponseFTL();
-	$over_time = array();
-
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		for ($i=0; $i < count($tmp)-1; $i++) {
-			$over_time[intval($tmp[0])][$i] = floatval($tmp[$i+1]);
+		$return = getResponseFTL();
+		$top_queries = array();
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			$top_queries[$tmp[2]] = intval($tmp[1]);
 		}
-	}
-	$result = array('over_time' => $over_time);
-	$data = array_merge($data, $result);
-}
 
-if (isset($_GET['getClientNames']) && $auth)
-{
-	sendRequestFTL("client-names");
-	$return = getResponseFTL();
-	$forward_dest = array();
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		$forward_dest[resolveHostname($tmp[2],true)] = floatval($tmp[1]);
-	}
-
-	$result = array('clients' => $forward_dest);
-	$data = array_merge($data, $result);
-}
-
-if (isset($_GET['overTimeDataClients']) && $auth)
-{
-	sendRequestFTL("ClientsoverTime");
-	$return = getResponseFTL();
-	$over_time = array();
-
-	foreach($return as $line)
-	{
-		$tmp = explode(" ",$line);
-		for ($i=0; $i < count($tmp)-1; $i++) {
-			$over_time[intval($tmp[0])][$i] = floatval($tmp[$i+1]);
+		if($_GET['topItems'] === "audit")
+		{
+			sendRequestFTL("top-ads for audit");
 		}
-	}
-	$result = array('over_time' => $over_time);
-	$data = array_merge($data, $result);
-}
+		else if(is_numeric($_GET['topItems']))
+		{
+			sendRequestFTL("top-ads (".$_GET['topItems'].")");
+		}
+		else
+		{
+			sendRequestFTL("top-ads");
+		}
 
-disconnectFTL();
+		$return = getResponseFTL();
+		$top_ads = array();
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			if(count($tmp) === 4)
+				$top_ads[$tmp[2]." (".$tmp[3].")"] = intval($tmp[1]);
+			else
+				$top_ads[$tmp[2]] = intval($tmp[1]);
+		}
+
+		$result = array('top_queries' => $top_queries,
+		                'top_ads' => $top_ads);
+
+		$data = array_merge($data, $result);
+	}
+
+	if ((isset($_GET['topClients']) || isset($_GET['getQuerySources'])) && $auth)
+	{
+
+		if(isset($_GET['topClients']))
+		{
+			$number = $_GET['topClients'];
+		}
+		elseif(isset($_GET['getQuerySources']))
+		{
+			$number = $_GET['getQuerySources'];
+		}
+
+		if(is_numeric($number))
+		{
+			sendRequestFTL("top-clients (".$number.")");
+		}
+		else
+		{
+			sendRequestFTL("top-clients");
+		}
+
+		$return = getResponseFTL();
+		$top_clients = array();
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			if(count($tmp) > 2 && strlen($tmp[3]) > 0)
+				$top_clients[$tmp[3]."|".$tmp[2]] = intval($tmp[1]);
+			else
+				$top_clients[$tmp[2]] = intval($tmp[1]);
+		}
+
+		$result = array('top_sources' => $top_clients);
+		$data = array_merge($data, $result);
+	}
+
+	if (isset($_GET['getForwardDestinations']) && $auth)
+	{
+		if($_GET['getForwardDestinations'] === "unsorted")
+		{
+			sendRequestFTL("forward-dest unsorted");
+		}
+		else
+		{
+			sendRequestFTL("forward-dest");
+		}
+		$return = getResponseFTL();
+		$forward_dest = array();
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			if(count($tmp) > 2 && strlen($tmp[3]) > 0)
+				$forward_dest[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
+			else
+				$forward_dest[$tmp[2]] = floatval($tmp[1]);
+		}
+
+		$result = array('forward_destinations' => $forward_dest);
+		$data = array_merge($data, $result);
+	}
+
+	if (isset($_GET['getQueryTypes']) && $auth)
+	{
+		sendRequestFTL("querytypes");
+		$return = getResponseFTL();
+		$querytypes = array();
+		foreach($return as $ret)
+		{
+			$tmp = explode(": ",$ret);
+			$querytypes[$tmp[0]] = floatval($tmp[1]);
+		}
+
+		$result = array('querytypes' => $querytypes);
+		$data = array_merge($data, $result);
+	}
+
+	if (isset($_GET['getAllQueries']) && $auth)
+	{
+		if(isset($_GET['from']) && isset($_GET['until']))
+		{
+			// Get limited time interval
+			sendRequestFTL("getallqueries-time ".$_GET['from']." ".$_GET['until']);
+		}
+		else if(isset($_GET['domain']))
+		{
+			// Get specific domain only
+			sendRequestFTL("getallqueries-domain ".$_GET['domain']);
+		}
+		else if(isset($_GET['client']))
+		{
+			// Get specific client only
+			sendRequestFTL("getallqueries-client ".$_GET['client']);
+		}
+		else if(is_numeric($_GET['getAllQueries']))
+		{
+			sendRequestFTL("getallqueries (".$_GET['getAllQueries'].")");
+		}
+		else
+		{
+			// Get all queries
+			sendRequestFTL("getallqueries");
+		}
+		$return = getResponseFTL();
+		$allQueries = array();
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			$tmp[3] = resolveHostname($tmp[3],false);
+			array_push($allQueries,$tmp);
+		}
+
+		$result = array('data' => $allQueries);
+		$data = array_merge($data, $result);
+	}
+
+	if(isset($_GET["recentBlocked"]))
+	{
+		sendRequestFTL("recentBlocked");
+		die(getResponseFTL()[0]);
+		unset($data);
+	}
+
+	if (isset($_GET['overTimeDataForwards']) && $auth)
+	{
+		sendRequestFTL("ForwardedoverTime");
+		$return = getResponseFTL();
+		$over_time = array();
+
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			for ($i=0; $i < count($tmp)-1; $i++) {
+				$over_time[intval($tmp[0])][$i] = floatval($tmp[$i+1]);
+			}
+		}
+		$result = array('over_time' => $over_time);
+		$data = array_merge($data, $result);
+	}
+
+	if (isset($_GET['getForwardDestinationNames']) && $auth)
+	{
+		sendRequestFTL("forward-names");
+		$return = getResponseFTL();
+		$forward_dest = array();
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			if(count($tmp) == 4)
+			{
+				$forward_dest[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
+			}
+			else
+			{
+				$forward_dest[$tmp[2]] = floatval($tmp[1]);
+			}
+		}
+
+		$result = array('forward_destinations' => $forward_dest);
+		$data = array_merge($data, $result);
+	}
+
+	if (isset($_GET['overTimeDataQueryTypes']) && $auth)
+	{
+		sendRequestFTL("QueryTypesoverTime");
+		$return = getResponseFTL();
+		$over_time = array();
+
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			for ($i=0; $i < count($tmp)-1; $i++) {
+				$over_time[intval($tmp[0])][$i] = floatval($tmp[$i+1]);
+			}
+		}
+		$result = array('over_time' => $over_time);
+		$data = array_merge($data, $result);
+	}
+
+	if (isset($_GET['getClientNames']) && $auth)
+	{
+		sendRequestFTL("client-names");
+		$return = getResponseFTL();
+		$forward_dest = array();
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			$forward_dest[resolveHostname($tmp[2],true)] = floatval($tmp[1]);
+		}
+
+		$result = array('clients' => $forward_dest);
+		$data = array_merge($data, $result);
+	}
+
+	if (isset($_GET['overTimeDataClients']) && $auth)
+	{
+		sendRequestFTL("ClientsoverTime");
+		$return = getResponseFTL();
+		$over_time = array();
+
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			for ($i=0; $i < count($tmp)-1; $i++) {
+				$over_time[intval($tmp[0])][$i] = floatval($tmp[$i+1]);
+			}
+		}
+		$result = array('over_time' => $over_time);
+		$data = array_merge($data, $result);
+	}
+
+	disconnectFTL();
+}
 ?>

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -123,7 +123,7 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
-			if(count($tmp) === 4)
+			if(count($tmp) > 3)
 				$top_ads[$tmp[2]." (".$tmp[3].")"] = intval($tmp[1]);
 			else
 				$top_ads[$tmp[2]] = intval($tmp[1]);
@@ -161,7 +161,7 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
-			if(count($tmp) > 2 && strlen($tmp[3]) > 0)
+			if(count($tmp) > 3 && strlen($tmp[3]) > 0)
 				$top_clients[$tmp[3]."|".$tmp[2]] = intval($tmp[1]);
 			else
 				$top_clients[$tmp[2]] = intval($tmp[1]);
@@ -186,7 +186,7 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
-			if(count($tmp) > 2 && strlen($tmp[3]) > 0)
+			if(count($tmp) > 3 && strlen($tmp[3]) > 0)
 				$forward_dest[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
 			else
 				$forward_dest[$tmp[2]] = floatval($tmp[1]);
@@ -282,7 +282,7 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
-			if(count($tmp) == 4)
+			if(count($tmp) > 3)
 			{
 				$forward_dest[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
 			}
@@ -321,7 +321,7 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
-			if(count($tmp) > 2 && strlen($tmp[3]) > 0)
+			if(count($tmp) > 3 && strlen($tmp[3]) > 0)
 				$client_names[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
 			else
 				$client_names[$tmp[2]] = floatval($tmp[1]);

--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -17,7 +17,7 @@ function connectFTL($address, $port=4711)
 	}
 
 	// Open Internet socket connection
-	$socket = @fsockopen($address, $port, $timeout = 1.0);
+	$socket = @fsockopen($address, $port, $errno, $errstr, 1.0);
 
 	return $socket;
 }

--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -6,30 +6,8 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-function testFTL($address)
+function connectFTL($address, $port=4711)
 {
-	if($address === "127.0.0.1")
-	{
-		$ret = shell_exec("pidof pihole-FTL");
-		return intval($ret);
-	}
-	// We cannot relly test for a distant FTL instance
-	// in the same way, so for any other IP address
-	// we simply return true here and rely on the API
-	// socket connection itself to fail if there is nothing
-	// on that address
-	return true;
-}
-
-function connectFTL($address, $port=4711, $quiet=true)
-{
-	$timeout = 3;
-
-	if(!$quiet)
-	{
-		echo "Attempting to connect to '$address' on port '$port'...\n";
-	}
-
 	if($address == "127.0.0.1")
 	{
 		// Read port
@@ -38,136 +16,42 @@ function connectFTL($address, $port=4711, $quiet=true)
 			$port = intval($portfile);
 	}
 
-	// Create a TCP/IP socket
-	$socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP)
-	or die("socket_create() failed: reason: " . socket_strerror(socket_last_error()) . "\n");
-
-	socket_set_nonblock($socket) or die("Unable to set nonblock on socket\n");
-
-	$time = time();
-	while (!@socket_connect($socket, $address, $port))
-	{
-		$err = socket_last_error($socket);
-		if ($err == 115 || $err == 114)
-		{
-			if ((time() - $time) >= $timeout)
-			{
-				socket_close($socket);
-				die("Connection timed out.\n");
-			}
-			// Wait for 1 millisecond
-			usleep(1000);
-			continue;
-		}
-		die(socket_strerror($err) . "\n");
-	}
-
-	socket_set_block($socket) or die("Unable to set block on socket\n");
-
-	// Set timeout to 3 seconds
-	socket_set_option($socket, SOL_SOCKET, SO_RCVTIMEO, ['sec'=>$timeout, 'usec'=>0]);
-	socket_set_option($socket, SOL_SOCKET, SO_SNDTIMEO, ['sec'=>$timeout, 'usec'=>0]);
-
-	if(!$quiet)
-	{
-		echo "Success!\n\n";
-	}
+	// Open Internet socket connection
+	$socket = @fsockopen($address, $port, $timeout = 1.0);
 
 	return $socket;
 }
-function sendRequestFTL($requestin, $quiet=true)
+function sendRequestFTL($requestin)
 {
 	global $socket;
 
 	$request = ">".$requestin;
-	if(!$quiet)
-	{
-		echo "Sending request (".$request.")...\n";
-	}
-
-	socket_write($socket, $request, strlen($request)) or die("Could not send data to server\n");
-	if(!$quiet)
-	{
-		echo "OK.\n";
-	}
+	fwrite($socket, $request) or die("Could not send data to server\n");
 }
 
-function getResponseFTL($quiet=true)
+function getResponseFTL()
 {
 	global $socket;
-	if(!$quiet)
-	{
-		echo "Reading response:\n";
-	}
 
 	$response = [];
 
 	while(true)
 	{
-		$out = socket_read($socket, 2048, PHP_NORMAL_READ);
-		if(!$quiet)
-		{
-			echo $out;
-		}
+		$out = fgets($socket, 128);
 		if(strrpos($out,"---EOM---") !== false)
-		{
 			break;
-		}
+
 		$out = rtrim($out);
 		if(strlen($out) > 0)
-		{
 			$response[] = $out;
-		}
 	}
 
 	return $response;
 }
 
-function disconnectFTL($quiet=true)
+function disconnectFTL()
 {
 	global $socket;
-	if(!$quiet)
-	{
-		echo "Closing socket...";
-	}
-
-	socket_close($socket);
-
-	if(!$quiet)
-	{
-		echo "OK.\n\n";
-	}
-}
-
-$clients = array();
-function resolveHostname($clientip, $printIP = false)
-{
-	global $clients;
-	$ipaddr = strtolower($clientip);
-	if(array_key_exists($clientip, $clients))
-	{
-		// Entry already exists
-		$clientname = $clients[$ipaddr];
-		if($printIP)
-			return $clientname."|".$clientip;
-		return $clientname;
-	}
-
-	else if(filter_var($clientip, FILTER_VALIDATE_IP))
-	{
-		// Get host name of client and convert to lower case
-		$clientname = strtolower(gethostbyaddr($ipaddr));
-	}
-	else
-	{
-		// This is already a host name
-		$clientname = $ipaddr;
-	}
-	// Buffer result
-	$clients[$ipaddr] = $clientname;
-
-	if($printIP)
-		return $clientname."|".$clientip;
-	return $clientname;
+	fclose($socket);
 }
 ?>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Improve way PHP connects to FTL. Instead of testing if a local instance of `pihole-FTL` is running and then connecting to it, we now use `fsockopen` as a higher-level function to determine if there is an instance of `FTL` running at whatever address:port is given.

This PR should resolve all those issues with the PHP error log using up the entire disk with messages like
```
FastCGI-stderr: PHP Warning:  socket_read(): unable to read from socket [104]: Connection reset by peer
```

This PR also removes some older (minor) bugs that present in the `FTLDNS` web branch and removes the now obsolete subroutine `resolveHostname()`.

**How does this PR accomplish the above?:**

Replace `socket_create()` and friends by `@fsockopen()`. The `@` ensures that connection errors are not logged in the error log. This is fine as we properly deal with them afterwards (`if(!is_resource($socket)){ ... }`).

Although this PR shows a ton of changes, > 98% are actually only indentation changes due to the error handling only allowing the individual queries if we were able to connect to FTL. The only way of going around this would have been to use `goto` statements, which is generally to be avoided.

**What documentation changes (if any) are needed to support this PR?:**

None