### PR TITLE
Correctly apply API_SHOW filters on dashboard

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -617,7 +617,6 @@ function updateTopLists() {
         if(jQuery.isEmptyObject(data.top_queries))
         {
             $("#domain-frequency").parent().remove();
-            return;
         }
 
         for (domain in data.top_ads) {
@@ -641,7 +640,6 @@ function updateTopLists() {
         if(jQuery.isEmptyObject(data.top_ads))
         {
             $("#ad-frequency").parent().remove();
-            return;
         }
 
         $("#domain-frequency .overlay").hide();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix a bug brought up on [Discourse](https://discourse.pi-hole.net/t/no-top-blocked-domains-on-web-ui/9377).

**How does this PR accomplish the above?:**

When the filters on the Settings page (API / Web interface) are set to anything else than both boxes ticked, the top domains / top ads tables on the dashboard are broken. This is caused by returning too early when filling tables with top domains/top ads data. This early return results in missing to remove the loading spinners.

Even worse, in case of "Show permitted domains" is unticked, the early return will lead to a situation where the top ads table is not even filled although we have the data for it.

The routine does not need these `returns` as it is robust against receiving empty data from the API.

**What documentation changes (if any) are needed to support this PR?:**

None.