### PR TITLE
Fix query sorting by Reply, DNSSEC and Action

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -267,10 +267,10 @@ $(document).ready(function() {
             { "width" : "4%" },
             { "width" : "36%", "render": $.fn.dataTable.render.text() },
             { "width" : "8%", "render": $.fn.dataTable.render.text() },
-            { "width" : "10%" },
-            { "width" : "8%" },
-            { "width" : "4%" },
-            { "width" : "10%" }
+            { "width" : "10%", "orderData": 4 },
+            { "width" : "8%", "orderData": 6 },
+            { "width" : "4%", "orderData": 5 },
+            { "width" : "10%", "orderData": 4 }
         ],
         "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
         "columnDefs": [ {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

This aims to fix the sorting buttons on the Reply, DNSSEC and Action columns on the Queries page within the web UI.

At present, selecting sort by Reply (ascending or descending) sorts by DNSSEC status instead, selecting sort by DNSSEC status, sorts by Reply, and sorting by Action does nothing.

The sorting of DNSSEC was reported broken in #706 

**How does this PR accomplish the above?:**

This change provides information to jquery.dataTables to allow it to sort correctly, orderData was added to column specifications, allowing sorting to work when storage and display columns do not match.

(Since the "Reply" column was added in # 694, Reply is stored as column 6, and displayed as column 5, DNSSEC is stored as column 5, and displayed as column 6, and Action is derived from from column 4, and displayed as column 7). 

**What documentation changes (if any) are needed to support this PR?:**

None.

Signed-off-by: Rob Gill <rrobgill@protonmail.com>

