### PR TITLE
Warn if privacy level > 0 but query logging activated

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -1036,6 +1036,9 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                     </div>
                                                 </div>
                                                 <p>The privacy level may be changed at any time without having to restart the DNS resolver. However, note that queries with (partially) hidden details cannot be disclosed with a subsequent reduction of the privacy level.</p>
+                                                <?php if($privacylevel > 0 && $piHoleLogging){ ?>
+                                                <p class="lookatme">Warning: Pi-hole's query logging is activated. Although the dashboard will hide the requested details, all queries are still fully logged to the pihole.log file.</p>
+                                                <?php } ?>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Display a warning if users specifies a privacy level > 0 but still has query logging enabled.
![screenshot at 2018-07-04 23-00-28](https://user-images.githubusercontent.com/16748619/42294033-62b389ae-7fde-11e8-8378-21eedb7f7899.png)


**How does this PR accomplish the above?:**

`if(privacy_level > 0 && query_logging == enabled){ show warning }`

**What documentation changes (if any) are needed to support this PR?:**

No