### PR TITLE
Settings page: Display PHP errors

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -209,16 +209,11 @@ $(".nav-tabs a").on("shown.bs.tab", function (e) {
     window.scrollTo(0, 0);
 });
 
-// Auto dismissal for info and error notifications
+// Auto dismissal for info notifications
 $(document).ready(function(){
     var alInfo = $("#alInfo");
-    var alError = $("#alError");
     if(alInfo.length)
     {
         alInfo.delay(3000).fadeOut(2000, function() { alInfo.hide(); });
-    }
-    if(alError.length)
-    {
-        alError.delay(3000).fadeOut(2000, function() { alError.hide(); });
     }
 });

--- a/settings.php
+++ b/settings.php
@@ -19,6 +19,13 @@ else
 	$piholeFTLConf = array();
 }
 
+// Handling of PHP internal errors
+$last_error = error_get_last();
+if($last_error["type"] === E_WARNING || $last_error["type"] === E_ERROR)
+{
+	$error .= "PHP error (".htmlspecialchars($last_error["type"])."): ".htmlspecialchars($last_error["message"])." in ".htmlspecialchars($last_error["file"]).":".htmlspecialchars($last_error["line"]);
+}
+
 ?>
 <style type="text/css">
 	.tooltip-inner {

--- a/settings.php
+++ b/settings.php
@@ -23,7 +23,7 @@ else
 $last_error = error_get_last();
 if($last_error["type"] === E_WARNING || $last_error["type"] === E_ERROR)
 {
-	$error .= "PHP error (".htmlspecialchars($last_error["type"])."): ".htmlspecialchars($last_error["message"])." in ".htmlspecialchars($last_error["file"]).":".htmlspecialchars($last_error["line"]);
+	$error .= "There was a problem applying your settings.<br>Debugging information:<br>PHP error (".htmlspecialchars($last_error["type"])."): ".htmlspecialchars($last_error["message"])." in ".htmlspecialchars($last_error["file"]).":".htmlspecialchars($last_error["line"]);
 }
 
 ?>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Display PHP errors on the Settings page when they occur. This fixes a bug I have noticed.

Example:

![screenshot at 2018-06-03 11-14-25](https://user-images.githubusercontent.com/16748619/40885109-515380f0-6720-11e8-9929-175dc3437701.png)

The Settings page wasn't able to parse the FTL config file due to the stored Regex. Hence, a few settings page elements didn't work as expected. With the new error message handler, users will get informed about such a problem and can solve it.

This particular problem doesn't exist any more as we moved regex filters from `pihole-FTL.conf` into `regex.list`

**How does this PR accomplish the above?:**

Add a error message with precise location information (file:line) to the error header of the Settings page.

**What documentation changes (if any) are needed to support this PR?:**

None