### PR TITLE
Allow custom ports for custom upstream DNS servers

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -213,19 +213,9 @@ function readAdlists()
 				}
 				$DNSservercount = count($DNSservers);
 
-				if(isset($_POST["localDNS"]) && isset($_POST["localDNSport"]) &&
-				   is_numeric($_POST["localDNSport"]))
-				{
-					// Save port and modify dnsmasq.d config file
-					exec("sudo pihole -a localdnsport ".intval($_POST["localDNSport"]));
-					$DNSservercount++;
-				}
-				else
-				{
-					// Remove possible entry if unticked
+				// Remove possibly existing localdnsport setting
+				exec("sudo pihole -a localdnsport 0");
 
-					exec("sudo pihole -a localdnsport 0");
-				}
 				// Check if at least one DNS server has been added
 				if($DNSservercount < 1)
 				{

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -187,14 +187,27 @@ function readAdlists()
 				{
 					if(array_key_exists("custom".$i,$_POST))
 					{
-						$IP = $_POST["custom".$i."val"];
-						if(validIP($IP))
+						$exploded = explode("#", $_POST["custom".$i."val"], 2);
+						$IP = $exploded[0];
+						if(count($exploded) > 1)
 						{
-							array_push($DNSservers,$IP);
+							$port = $exploded[1];
 						}
 						else
 						{
+							$port = "53";
+						}
+						if(!validIP($IP))
+						{
 							$error .= "IP (".htmlspecialchars($IP).") is invalid!<br>";
+						}
+						elseif(!is_numeric($port))
+						{
+							$error .= "Port (".htmlspecialchars($port).") is invalid!<br>";
+						}
+						else
+						{
+							array_push($DNSservers,$IP."#".$port);
 						}
 					}
 				}

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -213,9 +213,6 @@ function readAdlists()
 				}
 				$DNSservercount = count($DNSservers);
 
-				// Remove possibly existing localdnsport setting
-				exec("sudo pihole -a localdnsport 0");
-
 				// Check if at least one DNS server has been added
 				if($DNSservercount < 1)
 				{

--- a/settings.php
+++ b/settings.php
@@ -128,13 +128,13 @@ $i = 1;
 while (isset($setupVars["PIHOLE_DNS_" . $i])) {
     if (isinserverlist($setupVars["PIHOLE_DNS_" . $i])) {
         array_push($DNSactive, $setupVars["PIHOLE_DNS_" . $i]);
-    } elseif (strpos($setupVars["PIHOLE_DNS_" . $i], ".")) {
+    } elseif (strpos($setupVars["PIHOLE_DNS_" . $i], ".") !== false) {
         if (!isset($custom1)) {
             $custom1 = $setupVars["PIHOLE_DNS_" . $i];
         } else {
             $custom2 = $setupVars["PIHOLE_DNS_" . $i];
         }
-    } elseif (strpos($setupVars["PIHOLE_DNS_" . $i], ":")) {
+    } elseif (strpos($setupVars["PIHOLE_DNS_" . $i], ":") !== false) {
         if (!isset($custom3)) {
             $custom3 = $setupVars["PIHOLE_DNS_" . $i];
         } else {
@@ -717,7 +717,6 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                                    <?php if (isset($custom1)){ ?>checked<?php } ?>>
                                                         </div>
                                                         <input type="text" name="custom1val" class="form-control"
-                                                               data-inputmask="'alias': 'ip'" data-mask
                                                                <?php if (isset($custom1)){ ?>value="<?php echo $custom1; ?>"<?php } ?>>
                                                     </div>
                                                     <label>Custom 2 (IPv4)</label>
@@ -727,7 +726,6 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                                    <?php if (isset($custom2)){ ?>checked<?php } ?>>
                                                         </div>
                                                         <input type="text" name="custom2val" class="form-control"
-                                                               data-inputmask="'alias': 'ip'" data-mask
                                                                <?php if (isset($custom2)){ ?>value="<?php echo $custom2; ?>"<?php } ?>>
                                                     </div>
                                                     <label>Custom 3 (IPv6)</label>
@@ -737,7 +735,6 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                                    <?php if (isset($custom3)){ ?>checked<?php } ?>>
                                                         </div>
                                                         <input type="text" name="custom3val" class="form-control"
-                                                               data-inputmask="'alias': 'ipv6'" data-mask
                                                                <?php if (isset($custom3)){ ?>value="<?php echo $custom3; ?>"<?php } ?>>
                                                     </div>
                                                     <label>Custom 4 (IPv6)</label>
@@ -747,7 +744,6 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                                    <?php if (isset($custom4)){ ?>checked<?php } ?>>
                                                         </div>
                                                         <input type="text" name="custom4val" class="form-control"
-                                                               data-inputmask="'alias': 'ipv6'" data-mask
                                                                <?php if (isset($custom4)){ ?>value="<?php echo $custom4; ?>"<?php } ?>>
                                                     </div>
                                                     <label>Local DNS server on custom port</label>

--- a/settings.php
+++ b/settings.php
@@ -205,12 +205,6 @@ if (isset($setupVars["QUERY_LOGGING"])) {
 } else {
     $piHoleLogging = true;
 }
-
-$localDNS = false;
-if(isset($setupVars["LOCAL_DNS_PORT"]) && is_numeric($setupVars["LOCAL_DNS_PORT"]))
-{
-    $localDNS = intval($setupVars["LOCAL_DNS_PORT"]);
-}
 ?>
 
 <?php
@@ -745,16 +739,6 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                         </div>
                                                         <input type="text" name="custom4val" class="form-control"
                                                                <?php if (isset($custom4)){ ?>value="<?php echo $custom4; ?>"<?php } ?>>
-                                                    </div>
-                                                    <label>Local DNS server on custom port</label>
-                                                    <div class="input-group">
-                                                        <div class="input-group-addon">
-                                                            <input type="checkbox" name="localDNS" value="yes"
-                                                                   <?php if ($localDNS){ ?>checked<?php } ?>>
-                                                        </div>
-                                                        <input type="text" placeholder="127.0.0.1" class="form-control" disabled style="background: white; width: 50%; text-align: right;">
-                                                        <input type="text" name="localDNSport" class="form-control" placeholder="port" style="width: 50%"
-                                                               <?php if ($localDNS){ ?>value="<?php echo $localDNS; ?>"<?php } ?>>
                                                     </div>
                                                 </div>
                                             </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

This PR adds support for non-standard ports for the four custom upstream DNS servers on the dashboard. It fixes #680 

**How does this PR accomplish the above?:**

Implement proper handling of custom ports. I already configured the correct handling in the core code some while ago but forgot about it. We automatically add port 53 in case a user didn't specify a port.

![screenshot at 2018-05-04 19-35-26](https://user-images.githubusercontent.com/16748619/39642521-51540382-4fd2-11e8-897c-f3ceb6495220.png)


**What documentation changes (if any) are needed to support this PR?:**

I remove the custom local DNS port field as this implementation is much more powerful. The unbound blog article needs updating. @jacobsalmela 