### PR TITLE
Fix a minor bug in api.php?getClientNames

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -354,10 +354,8 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
-			if(count($tmp) > 3 && strlen($tmp[3]) > 0)
-				$client_names[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
-			else
-				$client_names[$tmp[2]] = floatval($tmp[1]);
+			// returned data is in format: "ID count hostname"
+			$client_names[intval($tmp[0])] = $tmp[2];
 		}
 
 		$result = array('clients' => $client_names);

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -386,12 +386,7 @@ function updateClientsOverTime() {
         for (key in data.clients)
         {
             if (!{}.hasOwnProperty.call(data.clients, key)) continue;
-            if(key.indexOf("|") > -1)
-            {
-                var idx = key.indexOf("|");
-                key = key.substr(0, idx);
-            }
-            labels.push(key);
+            labels.push(data.clients[key]);
         }
         // Get colors from AdminLTE
         var colors = [];


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix a minor bug with `api.php?getClientNames`. FTL handles each client separately, i.e. `localhost` with once `127.0.0.1` and once `::1` are independent clients. However, the PHP API created a response in format "`hostname = count`" and hence duplicated hostnames got lost and the assignment of client names to data got scrambled in the Clients over Time graph.

**How does this PR accomplish the above?:**

This misbehaviour is fixed by changing the data returned by the API from "`hostname = count`" to "`ID = hostname`" with non-duplicated IDs. This is possible as we don't use the count in this graph and no other graph is using this API endpoint.
