### PR TITLE
Update warnings on settings page buttons

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -68,7 +68,7 @@ $(".confirm-restartdns").confirm({
 });
 
 $(".confirm-flushlogs").confirm({
-	text: "By default, the log is flushed at the end of the day via cron, but a very large log file can slow down the Web interface, so flushing it can be useful. Note that your statistics will be reset and you lose the statistics up to this point. Are you sure you want to flush your logs?",
+	text: "Are you sure you want to flush your logs?",
 	title: "Confirmation required",
 	confirm(button) {
 		$("#flushlogsform").submit();
@@ -85,7 +85,7 @@ $(".confirm-flushlogs").confirm({
 });
 
 $(".confirm-disablelogging").confirm({
-	text: "Note that disabling query logging will render graphs on the web user interface useless. Are you sure you want to disable logging and flush your Pi-hole logs?",
+	text: "Are you sure you want to disable logging and flush your Pi-hole logs?",
 	title: "Confirmation required",
 	confirm(button) {
 		$("#disablelogsform").submit();
@@ -102,7 +102,7 @@ $(".confirm-disablelogging").confirm({
 });
 
 $(".confirm-disablelogging-noflush").confirm({
-	text: "Note that disabling query logging will render graphs on the web user interface useless after this point. Are you sure you want to disable logging?",
+	text: "Are you sure you want to disable logging?",
 	title: "Confirmation required",
 	confirm(button) {
 		$("#disablelogsform-noflush").submit();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Relax warnings on the Settings page confirmation dialogs shown after clicking the buttons.

- Flush logs: huge log files do not affect the speed of the web interface at all. Flushing wouldn't change anything (that seems to be there since the PHP API days).

- Disable logging: With *FTL*DNS, disabling the logs is perfectly fine and statistics will still be computed, so this warning is actually wrong now.

**How does this PR accomplish the above?:**

Changed text in JS file.