### PR TITLE
Fix span that overlays Disable/Enable when sidebar collapsed

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -66,9 +66,11 @@ function piholeChange(action, duration)
         case "enable":
             btnStatus = $("#flip-status-enable");
             btnStatus.html("<i class='fa fa-spinner'> </i>");
+            btnStatus.css("zIndex", 0);
             $.getJSON("api.php?enable&token=" + token, function(data) {
                 if(data.status === "enabled") {
                     btnStatus.html("");
+                    btnStatus.css("zIndex", -1);
                     piholeChanged("enabled");
                 }
             });
@@ -77,9 +79,11 @@ function piholeChange(action, duration)
         case "disable":
             btnStatus = $("#flip-status-disable");
             btnStatus.html("<i class='fa fa-spinner'> </i>");
+            btnStatus.css("zIndex", 0);
             $.getJSON("api.php?disable=" + duration + "&token=" + token, function(data) {
                 if(data.status === "disabled") {
                     btnStatus.html("");
+                    btnStatus.css("zIndex", -1);
                     piholeChanged("disabled");
                     if(duration > 0)
                     {

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -461,7 +461,7 @@ if($auth) {
                     <span class="pull-right-container">
                       <i class="fa fa-angle-down pull-right" style="padding-right: 5px;"></i>
                     </span>
-                    <i class="fa fa-stop"></i> <span>Disable</span>&nbsp;&nbsp;&nbsp;<span id="flip-status-disable"></span>
+                    <i class="fa fa-stop"></i> <span>Disable</span>&nbsp;&nbsp;&nbsp;<span style="z-index: -1;" id="flip-status-disable"></span>
                   </a>
                   <ul class="treeview-menu">
                     <li>
@@ -493,7 +493,7 @@ if($auth) {
                     <!-- <a href="#" id="flip-status"><i class="fa fa-stop"></i> <span>Disable</span></a> -->
                 </li>
                 <li id="pihole-enable" class="treeview"<?php if ($pistatus == "1") { ?> hidden="true"<?php } ?>>
-                    <a href="#"><i class="fa fa-play"></i> <span id="enableLabel">Enable</span>&nbsp;&nbsp;&nbsp;<span id="flip-status-enable"></span></a>
+                    <a href="#"><i class="fa fa-play"></i> <span id="enableLabel">Enable</span>&nbsp;&nbsp;&nbsp;<span style="z-index: -1;" id="flip-status-enable"></span></a>
                 </li>
                 <!-- Tools -->
                 <li class="treeview <?php if(in_array($scriptname, array("gravity.php", "queryads.php", "auditlog.php", "taillog.php", "taillog-FTL.php", "debug.php"))){ ?>active<?php } ?>">


### PR DESCRIPTION
Signed-off-by: Yusef Ouda <yusef.ouda@outlook.com>

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Currently there is an issue when hovering over the enable/disable button on the sidebar when it is in the collapsed state. The word "Enable" or "Disable" is currently being cut off by a span element that does not need to be shown. It is used to display a loading icon when the button is clicked.
![image](https://user-images.githubusercontent.com/5180063/40216352-c0db99c8-5a2b-11e8-8ea0-3da6b21e033b.png)
![image](https://user-images.githubusercontent.com/5180063/40243700-8a8f7b90-5a86-11e8-9fdd-724ca37079ae.png)


**How does this PR accomplish the above?:**

This PR fixes the above issue by initially setting a z-index of -1 to the span, so it is hidden by default. In the footer.js code, when the button is either clicked to enable or disable, I added code that will change the z-index. It will initially set it to 0 (visible) while the spinner icon should be shown, and once finished, sets it back to -1.
![image](https://user-images.githubusercontent.com/5180063/40216426-2aca7b4c-5a2c-11e8-9fd2-697c778db199.png)
![image](https://user-images.githubusercontent.com/5180063/40243701-8be80282-5a86-11e8-81c5-ab3d73e845da.png)



**What documentation changes (if any) are needed to support this PR?:**

N/A