### PR TITLE
Ensure Top Clients (total) and Top Clients (blocked only) are always rendered on a new row

### DIFF
--- a/index.php
+++ b/index.php
@@ -274,6 +274,8 @@ else
       </div>
       <!-- /.box -->
     </div>
+</div>
+<div class="row">
     <!-- /.col -->
     <div class="<?php echo $tablelayout; ?>">
       <div class="box" id="client-frequency">


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
fix for issue #748 

**How does this PR accomplish the above?:**
closes off the `row` div after the first two tables, and then adds a new `row` div.

**What documentation changes (if any) are needed to support this PR?:**
n/a