### PR TITLE
Gravity: date last changed (Web & API)

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -31,6 +31,7 @@ else
 
 	if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET))
 	{
+		require_once("scripts/pi-hole/php/gravity.php");
 		sendRequestFTL("stats");
 		$return = getResponseFTL();
 
@@ -61,6 +62,7 @@ else
 				$stats[$tmp[0]] = floatval($tmp[1]);
 			}
 		}
+		$stats['gravity_last_updated'] = gravity_last_update(true);
 		$data = array_merge($data,$stats);
 	}
 

--- a/api_PHP.php
+++ b/api_PHP.php
@@ -13,6 +13,7 @@
     }
 
     include('scripts/pi-hole/php/data.php');
+    include_once('scripts/pi-hole/php/gravity.php');
 
     // Non-Auth
 
@@ -34,6 +35,7 @@
         $sum['dns_queries_today'] = number_format( $sum['dns_queries_today']);
         $sum['ads_percentage_today'] = number_format( $sum['ads_percentage_today'], 1, '.', '');
         $sum['domains_being_blocked'] = number_format( $sum['domains_being_blocked']);
+        $sum['gravity_last_updated'] = gravity_last_update(true);
         $data = array_merge($data,  $sum);
     }
 

--- a/index.php
+++ b/index.php
@@ -7,6 +7,7 @@
 *    Please see LICENSE file for your rights under this license. */
     $indexpage = true;
     require "scripts/pi-hole/php/header.php";
+    require_once("scripts/pi-hole/php/gravity.php"); 
 ?>
 <!-- Small boxes (Stat box) -->
 <div class="row">
@@ -48,27 +49,10 @@
             </div>
         </div>
     </div>
-<?php
-$gravitylist = "/etc/pihole/gravity.list";
-if (file_exists($gravitylist))
-{
-    $gravitydiff = date_diff(date_create("@".filemtime($gravitylist)),date_create("now"));
-    if($gravitydiff->d > 1)
-        $gravitydate = $gravitydiff->format("Blocking list updated %a days, %H:%I ago");
-    elseif($gravitydiff->d == 1)
-        $gravitydate = $gravitydiff->format("Blocking list updated one day, %H:%I ago");
-    else
-        $gravitydate = $gravitydiff->format("Blocking list updated %H:%I ago");
-}
-else
-{
-    $gravitydate = "Blocking list not found";
-}
-?>
     <!-- ./col -->
     <div class="col-lg-3 col-xs-12">
         <!-- small box -->
-        <div class="small-box bg-red" title="<?php echo $gravitydate; ?>">
+        <div class="small-box bg-red" title="<?php echo gravity_last_update(); ?>">
             <div class="inner">
                 <p>Domains on Blocklist</p>
                 <h3 class="statistic"><span id="domains_being_blocked">---</span></h3>
@@ -229,11 +213,11 @@ else
 <?php
 if($boxedlayout)
 {
-	$tablelayout = "col-md-6";
+  $tablelayout = "col-md-6";
 }
 else
 {
-	$tablelayout = "col-md-6 col-lg-4";
+  $tablelayout = "col-md-6 col-lg-4";
 }
 ?>
 <div class="row">

--- a/scripts/pi-hole/php/gravity.php
+++ b/scripts/pi-hole/php/gravity.php
@@ -1,0 +1,51 @@
+<?php
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+function gravity_last_update($raw = false){
+	/*
+	@walter-exit | April 23rd, 2018:
+	Checks when the gravity list was last updated, if it exists at all.
+	Returns the info in human-readable format for use on the dashboard,
+	or raw for use by the API.
+	*/
+	$gravitylist = "/etc/pihole/gravity.list";
+	if (file_exists($gravitylist)){
+		$date_file_created_unix = filemtime($gravitylist);
+		$date_file_created = date_create("@".$date_file_created_unix);
+		$date_now = date_create("now");
+	    $gravitydiff = date_diff($date_file_created,$date_now);
+	    if($raw){
+			$output = array(
+				"file_exists"=> true,
+				"absolute" => $date_file_created_unix,
+				"relative" => array(
+					"days" =>  $gravitydiff->format("%a"),
+					"hours" =>  $gravitydiff->format("%H"),
+					"minutes" =>  $gravitydiff->format("%I"),
+				)
+			);
+		}else{
+			if($gravitydiff->d > 1){
+		        $output = $gravitydiff->format("Blocking list updated %a days, %H:%I ago");
+		    }elseif($gravitydiff->d == 1){
+		        $output = $gravitydiff->format("Blocking list updated one day, %H:%I ago");
+		    }else{
+		        $output = $gravitydiff->format("Blocking list updated %H:%I ago");
+		    }
+		}
+	}else{
+		if($raw){
+			$output = array("file_exists"=>false);
+		}else{
+			$output = "Blocking list not found";	
+		}
+	}
+	return $output;
+}
+
+?>

--- a/scripts/pi-hole/php/gravity.php
+++ b/scripts/pi-hole/php/gravity.php
@@ -7,45 +7,45 @@
 *  Please see LICENSE file for your rights under this license. */
 
 function gravity_last_update($raw = false){
-	/*
-	@walter-exit | April 23rd, 2018:
-	Checks when the gravity list was last updated, if it exists at all.
-	Returns the info in human-readable format for use on the dashboard,
-	or raw for use by the API.
-	*/
-	$gravitylist = "/etc/pihole/gravity.list";
-	if (file_exists($gravitylist)){
-		$date_file_created_unix = filemtime($gravitylist);
-		$date_file_created = date_create("@".$date_file_created_unix);
-		$date_now = date_create("now");
-		$gravitydiff = date_diff($date_file_created,$date_now);
-		if($raw){
-			$output = array(
-				"file_exists"=> true,
-				"absolute" => $date_file_created_unix,
-				"relative" => array(
-					"days" =>  $gravitydiff->format("%a"),
-					"hours" =>  $gravitydiff->format("%H"),
-					"minutes" =>  $gravitydiff->format("%I"),
-				)
-			);
-		}else{
-			if($gravitydiff->d > 1){
-				$output = $gravitydiff->format("Blocking list updated %a days, %H:%I ago");
-			}elseif($gravitydiff->d == 1){
-				$output = $gravitydiff->format("Blocking list updated one day, %H:%I ago");
-			}else{
-				$output = $gravitydiff->format("Blocking list updated %H:%I ago");
-			}
-		}
-	}else{
-		if($raw){
-			$output = array("file_exists"=>false);
-		}else{
-			$output = "Blocking list not found";	
-		}
-	}
-	return $output;
+    /*
+    @walter-exit | April 23rd, 2018:
+    Checks when the gravity list was last updated, if it exists at all.
+    Returns the info in human-readable format for use on the dashboard,
+    or raw for use by the API.
+    */
+    $gravitylist = "/etc/pihole/gravity.list";
+    if (file_exists($gravitylist)){
+        $date_file_created_unix = filemtime($gravitylist);
+        $date_file_created = date_create("@".$date_file_created_unix);
+        $date_now = date_create("now");
+        $gravitydiff = date_diff($date_file_created,$date_now);
+        if($raw){
+            $output = array(
+                "file_exists"=> true,
+                "absolute" => $date_file_created_unix,
+                "relative" => array(
+                    "days" =>  $gravitydiff->format("%a"),
+                    "hours" =>  $gravitydiff->format("%H"),
+                    "minutes" =>  $gravitydiff->format("%I"),
+                )
+            );
+        }else{
+            if($gravitydiff->d > 1){
+                $output = $gravitydiff->format("Blocking list updated %a days, %H:%I ago");
+            }elseif($gravitydiff->d == 1){
+                $output = $gravitydiff->format("Blocking list updated one day, %H:%I ago");
+            }else{
+                $output = $gravitydiff->format("Blocking list updated %H:%I ago");
+            }
+        }
+    }else{
+        if($raw){
+            $output = array("file_exists"=>false);
+        }else{
+            $output = "Blocking list not found";	
+        }
+    }
+    return $output;
 }
 
 ?>

--- a/scripts/pi-hole/php/gravity.php
+++ b/scripts/pi-hole/php/gravity.php
@@ -8,7 +8,7 @@
 
 function gravity_last_update($raw = false){
     /*
-    @walter-exit | April 23rd, 2018:
+    @walter-exit <walter@exclusive-it.nl> | April 23rd, 2018:
     Checks when the gravity list was last updated, if it exists at all.
     Returns the info in human-readable format for use on the dashboard,
     or raw for use by the API.

--- a/scripts/pi-hole/php/gravity.php
+++ b/scripts/pi-hole/php/gravity.php
@@ -18,8 +18,8 @@ function gravity_last_update($raw = false){
 		$date_file_created_unix = filemtime($gravitylist);
 		$date_file_created = date_create("@".$date_file_created_unix);
 		$date_now = date_create("now");
-	    $gravitydiff = date_diff($date_file_created,$date_now);
-	    if($raw){
+		$gravitydiff = date_diff($date_file_created,$date_now);
+		if($raw){
 			$output = array(
 				"file_exists"=> true,
 				"absolute" => $date_file_created_unix,
@@ -31,12 +31,12 @@ function gravity_last_update($raw = false){
 			);
 		}else{
 			if($gravitydiff->d > 1){
-		        $output = $gravitydiff->format("Blocking list updated %a days, %H:%I ago");
-		    }elseif($gravitydiff->d == 1){
-		        $output = $gravitydiff->format("Blocking list updated one day, %H:%I ago");
-		    }else{
-		        $output = $gravitydiff->format("Blocking list updated %H:%I ago");
-		    }
+				$output = $gravitydiff->format("Blocking list updated %a days, %H:%I ago");
+			}elseif($gravitydiff->d == 1){
+				$output = $gravitydiff->format("Blocking list updated one day, %H:%I ago");
+			}else{
+				$output = $gravitydiff->format("Blocking list updated %H:%I ago");
+			}
 		}
 	}else{
 		if($raw){


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ ] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Changes concerning the date the gravity list was last changed. Used in the webinterface dashboard as a tooltip (html title element), and now also available in the API (both PHP and FTL). Function was moved to new file /scripts/pi-hole/php/gravity.php to keep things neat and to avoid duplicate code.

Personally I use this piece of information in my intranet statistics dashboard. It might be useful to others as well.

**How does this PR accomplish the above?:**

See file diffs

**What documentation changes (if any) are needed to support this PR?:**
You might want to add it to the API documentation as an available statistic.
