### PR TITLE
Use new `client-names` FTL response format

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -353,7 +353,11 @@ else
 		$client_names = array();
 		foreach($return as $line)
 		{
-			$client_names[] = $line;
+			$tmp = explode(" ", $line);
+			$client_names[] = array(
+				"name" => $tmp[0],
+				"ip" => $tmp[1]
+			);
 		}
 
 		$result = array('clients' => $client_names);

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -353,9 +353,7 @@ else
 		$client_names = array();
 		foreach($return as $line)
 		{
-			$tmp = explode(" ",$line);
-			// returned data is in format: "ID count hostname"
-			$client_names[intval($tmp[0])] = $tmp[2];
+			$client_names[] = $line;
 		}
 
 		$result = array('clients' => $client_names);

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -386,7 +386,7 @@ function updateClientsOverTime() {
         for (key in data.clients)
         {
             if (!{}.hasOwnProperty.call(data.clients, key)) continue;
-            labels.push(data.clients[key]);
+            labels.push(data.clients[key].name);
         }
         // Get colors from AdminLTE
         var colors = [];

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -386,7 +386,16 @@ function updateClientsOverTime() {
         for (key in data.clients)
         {
             if (!{}.hasOwnProperty.call(data.clients, key)) continue;
-            labels.push(data.clients[key].name);
+            var clientname;
+            if(data.clients[key].name.length > 0)
+            {
+                clientname = data.clients[key].name;
+            }
+            else
+            {
+                clientname = data.clients[key].ip;
+            }
+            labels.push(clientname);
         }
         // Get colors from AdminLTE
         var colors = [];


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Use the new `client-names` response format. See pi-hole/FTL#297

**How does this PR accomplish the above?:**

Change the parsing of the FTL response.

**What documentation changes (if any) are needed to support this PR?:**

None. The API output remains the same.