### PR TITLE
Query Log: Remove DNSSEC column

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -140,7 +140,6 @@ if(strlen($showing) > 0)
                         <th>Client</th>
                         <th>Status</th>
                         <th>Reply</th>
-                        <th>DNSSEC</th>
                         <th>Action</th>
                     </tr>
                 </thead>
@@ -152,7 +151,6 @@ if(strlen($showing) > 0)
                         <th>Client</th>
                         <th>Status</th>
                         <th>Reply</th>
-                        <th>DNSSEC</th>
                         <th>Action</th>
                     </tr>
                 </tfoot>

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -190,7 +190,7 @@ $(document).ready(function() {
             {
                 blocked = true;
                 $(row).css("color","red");
-                $("td:eq(4)", row).html( "Pi-holed <br class='hidden-lg'>(wildcard)"+dnssec_status );
+                $("td:eq(4)", row).html( "Pi-holed <br class='hidden-lg'>(wildcard)");
                 $("td:eq(6)", row).html( "" );
             }
             else if (data[4] === "5")

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -145,72 +145,65 @@ $(document).ready(function() {
     tableApi = $("#all-queries").DataTable( {
         "rowCallback": function( row, data, index ){
             var blocked = false;
+
+            $dnssec_status = "";
+            if (data[5] === "1")
+            {
+                $dnssec_status = "<br><span style=\"color:green\">SECURE</span>";
+            }
+            else if (data[5] === "2")
+            {
+                $dnssec_status = "<br><span style=\"color:orange\">INSECURE</span>";
+            }
+            else if (data[5] === "3")
+            {
+                $dnssec_status = "<br><span style=\"color:red\">BOGUS</span>";
+            }
+            else if (data[5] === "4")
+            {
+                $dnssec_status = "<br><span style=\"color:red\">ABANDONED</span>";
+            }
+            else if (data[5] === "5")
+            {
+                $dnssec_status = "<br><span style=\"color:red\">?</span>";
+            }
             if (data[4] === "1")
             {
                 blocked = true;
                 $(row).css("color","red");
-                $("td:eq(4)", row).html( "Pi-holed" );
-                $("td:eq(7)", row).html( "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>" );
+                $("td:eq(4)", row).html( "Pi-holed"+$dnssec_status );
+                $("td:eq(6)", row).html( "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>" );
             }
             else if (data[4] === "2")
             {
                 $(row).css("color","green");
-                $("td:eq(4)", row).html( "OK <br class='hidden-lg'>(forwarded)" );
-                $("td:eq(7)", row).html( "<button style=\"color:red; white-space: nowrap;\"><i class=\"fa fa-ban\"></i> Blacklist</button>" );
+                $("td:eq(4)", row).html( "OK <br class='hidden-lg'>(forwarded)"+$dnssec_status );
+                $("td:eq(6)", row).html( "<button style=\"color:red; white-space: nowrap;\"><i class=\"fa fa-ban\"></i> Blacklist</button>" );
             }
             else if (data[4] === "3")
             {
                 $(row).css("color","green");
-                $("td:eq(4)", row).html( "OK <br class='hidden-lg'>(cached)" );
-                $("td:eq(7)", row).html( "<button style=\"color:red; white-space: nowrap;\"><i class=\"fa fa-ban\"></i> Blacklist</button>" );
+                $("td:eq(4)", row).html( "OK <br class='hidden-lg'>(cached)"+$dnssec_status );
+                $("td:eq(6)", row).html( "<button style=\"color:red; white-space: nowrap;\"><i class=\"fa fa-ban\"></i> Blacklist</button>" );
             }
             else if (data[4] === "4")
             {
                 blocked = true;
                 $(row).css("color","red");
-                $("td:eq(4)", row).html( "Pi-holed <br class='hidden-lg'>(wildcard)" );
-                $("td:eq(7)", row).html( "" );
+                $("td:eq(4)", row).html( "Pi-holed <br class='hidden-lg'>(wildcard)"+$dnssec_status );
+                $("td:eq(6)", row).html( "" );
             }
             else if (data[4] === "5")
             {
                 blocked = true;
                 $(row).css("color","red");
                 $("td:eq(4)", row).html( "Pi-holed <br class='hidden-lg'>(blacklist)" );
-                $("td:eq(7)", row).html( "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>" );
+                $("td:eq(6)", row).html( "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>" );
             }
             else
             {
                 $("td:eq(4)", row).html( "Unknown" );
-                $("td:eq(7)", row).html( "" );
-            }
-            if (data[5] === "1")
-            {
-                $("td:eq(6)", row).css("color","green");
-                $("td:eq(6)", row).html( "SECURE" );
-            }
-            else if (data[5] === "2")
-            {
-                $("td:eq(6)", row).css("color","orange");
-                $("td:eq(6)", row).html( "INSECURE" );
-            }
-            else if (data[5] === "3")
-            {
-                $("td:eq(6)", row).css("color","red");
-                $("td:eq(6)", row).html( "BOGUS" );
-            }
-            else if (data[5] === "4")
-            {
-                $("td:eq(6)", row).css("color","red");
-                $("td:eq(6)", row).html( "ABANDONED" );
-            }
-            else if (data[5] === "5")
-            {
-                $("td:eq(6)", row).css("color","red");
-                $("td:eq(6)", row).html( "?" );
-            }
-            else
-            {
-                $("td:eq(6)", row).html( "-" );
+                $("td:eq(6)", row).html( "" );
             }
 
             // Check for existance of sixth column and display only if not Pi-holed
@@ -267,9 +260,8 @@ $(document).ready(function() {
             { "width" : "4%" },
             { "width" : "36%", "render": $.fn.dataTable.render.text() },
             { "width" : "8%", "render": $.fn.dataTable.render.text() },
-            { "width" : "10%", "orderData": 4 },
+            { "width" : "14%", "orderData": 4 },
             { "width" : "8%", "orderData": 6 },
-            { "width" : "4%", "orderData": 5 },
             { "width" : "10%", "orderData": 4 }
         ],
         "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -146,51 +146,51 @@ $(document).ready(function() {
         "rowCallback": function( row, data, index ){
             var blocked = false;
 
-            $dnssec_status = "";
+            var dnssec_status = "";
             if (data[5] === "1")
             {
-                $dnssec_status = "<br><span style=\"color:green\">SECURE</span>";
+                dnssec_status = "<br><span style=\"color:green\">SECURE</span>";
             }
             else if (data[5] === "2")
             {
-                $dnssec_status = "<br><span style=\"color:orange\">INSECURE</span>";
+                dnssec_status = "<br><span style=\"color:orange\">INSECURE</span>";
             }
             else if (data[5] === "3")
             {
-                $dnssec_status = "<br><span style=\"color:red\">BOGUS</span>";
+                dnssec_status = "<br><span style=\"color:red\">BOGUS</span>";
             }
             else if (data[5] === "4")
             {
-                $dnssec_status = "<br><span style=\"color:red\">ABANDONED</span>";
+                dnssec_status = "<br><span style=\"color:red\">ABANDONED</span>";
             }
             else if (data[5] === "5")
             {
-                $dnssec_status = "<br><span style=\"color:red\">?</span>";
+                dnssec_status = "<br><span style=\"color:red\">?</span>";
             }
             if (data[4] === "1")
             {
                 blocked = true;
                 $(row).css("color","red");
-                $("td:eq(4)", row).html( "Pi-holed"+$dnssec_status );
+                $("td:eq(4)", row).html( "Pi-holed"+dnssec_status );
                 $("td:eq(6)", row).html( "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>" );
             }
             else if (data[4] === "2")
             {
                 $(row).css("color","green");
-                $("td:eq(4)", row).html( "OK <br class='hidden-lg'>(forwarded)"+$dnssec_status );
+                $("td:eq(4)", row).html( "OK <br class='hidden-lg'>(forwarded)"+dnssec_status );
                 $("td:eq(6)", row).html( "<button style=\"color:red; white-space: nowrap;\"><i class=\"fa fa-ban\"></i> Blacklist</button>" );
             }
             else if (data[4] === "3")
             {
                 $(row).css("color","green");
-                $("td:eq(4)", row).html( "OK <br class='hidden-lg'>(cached)"+$dnssec_status );
+                $("td:eq(4)", row).html( "OK <br class='hidden-lg'>(cached)"+dnssec_status );
                 $("td:eq(6)", row).html( "<button style=\"color:red; white-space: nowrap;\"><i class=\"fa fa-ban\"></i> Blacklist</button>" );
             }
             else if (data[4] === "4")
             {
                 blocked = true;
                 $(row).css("color","red");
-                $("td:eq(4)", row).html( "Pi-holed <br class='hidden-lg'>(wildcard)"+$dnssec_status );
+                $("td:eq(4)", row).html( "Pi-holed <br class='hidden-lg'>(wildcard)"+dnssec_status );
                 $("td:eq(6)", row).html( "" );
             }
             else if (data[4] === "5")


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Remove extra DNSSEC column. Instead, we integrate the DNSSEC result into the STATUS column if available:

![screenshot at 2018-06-03 11-31-50](https://user-images.githubusercontent.com/16748619/40885214-556aba1c-6722-11e8-9595-ab51a193c907.png)

**How does this PR accomplish the above?:**

Change the JS of the Query Log page and remove the (former) sixth column of the DataTables object.

**What documentation changes (if any) are needed to support this PR?:**

I don't think so, it should be fairly obvious to the guys using DNSSEC and stays out of the way for those that don't.