### PR TITLE
Remove max line length in getResponseFTL

### DIFF
--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -37,7 +37,7 @@ function getResponseFTL()
 
 	while(true)
 	{
-		$out = fgets($socket, 128);
+		$out = fgets($socket);
 		if(strrpos($out,"---EOM---") !== false)
 			break;
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix issue found on Discourse: https://discourse.pi-hole.net/t/9544
This bug caused the clients over time graph to break when there were many clients and lots of activity.

**How does this PR accomplish the above?:**

Remove the maximum line length parameter when using `fgets` in `getResponseFTL`.

**What documentation changes (if any) are needed to support this PR?:**

None