### PR TITLE
Fix 579 | Add interface option for administrator email address

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@
 <div class="row">
     <div class="col-lg-3 col-xs-12">
         <!-- small box -->
-        <div class="small-box bg-green">
+        <div class="small-box bg-green" id="total_queries" title="only A + AAAA queries">
             <div class="inner">
                 <p>Total queries (<span id="unique_clients">-</span> clients)</p>
                 <h3 class="statistic"><span id="dns_queries_today">---</span></h3>

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -739,6 +739,11 @@ function updateSummaryData(runOnce) {
             $("span#" + today).addClass("glow");
         });
 
+        if(data.hasOwnProperty("dns_queries_all_types"))
+        {
+            $("#total_queries").prop("title", "only A + AAAA queries (" + data["dns_queries_all_types"] + " in total)");
+        }
+
         window.setTimeout(function() {
             ["ads_blocked_today", "dns_queries_today", "domains_being_blocked", "ads_percentage_today", "unique_clients"].forEach(function(header, idx) {
                 var textData = (idx === 3 && data[header] !== "to") ? data[header] + "%" : data[header];

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -452,6 +452,21 @@ function readAdlists()
 				{
 					exec('sudo pihole -a -c');
 				}
+        $adminemail = trim($_POST["adminemail"])
+        // If we didn't get an email, don't try to save it
+        if(strlen($adminemail) == 0 || !isset($adminemail))
+        {
+          $adminemail = 'noadminemail'
+        }
+        // Make sure that any email we did get is valid, otherwise error
+        elseif (!filter_var($adminemail, FILTER_VALIDATE_EMAIL)) {
+          $error  .= "Administrator email address (".htmlspecialchars($adminemail).") is invalid!<br>";
+        }
+        // Save the email after we've validated it
+        else
+				{
+					exec('sudo pihole -a -e '.$adminemail);
+				}
 				if(isset($_POST["boxedlayout"]))
 				{
 					exec('sudo pihole -a layout boxed');

--- a/settings.php
+++ b/settings.php
@@ -880,6 +880,13 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                 } else {
                     $temperatureunit = "C";
                 }
+
+                // Administrator email address
+                if (isset($setupVars["ADMIN_EMAIL"])) {
+                    $adminemail = $setupVars["ADMIN_EMAIL"];
+                } else {
+                    $adminemail = "";
+                }
                 ?>
                 <div id="api" class="tab-pane fade<?php if($tab === "api"){ ?> in active<?php } ?>">
                     <div class="row">
@@ -977,6 +984,11 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                                       <?php if ($temperatureunit === "F"){ ?>checked<?php }
                                                                       ?>>Fahrenheit</label>
                                                     </div>
+                                                </div>
+                                                <h4>Administrator Email</h4>
+                                                <div class="form-group">
+                                                    <input type="text" class="form-control" name="adminemail"
+                                                           value="<?php echo htmlspecialchars($adminemail); ?>">
                                                 </div>
                                                 <input type="hidden" name="field" value="webUI">
                                                 <input type="hidden" name="token" value="<?php echo $token ?>">


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

This was not tested as I don't know how to easily spin this up in a VM, but not opposed to testing it with a bit of guidance on how to get it up and running. Due to the size of the change, it may not be worth the effort on your side, but figured I'd explain.

---

**What does this PR aim to accomplish?:**
Fix #579 — Adds Web UI option to control the `ADMIN_EMAIL` setupVars.conf value.

**How does this PR accomplish the above?:**
This PR adds a form input named `adminemail` which accepts a value. This is populated with the value of `ADMIN_EMAIL` if it exists. When submitted to the server, it is passed into `savesettings.php`

Within the save process, we first trim the email to ensure there is no extra whitespace being submitted causing false positives. We check if the value is set and the length is greater than 0, if not, we ignore the field.

If we have a set variable and it has length, we validate that it's a valid email address using `FILTER_VALIDATE_EMAIL`. This is based off of http://php.net/manual/en/filter.examples.validation.php

If it's not valid, add to the `$error` variable that this was not a valid email address, otherwise, execute the Pi-hole command to save the email address.

**What documentation changes (if any) are needed to support this PR?:**
N/A
