### PR TITLE
Add "Top Clients (blocked)" table

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -173,6 +173,38 @@ else
 		$data = array_merge($data, $result);
 	}
 
+	if (isset($_GET['topClientsBlocked']) && $auth)
+	{
+
+		if(isset($_GET['topClientsBlocked']))
+		{
+			$number = $_GET['topClientsBlocked'];
+		}
+
+		if(is_numeric($number))
+		{
+			sendRequestFTL("top-clients blocked (".$number.")");
+		}
+		else
+		{
+			sendRequestFTL("top-clients blocked");
+		}
+
+		$return = getResponseFTL();
+		$top_clients = array();
+		foreach($return as $line)
+		{
+			$tmp = explode(" ",$line);
+			if(count($tmp) > 3 && strlen($tmp[3]) > 0)
+				$top_clients[$tmp[3]."|".$tmp[2]] = intval($tmp[1]);
+			else
+				$top_clients[$tmp[2]] = intval($tmp[1]);
+		}
+
+		$result = array('top_sources_blocked' => $top_clients);
+		$data = array_merge($data, $result);
+	}
+
 	if (isset($_GET['getForwardDestinations']) && $auth)
 	{
 		if($_GET['getForwardDestinations'] === "unsorted")

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@
 *    Please see LICENSE file for your rights under this license. */
     $indexpage = true;
     require "scripts/pi-hole/php/header.php";
-    require_once("scripts/pi-hole/php/gravity.php"); 
+    require_once("scripts/pi-hole/php/gravity.php");
 ?>
 <!-- Small boxes (Stat box) -->
 <div class="row">
@@ -217,7 +217,7 @@ if($boxedlayout)
 }
 else
 {
-  $tablelayout = "col-md-6 col-lg-4";
+  $tablelayout = "col-md-6 col-lg-6";
 }
 ?>
 <div class="row">
@@ -278,7 +278,35 @@ else
     <div class="<?php echo $tablelayout; ?>">
       <div class="box" id="client-frequency">
         <div class="box-header with-border">
-          <h3 class="box-title">Top Clients</h3>
+          <h3 class="box-title">Top Clients (total)</h3>
+        </div>
+        <!-- /.box-header -->
+        <div class="box-body">
+            <div class="table-responsive">
+                <table class="table table-bordered">
+                  <tbody>
+                    <tr>
+                    <th>Client</th>
+                    <th>Requests</th>
+                    <th>Frequency</th>
+                    </tr>
+                  </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="overlay">
+          <i class="fa fa-refresh fa-spin"></i>
+        </div>
+        <!-- /.box-body -->
+      </div>
+      <!-- /.box -->
+    </div>
+    <!-- /.col -->
+    <!-- /.col -->
+    <div class="<?php echo $tablelayout; ?>">
+      <div class="box" id="client-frequency-blocked">
+        <div class="box-header with-border">
+          <h3 class="box-title">Top Clients (blocked only)</h3>
         </div>
         <!-- /.box-header -->
         <div class="box-body">

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -593,7 +593,7 @@ function updateTopClientsChart() {
                 }
 
                 url = "<a href=\"queries.php?client="+clientip+"\" title=\""+clientip+"\">"+clientname+"</a>";
-                percentage = data.top_sources_blocked[client] / data.dns_queries_today * 100;
+                percentage = data.top_sources_blocked[client] / data.ads_blocked_today * 100;
                 clientblockedtable.append("<tr> <td>" + url +
                     "</td> <td>" + data.top_sources_blocked[client] + "</td> <td> <div class=\"progress progress-sm\" title=\""+percentage.toFixed(1)+"% of " + data.dns_queries_today + "\"> <div class=\"progress-bar progress-bar-blue\" style=\"width: " +
                     percentage + "%\"></div> </div> </td> </tr> ");

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -535,8 +535,8 @@ function updateTopClientsChart() {
 
         // Clear tables before filling them with data
         $("#client-frequency td").parent().remove();
-        var clienttable =  $("#client-frequency").find("tbody:last");
-        var client, percentage, clientname, clientip;
+        var clienttable = $("#client-frequency").find("tbody:last");
+        var client, percentage, clientname, clientip, idx;
         for (client in data.top_sources) {
 
             if ({}.hasOwnProperty.call(data.top_sources, client)){
@@ -549,7 +549,7 @@ function updateTopClientsChart() {
                 client = escapeHtml(client);
                 if(client.indexOf("|") > -1)
                 {
-                    var idx = client.indexOf("|");
+                    idx = client.indexOf("|");
                     clientname = client.substr(0, idx);
                     clientip = client.substr(idx+1, client.length-idx);
                 }
@@ -569,8 +569,7 @@ function updateTopClientsChart() {
 
         // Clear tables before filling them with data
         $("#client-frequency-blocked td").parent().remove();
-        var clientblockedtable =  $("#client-frequency-blocked").find("tbody:last");
-        var client, percentage, clientname, clientip;
+        var clientblockedtable = $("#client-frequency-blocked").find("tbody:last");
         for (client in data.top_sources_blocked) {
 
             if ({}.hasOwnProperty.call(data.top_sources_blocked, client)){
@@ -583,7 +582,7 @@ function updateTopClientsChart() {
                 client = escapeHtml(client);
                 if(client.indexOf("|") > -1)
                 {
-                    var idx = client.indexOf("|");
+                    idx = client.indexOf("|");
                     clientname = client.substr(0, idx);
                     clientip = client.substr(idx+1, client.length-idx);
                 }

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -536,7 +536,7 @@ function updateTopClientsChart() {
         // Clear tables before filling them with data
         $("#client-frequency td").parent().remove();
         var clienttable = $("#client-frequency").find("tbody:last");
-        var client, percentage, clientname, clientip, idx;
+        var client, percentage, clientname, clientip, idx, url;
         for (client in data.top_sources) {
 
             if ({}.hasOwnProperty.call(data.top_sources, client)){
@@ -559,7 +559,7 @@ function updateTopClientsChart() {
                     clientip = client;
                 }
 
-                var url = "<a href=\"queries.php?client="+clientip+"\" title=\""+clientip+"\">"+clientname+"</a>";
+                url = "<a href=\"queries.php?client="+clientip+"\" title=\""+clientip+"\">"+clientname+"</a>";
                 percentage = data.top_sources[client] / data.dns_queries_today * 100;
                 clienttable.append("<tr> <td>" + url +
                     "</td> <td>" + data.top_sources[client] + "</td> <td> <div class=\"progress progress-sm\" title=\""+percentage.toFixed(1)+"% of " + data.dns_queries_today + "\"> <div class=\"progress-bar progress-bar-blue\" style=\"width: " +
@@ -592,7 +592,7 @@ function updateTopClientsChart() {
                     clientip = client;
                 }
 
-                var url = "<a href=\"queries.php?client="+clientip+"\" title=\""+clientip+"\">"+clientname+"</a>";
+                url = "<a href=\"queries.php?client="+clientip+"\" title=\""+clientip+"\">"+clientname+"</a>";
                 percentage = data.top_sources_blocked[client] / data.dns_queries_today * 100;
                 clientblockedtable.append("<tr> <td>" + url +
                     "</td> <td>" + data.top_sources_blocked[client] + "</td> <td> <div class=\"progress progress-sm\" title=\""+percentage.toFixed(1)+"% of " + data.dns_queries_today + "\"> <div class=\"progress-bar progress-bar-blue\" style=\"width: " +


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Add a fourth table listing the number of blocked queries per client:
![screenshot-2018-5-10 pi-hole admin console](https://user-images.githubusercontent.com/16748619/39871391-efee5f38-5464-11e8-9339-7cae304e009a.png)

Note that this is a feature request from [Discourse](https://discourse.pi-hole.net/t/top-blocked-domains-per-client/5055).

**How does this PR accomplish the above?:**

- Add new API endpoint `api.php?topClientsBlocked`
- Add new table to dashboard
- Extend existing "Top Clients" table JS code to also treat the new table (we get both datasets in one query). This is duplicating the functionality we already have for the other two tables (Top Domains/Top Ads) which basically follow the same logic.

**What documentation changes (if any) are needed to support this PR?:**

None