### PR TITLE
Make sure backend does always interpret list of DNS servers even if it is empty

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -298,7 +298,7 @@ function readAdlists()
 				if(!strlen($error))
 				{
 					$IPs = implode (",", $DNSservers);
-					$return = exec("sudo pihole -a setdns ".$IPs." ".$extra);
+					$return = exec("sudo pihole -a setdns \"".$IPs."\" ".$extra);
 					$success .= htmlspecialchars($return)."<br>";
 					$success .= "The DNS settings have been updated (using ".$DNSservercount." DNS servers)";
 				}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix an issue with an empty list of DNS server not being correctly interpreted

**How does this PR accomplish the above?:**

Add `""` around the list