### PR TITLE
Use regex lists instead of wildcards for blocking 

### DIFF
--- a/help.php
+++ b/help.php
@@ -70,7 +70,7 @@
     <div class="col-md-12">
     <h2>White- / Blacklist</h2>
     <p>Add or remove domains (or subdomains) from the white-/blacklist. If a domain is added to e.g. the whitelist, any possible entry of the same domain will be automatically removed from the blacklist and vice versa.</p>
-    <p>Wildcard blacklisting is supported (entering <samp>something.de</samp> will block this domain including all subdomains like <samp>a.bb.c.999.something.de</samp>). Note that wildcard whitelisting is <em>not</em> supported.</p>
+    <p>Regex blacklisting is supported (entering <samp>^example.*$</samp> will block any domain starting with <samp>example</samp>). You can still whitelist specific domains even if the fall under a regex pattern.</p>
     <p>You can white-/blacklist multiple entries at a time if you separate the domains by spaces.</p>
     </div>
 </div>

--- a/help.php
+++ b/help.php
@@ -70,7 +70,7 @@
     <div class="col-md-12">
     <h2>White- / Blacklist</h2>
     <p>Add or remove domains (or subdomains) from the white-/blacklist. If a domain is added to e.g. the whitelist, any possible entry of the same domain will be automatically removed from the blacklist and vice versa.</p>
-    <p>Regex blacklisting is supported (entering <samp>^example.*$</samp> will block any domain starting with <samp>example</samp>). You can still whitelist specific domains even if the fall under a regex pattern.</p>
+    <p>Regex blacklisting is supported (entering <samp>^example/samp> will block any domain starting with <samp>example</samp>, see also our <a href="https://docs.pi-hole.net/ftldns/regex/" target="_blank">Regex documentation</a>). You can still whitelist specific domains even if the fall under a regex pattern.</p>
     <p>You can white-/blacklist multiple entries at a time if you separate the domains by spaces.</p>
     </div>
 </div>

--- a/help.php
+++ b/help.php
@@ -70,7 +70,7 @@
     <div class="col-md-12">
     <h2>White- / Blacklist</h2>
     <p>Add or remove domains (or subdomains) from the white-/blacklist. If a domain is added to e.g. the whitelist, any possible entry of the same domain will be automatically removed from the blacklist and vice versa.</p>
-    <p>Regex blacklisting is supported (entering <samp>^example/samp> will block any domain starting with <samp>example</samp>, see also our <a href="https://docs.pi-hole.net/ftldns/regex/" target="_blank">Regex documentation</a>). You can still whitelist specific domains even if the fall under a regex pattern.</p>
+    <p>Regex blacklisting is supported (entering <samp>^example</samp> will block any domain starting with <samp>example</samp>, see also our <a href="https://docs.pi-hole.net/ftldns/regex/" target="_blank">Regex documentation</a>). You can still whitelist specific domains even if they fall under a regex pattern.</p>
     <p>You can white-/blacklist multiple entries at a time if you separate the domains by spaces.</p>
     </div>
 </div>

--- a/list.php
+++ b/list.php
@@ -67,7 +67,7 @@ function getFullName() {
 <?php } ?>
 <ul class="list-group" id="list"></ul>
 <?php if($list === "black") { ?>
-<h3>Regex &amp; Wildcard blocking</h3>
+<h3><a href="https://docs.pi-hole.net/ftldns/regex/" target="_blank" title="Click for Pi-hole Regex documentation">Regex</a> &amp; Wildcard blocking</h3>
 <ul class="list-group" id="list-regex"></ul>
 <?php } ?>
 

--- a/list.php
+++ b/list.php
@@ -1,4 +1,4 @@
-<?php /* 
+<?php /*
 *    Pi-hole: A black hole for Internet advertisements
 *    (c) 2017 Pi-hole, LLC (https://pi-hole.net)
 *    Network-wide ad blocking via your own hardware.
@@ -44,9 +44,6 @@ function getFullName() {
         <button id="btnRefresh" class="btn btn-default" type="button"><i class="fa fa-refresh"></i></button>
     </span>
 </div>
-<?php if($list === "white") { ?>
-    <p>Note: Whitelisting a subdomain of a wildcard blocked domain is not possible.</p>    
-<?php } ?>
 
 <!-- Alerts -->
 <div id="alInfo" class="alert alert-info alert-dismissible fade in" role="alert" hidden="true">
@@ -69,8 +66,8 @@ function getFullName() {
 <?php } ?>
 <ul class="list-group" id="list"></ul>
 <?php if($list === "black") { ?>
-<h3>Wildcard blocking</h3>
-<ul class="list-group" id="list-wildcard"></ul>
+<h3>Regex blocking</h3>
+<ul class="list-group" id="list-regex"></ul>
 <?php } ?>
 
 <?php

--- a/list.php
+++ b/list.php
@@ -37,7 +37,7 @@ function getFullName() {
     <span class="input-group-btn">
     <?php if($list === "black") { ?>
         <button id="btnAdd" class="btn btn-default" type="button">Add (exact)</button>
-        <button id="btnAddWildcard" class="btn btn-default" type="button">Add (wildcard)</button>
+        <button id="btnAddWildcard" class="btn btn-default" type="button">Add (regex)</button>
     <?php }else{ ?>
         <button id="btnAdd" class="btn btn-default" type="button">Add</button>
     <?php } ?>

--- a/list.php
+++ b/list.php
@@ -37,7 +37,8 @@ function getFullName() {
     <span class="input-group-btn">
     <?php if($list === "black") { ?>
         <button id="btnAdd" class="btn btn-default" type="button">Add (exact)</button>
-        <button id="btnAddWildcard" class="btn btn-default" type="button">Add (regex)</button>
+        <button id="btnAddWildcard" class="btn btn-default" type="button">Add (wildcard)</button>
+        <button id="btnAddRegex" class="btn btn-default" type="button">Add (regex)</button>
     <?php }else{ ?>
         <button id="btnAdd" class="btn btn-default" type="button">Add</button>
     <?php } ?>
@@ -66,7 +67,7 @@ function getFullName() {
 <?php } ?>
 <ul class="list-group" id="list"></ul>
 <?php if($list === "black") { ?>
-<h3>Regex blocking</h3>
+<h3>Regex &amp; Wildcard blocking</h3>
 <ul class="list-group" id="list-regex"></ul>
 <?php } ?>
 

--- a/scripts/pi-hole/js/list.js
+++ b/scripts/pi-hole/js/list.js
@@ -13,13 +13,14 @@ var listType = $("#list-type").html();
 var fullName = listType === "white" ? "Whitelist" : "Blacklist";
 
 function sub(index, entry, arg) {
-    var domain = $("#"+index);
+    var domain = $("#list #"+index);
     var locallistType = listType;
-    domain.hide("highlight");
-    if(arg === "wild")
+    if(arg === "regex")
     {
-        locallistType = "wild";
+        locallistType = "regex";
+        domain = $("#list-regex #"+index);
     }
+    domain.hide("highlight");
     $.ajax({
         url: "scripts/pi-hole/php/sub.php",
         method: "post",
@@ -104,7 +105,7 @@ function refresh(fade) {
                         "<span class=\"glyphicon glyphicon-trash\"></span></button></li>");
                         // Handle button
                         $("#list-regex #"+index+"").on("click", "button", function() {
-                            sub(index, entry, "wild");
+                            sub(index, entry, "regex");
                         });
                     });
                 }

--- a/scripts/pi-hole/js/list.js
+++ b/scripts/pi-hole/js/list.js
@@ -108,18 +108,6 @@ function refresh(fade) {
                         });
                     });
                 }
-
-
-/*
-                        // Blacklist: exact + wildcard array
-                        entry = entry.substr(1, entry.length - 1);
-
-            if(data.length === 2)
-            {
-                    }
-                    else
-                    {
-*/
             }
             list.fadeIn(100);
             if(listw)

--- a/scripts/pi-hole/js/list.js
+++ b/scripts/pi-hole/js/list.js
@@ -146,7 +146,8 @@ function add(arg) {
         method: "post",
         data: {"domain":domain.val().trim(), "list":locallistType, "token":token},
         success: function(response) {
-          if (response.indexOf("] Pi-hole blocking is ") === -1) {
+          if (locallistType !== "wild" && response.indexOf("] Pi-hole blocking is ") === -1 ||
+              locallistType === "wild" && response.length > 1) {
             alFailure.show();
             err.html(response);
             alFailure.delay(4000).fadeOut(2000, function() {

--- a/scripts/pi-hole/js/list.js
+++ b/scripts/pi-hole/js/list.js
@@ -126,12 +126,14 @@ window.onload = refresh(false);
 function add(arg) {
     var locallistType = listType;
     var domain = $("#domain");
+    var wild = false;
     if(domain.val().length === 0){
         return;
     }
-    if(arg === "wild")
+    if(arg === "wild" || arg === "regex")
     {
-        locallistType = "wild";
+        locallistType = arg;
+        wild = true;
     }
 
     var alInfo = $("#alInfo");
@@ -146,8 +148,8 @@ function add(arg) {
         method: "post",
         data: {"domain":domain.val().trim(), "list":locallistType, "token":token},
         success: function(response) {
-          if (locallistType !== "wild" && response.indexOf("] Pi-hole blocking is ") === -1 ||
-              locallistType === "wild" && response.length > 1) {
+          if (!wild && response.indexOf("] Pi-hole blocking is ") === -1 ||
+               wild && response.length > 1) {
             alFailure.show();
             err.html(response);
             alFailure.delay(4000).fadeOut(2000, function() {
@@ -198,6 +200,10 @@ $("#btnAdd").on("click", function() {
 
 $("#btnAddWildcard").on("click", function() {
     add("wild");
+});
+
+$("#btnAddRegex").on("click", function() {
+    add("regex");
 });
 
 $("#btnRefresh").on("click", function() {

--- a/scripts/pi-hole/js/list.js
+++ b/scripts/pi-hole/js/list.js
@@ -42,7 +42,7 @@ function refresh(fade) {
     var list = $("#list");
     if(listType === "black")
     {
-        listw = $("#list-wildcard");
+        listw = $("#list-regex");
     }
     if(fade) {
         list.fadeOut(100);
@@ -61,7 +61,7 @@ function refresh(fade) {
             {
                 listw.html("");
             }
-            var data = JSON.parse(response).sort();
+            var data = JSON.parse(response);
 
             if(data.length === 0) {
                 $("h3").hide();
@@ -74,37 +74,52 @@ function refresh(fade) {
                     list.html("<div class=\"alert alert-info\" role=\"alert\">Your " + fullName + " is empty!</div>");
                 }
             }
-            else {
+            else
+            {
                 $("h3").show();
-                data.forEach(function (entry, index) {
-                    if(entry.substr(0,1) === "*")
-                    {
-                        // Wildcard entry
-                        // remove leading *
-                        entry = entry.substr(1, entry.length - 1);
+                data[0] = data[0].sort();
+                data[0].forEach(function (entry, index) {
+                    // Whitelist entry or Blacklist (exact entry) are in the zero-th
+                    // array returned by get.php
+                    list.append(
+                    "<li id=\"" + index + "\" class=\"list-group-item clearfix\">" + entry +
+                    "<button class=\"btn btn-danger btn-xs pull-right\" type=\"button\">" +
+                    "<span class=\"glyphicon glyphicon-trash\"></span></button></li>");
+                    // Handle button
+                    $("#list #"+index+"").on("click", "button", function() {
+                        sub(index, entry, "exact");
+                    });
+                });
+
+                // Add regex domains if present in returned list data
+                if(data.length === 2)
+                {
+                    data[1] = data[1].sort();
+                    data[1].forEach(function (entry, index) {
+                        // Whitelist entry or Blacklist (exact entry) are in the zero-th
+                        // array returned by get.php
                         listw.append(
                         "<li id=\"" + index + "\" class=\"list-group-item clearfix\">" + entry +
                         "<button class=\"btn btn-danger btn-xs pull-right\" type=\"button\">" +
                         "<span class=\"glyphicon glyphicon-trash\"></span></button></li>");
                         // Handle button
-                        $("#list-wildcard #"+index+"").on("click", "button", function() {
+                        $("#list-regex #"+index+"").on("click", "button", function() {
                             sub(index, entry, "wild");
                         });
+                    });
+                }
+
+
+/*
+                        // Blacklist: exact + wildcard array
+                        entry = entry.substr(1, entry.length - 1);
+
+            if(data.length === 2)
+            {
                     }
                     else
                     {
-                        // Normal entry
-                        list.append(
-                        "<li id=\"" + index + "\" class=\"list-group-item clearfix\">" + entry +
-                        "<button class=\"btn btn-danger btn-xs pull-right\" type=\"button\">" +
-                        "<span class=\"glyphicon glyphicon-trash\"></span></button></li>");
-                        // Handle button
-                        $("#list #"+index+"").on("click", "button", function() {
-                            sub(index, entry, "exact");
-                        });
-                    }
-
-                });
+*/
             }
             list.fadeIn(100);
             if(listw)

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -274,7 +274,7 @@ $(document).ready(function() {
             // Receive previous state from client's local storage area
             var data = localStorage.getItem("query_log_table");
             // Return if not available
-            if(data === null) return null;
+            if(data === null){ return null; }
             // Ensure that we always start on the first page (most recent query)
             data = JSON.parse(data);
             data["start"] = 0;

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -273,6 +273,23 @@ $(document).ready(function() {
             { "width" : "10%", "orderData": 4 }
         ],
         "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+        "stateSave": true,
+        stateSaveCallback: function(settings, data) {
+            // Store current state in client's local storage area
+            localStorage.setItem("query_log_table", JSON.stringify(data));
+        },
+        stateLoadCallback: function(settings) {
+            // Receive previous state from client's local storage area
+            var data = localStorage.getItem("query_log_table");
+            // Return if not available
+            if(data === null) return null;
+            // Ensure that we always start on the first page (most recent query)
+            data = JSON.parse(data);
+            data["start"] = 0;
+            console.log(data);
+            // Apply loaded state to table
+            return data;
+        },
         "columnDefs": [ {
             "targets": -1,
             "data": null,

--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -55,8 +55,10 @@ switch($type) {
         $domain = str_replace(".","\.",$_POST['domain']);
         // Add regex filter for legacy wildcard behavior
         add_regex("((^)|(\.))".$domain."$");
+        break;
     case "regex":
         add_regex($_POST['domain']);
+        break;
     case "audit":
         echo exec("sudo pihole -a audit ${_POST['domain']}");
         break;

--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -20,7 +20,7 @@ function add_regex($regex)
     if(file_put_contents($regexfile, "\n".$regex, FILE_APPEND) === FALSE)
     {
         $err = error_get_last()["message"];
-        echo "Unable to add regex \"".htmlspecialchars($_POST['domain'])."\" to ${regexfile}<br>Error message: $err";
+        echo "Unable to add regex \"".htmlspecialchars($regex)."\" to ${regexfile}<br>Error message: $err";
     }
     else
     {

--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -34,7 +34,7 @@ switch($type) {
         }
         break;
     case "wild":
-        if(file_put_contents($regexfile, $_POST['domain']."\n", FILE_APPEND) === FALSE)
+        if(file_put_contents($regexfile, "\n".$_POST['domain'], FILE_APPEND) === FALSE)
         {
             $err = error_get_last()["message"];
             echo "Unable to add regex \"".htmlspecialchars($_POST['domain'])."\" to ${regexfile}<br>Error message: $err";

--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -39,6 +39,13 @@ switch($type) {
             $err = error_get_last()["message"];
             echo "Unable to add regex \"".htmlspecialchars($_POST['domain'])."\" to ${regexfile}<br>Error message: $err";
         }
+        else
+        {
+            // Send SIGHUP to pihole-FTL using a frontend command
+            // to force reloading of the regex domains
+            // This will also wipe the resolver's cache
+            echo exec("sudo pihole restartdns reload");
+        }
     case "audit":
         echo exec("sudo pihole -a audit ${_POST['domain']}");
         break;

--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -34,12 +34,10 @@ switch($type) {
         }
         break;
     case "wild":
-        if(!isset($_POST["auditlog"]))
-            echo exec("sudo pihole -wild -q ${_POST['domain']}");
-        else
+        if(file_put_contents($regexfile, $_POST['domain']."\n", FILE_APPEND) === FALSE)
         {
-            echo exec("sudo pihole -wild -q -n ${_POST['domain']}");
-            echo exec("sudo pihole -a audit ${_POST['domain']}");
+            $err = error_get_last()["message"];
+            echo "Unable to add regex \"".htmlspecialchars($_POST['domain'])."\" to ${regexfile}<br>Error message: $err";
         }
     case "audit":
         echo exec("sudo pihole -a audit ${_POST['domain']}");

--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -139,7 +139,7 @@ function list_verify($type) {
     // valid domain for regex expressions
     // Regex filters are validated by FTL
     // on import and skipped if invalid
-    if($_POST['list'] !== "wild")
+    if($_POST['list'] !== "regex")
     {
         check_domain();
     }

--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -11,6 +11,7 @@ $ERRORLOG = getenv('PHP_ERROR_LOG');
 if (empty($ERRORLOG)) {
     $ERRORLOG = '/var/log/lighttpd/error.log';
 }
+$regexfile = "/etc/pihole/regex.list";
 
 function pi_log($message) {
     error_log(date('Y-m-d H:i:s') . ': ' . $message . "\n", 3, $GLOBALS['ERRORLOG']);
@@ -133,6 +134,14 @@ function list_verify($type) {
     {
         log_and_die("Not allowed!");
     }
-    check_domain();
+
+    // Don't check if the added item is a
+    // valid domain for regex expressions
+    // Regex filters are validated by FTL
+    // on import and skipped if invalid
+    if($_POST['list'] !== "wild")
+    {
+        check_domain();
+    }
 }
 ?>

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -12,51 +12,39 @@ if(!isset($_GET['list']))
 
 $listtype = $_GET['list'];
 
+$basedir = "/etc/pihole/";
+
 require "func.php";
 
 switch ($listtype) {
-	case "white":
-		$list = getListContent("white");
-		break;
+    case "white":
+        $list = array(getListContent("whitelist.txt"));
+        break;
 
-	case "black":
-		$list = array_merge(getListContent("black"),getWildcardListContent());
-		break;
+    case "black":
+        $exact = array(getListContent("blacklist.txt"));
+        $regex = array(getListContent("regex.list"));
+        $list = array_merge($exact, $regex);
+        break;
 
-	default:
-		die("Invalid list parameter");
-		break;
+    default:
+        die("Invalid list parameter");
+        break;
 }
 
 
-function getListContent($type) {
-    $rawList = file_get_contents(checkfile("/etc/pihole/".$type."list.txt"));
+function getListContent($listname) {
+    global $basedir;
+    $rawList = file_get_contents(checkfile($basedir.$listname));
     $list = explode("\n", $rawList);
 
     // Get rid of empty lines
     for($i = sizeof($list)-1; $i >= 0; $i--) {
-        if($list[$i] == "")
+        if(strlen($list[$i]) < 1)
             unset($list[$i]);
     }
 
     return $list;
-
-}
-
-function getWildcardListContent() {
-    $rawList = file_get_contents(checkfile("/etc/dnsmasq.d/03-pihole-wildcard.conf"));
-    $wclist = explode("\n", $rawList);
-    $list = [];
-
-    foreach ($wclist as $entry) {
-        $expl = explode("/", $entry);
-        if(count($expl) == 3)
-        {
-            array_push($list,"*${expl[1]}");
-        }
-    }
-
-    return array_unique($list);
 
 }
 

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -22,9 +22,9 @@ switch ($listtype) {
         break;
 
     case "black":
-        $exact = array(getListContent("blacklist.txt"));
-        $regex = array(getListContent("regex.list"));
-        $list = array_merge($exact, $regex);
+        $exact = getListContent("blacklist.txt");
+        $regex = getListContent("regex.list");
+        $list = array($exact, $regex);
         break;
 
     default:

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -44,7 +44,10 @@ function getListContent($listname) {
             unset($list[$i]);
     }
 
-    return $list;
+    // Re-index list after possible unset() activity
+    $newlist = array_values($list);
+
+    return $newlist;
 
 }
 

--- a/scripts/pi-hole/php/sub.php
+++ b/scripts/pi-hole/php/sub.php
@@ -28,12 +28,10 @@ switch($type) {
             echo "Unable to read ${regexfile}<br>Error message: $err";
         }
 
-        // Replace regex with empty line ...
-        $list = str_replace($_POST['domain'], '', $list);
-        // ... and remove all empty lines from the file
-        $tmp = explode("\n", $list);
-        $tmp = array_filter($tmp);
-        $list = implode("\n", $tmp);
+        // Remove the regex and any empty lines from the list
+        $list = explode("\n", $list);
+        $list = array_diff($list, array($_POST['domain'], ""));
+        $list = implode("\n", $list);
 
         if(file_put_contents($regexfile, $list) === FALSE)
         {

--- a/scripts/pi-hole/php/sub.php
+++ b/scripts/pi-hole/php/sub.php
@@ -40,6 +40,13 @@ switch($type) {
             $err = error_get_last()["message"];
             echo "Unable to remove regex \"".htmlspecialchars($_POST['domain'])."\" from ${regexfile}<br>Error message: $err";
         }
+        else
+        {
+            // Send SIGHUP to pihole-FTL using a frontend command
+            // to force reloading of the regex domains
+            // This will also wipe the resolver's cache
+            echo exec("sudo pihole restartdns reload");
+        }
         break;
 }
 

--- a/scripts/pi-hole/php/sub.php
+++ b/scripts/pi-hole/php/sub.php
@@ -34,6 +34,8 @@ switch($type) {
         $tmp = explode("\n", $list);
         $tmp = array_filter($tmp);
         $list = implode("\n", $tmp);
+        // ... and add a newline to the end
+        $list .= "\n";
 
         if(file_put_contents($regexfile, $list) === FALSE)
         {

--- a/scripts/pi-hole/php/sub.php
+++ b/scripts/pi-hole/php/sub.php
@@ -34,8 +34,6 @@ switch($type) {
         $tmp = explode("\n", $list);
         $tmp = array_filter($tmp);
         $list = implode("\n", $tmp);
-        // ... and add a newline to the end
-        $list .= "\n";
 
         if(file_put_contents($regexfile, $list) === FALSE)
         {

--- a/scripts/pi-hole/php/sub.php
+++ b/scripts/pi-hole/php/sub.php
@@ -21,7 +21,7 @@ switch($type) {
     case "black":
         exec("sudo pihole -b -q -d ${_POST['domain']}");
         break;
-    case "wild":
+    case "regex":
         if(($list = file_get_contents($regexfile)) === FALSE)
         {
             $err = error_get_last()["message"];

--- a/scripts/pi-hole/php/sub.php
+++ b/scripts/pi-hole/php/sub.php
@@ -22,7 +22,24 @@ switch($type) {
         exec("sudo pihole -b -q -d ${_POST['domain']}");
         break;
     case "wild":
-        exec("sudo pihole -wild -q -d ${_POST['domain']}");
+        if(($list = file_get_contents($regexfile)) === FALSE)
+        {
+            $err = error_get_last()["message"];
+            echo "Unable to read ${regexfile}<br>Error message: $err";
+        }
+
+        // Replace regex with empty line ...
+        $list = str_replace($_POST['domain'], '', $list);
+        // ... and remove all empty lines from the file
+        $tmp = explode("\n", $list);
+        $tmp = array_filter($tmp);
+        $list = implode("\n", $tmp);
+
+        if(file_put_contents($regexfile, $list) === FALSE)
+        {
+            $err = error_get_last()["message"];
+            echo "Unable to remove regex \"".htmlspecialchars($_POST['domain'])."\" from ${regexfile}<br>Error message: $err";
+        }
         break;
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Change the web interface to support wildcard blocking through *FTL*DNS's regex filters. This is much more flexible than what we used before (defining zones in a `dnsmasq` config file) and replaces this method.

**How does this PR accomplish the above?:**

Use regex filters instead of building a `dnsmasq` config file.

**What documentation changes (if any) are needed to support this PR?:**

Probably, needs to be identified.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.