### PR TITLE
Add regex support for Teleporter

### DIFF
--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -14,23 +14,6 @@ $type = $_POST['list'];
 // All of the verification for list editing
 list_verify($type);
 
-function add_regex($regex)
-{
-    global $regexfile;
-    if(file_put_contents($regexfile, "\n".$regex, FILE_APPEND) === FALSE)
-    {
-        $err = error_get_last()["message"];
-        echo "Unable to add regex \"".htmlspecialchars($regex)."\" to ${regexfile}<br>Error message: $err";
-    }
-    else
-    {
-        // Send SIGHUP to pihole-FTL using a frontend command
-        // to force reloading of the regex domains
-        // This will also wipe the resolver's cache
-        echo exec("sudo pihole restartdns reload");
-    }
-}
-
 switch($type) {
     case "white":
         if(!isset($_POST["auditlog"]))

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -45,4 +45,21 @@ if(!function_exists('hash_equals')) {
    }
 }
 
+function add_regex($regex)
+{
+    global $regexfile;
+    if(file_put_contents($regexfile, "\n".$regex, FILE_APPEND) === FALSE)
+    {
+        $err = error_get_last()["message"];
+        echo "Unable to add regex \"".htmlspecialchars($regex)."\" to ${regexfile}<br>Error message: $err";
+    }
+    else
+    {
+        // Send SIGHUP to pihole-FTL using a frontend command
+        // to force reloading of the regex domains
+        // This will also wipe the resolver's cache
+        echo exec("sudo pihole restartdns reload");
+    }
+}
+
 ?>

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -45,10 +45,10 @@ if(!function_exists('hash_equals')) {
    }
 }
 
-function add_regex($regex)
+function add_regex($regex, $mode=FILE_APPEND, $append="\n")
 {
     global $regexfile;
-    if(file_put_contents($regexfile, "\n".$regex, FILE_APPEND) === FALSE)
+    if(file_put_contents($regexfile, $append.$regex, $mode) === FALSE)
     {
         $err = error_get_last()["message"];
         echo "Unable to add regex \"".htmlspecialchars($regex)."\" to ${regexfile}<br>Error message: $err";

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -113,6 +113,7 @@ if(isset($_POST["action"]))
 				exec("sudo pihole -b -q -nr ".implode(" ", $blacklist));
 				$importedsomething = true;
 			}
+
 			if(isset($_POST["whitelist"]) && $file->getFilename() === "whitelist.txt")
 			{
 				$whitelist = process_file(file_get_contents($file));
@@ -124,10 +125,11 @@ if(isset($_POST["action"]))
 
 			if(isset($_POST["regexlist"]) && $file->getFilename() === "regex.list")
 			{
-				$regexlist = process_file(file_get_contents($file),false);
+				$regexraw = file_get_contents($file);
+				$regexlist = process_file($regexraw,false);
 				echo "Processing regex.list (".count($regexlist)." entries)<br>\n";
-				exec("sudo pihole --regex -nr --nuke");
-				exec("sudo pihole --regex -q -nr ".implode(" ", $regexlist));
+				// NULL = overwrite (or create) the regex filter file
+				add_regex($regexraw, NULL,"");
 				$importedsomething = true;
 			}
 

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -66,27 +66,6 @@ function check_domains($domains)
 	}
 }
 
-function getWildcardListContent() {
-	if(file_exists("/etc/dnsmasq.d/03-pihole-wildcard.conf"))
-	{
-		$rawList = file_get_contents("/etc/dnsmasq.d/03-pihole-wildcard.conf");
-		$wclist = explode("\n", $rawList);
-		$list = [];
-
-		foreach ($wclist as $entry) {
-			$expl = explode("/", $entry);
-			if(count($expl) == 3)
-			{
-				array_push($list,$expl[1]);
-			}
-		}
-
-		return implode("\n",array_unique($list));
-	}
-
-	return "";
-}
-
 if(isset($_POST["action"]))
 {
 	if($_FILES["zip_file"]["name"] && $_POST["action"] == "in")
@@ -177,9 +156,9 @@ else
 	archive_add_file("/etc/pihole/","adlists.list");
 	archive_add_file("/etc/pihole/","setupVars.conf");
 	archive_add_file("/etc/pihole/","auditlog.list");
+	archive_add_file("/etc/pihole/","regex.list");
 	archive_add_directory("/etc/dnsmasq.d/");
 
-	$archive["wildcardblocking.txt"] = getWildcardListContent();
 	$archive->compress(Phar::GZ); // Creates a gziped copy
 	unlink($archive_file_name); // Unlink original tar file as it is not needed anymore
 	$archive_file_name .= ".gz"; // Append ".gz" extension to ".tar"

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -43,7 +43,7 @@ function limit_length(&$item, $key)
 	$item = substr($item, 0, 253);
 }
 
-function process_file($contents)
+function process_file($contents,$check=True)
 {
 	$domains = array_filter(explode("\n",$contents));
 
@@ -51,8 +51,12 @@ function process_file($contents)
 	// function to every member of the array of domains
 	array_walk($domains, "limit_length");
 
-	// Check validity of domains (after possible clipping)
-	check_domains($domains);
+	// Check validity of domains (don't do it for regex filters)
+	if($check)
+	{
+		check_domains($domains);
+	}
+
 	return $domains;
 }
 
@@ -118,12 +122,12 @@ if(isset($_POST["action"]))
 				$importedsomething = true;
 			}
 
-			if(isset($_POST["wildlist"]) && $file->getFilename() === "wildcardblocking.txt")
+			if(isset($_POST["regexlist"]) && $file->getFilename() === "regex.list")
 			{
-				$wildlist = process_file(file_get_contents($file));
-				echo "Processing wildcardblocking.txt<br>\n";
-				exec("sudo pihole -wild -nr --nuke");
-				exec("sudo pihole -wild -q -nr ".implode(" ", $wildlist));
+				$regexlist = process_file(file_get_contents($file),false);
+				echo "Processing regex.list<br>\n";
+				exec("sudo pihole --regex -nr --nuke");
+				exec("sudo pihole --regex -q -nr ".implode(" ", $regexlist));
 				$importedsomething = true;
 			}
 			if($importedsomething)

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -108,7 +108,7 @@ if(isset($_POST["action"]))
 			if(isset($_POST["blacklist"]) && $file->getFilename() === "blacklist.txt")
 			{
 				$blacklist = process_file(file_get_contents($file));
-				echo "Processing blacklist.txt<br>\n";
+				echo "Processing blacklist.txt (".count($blacklist)." entries)<br>\n";
 				exec("sudo pihole -b -nr --nuke");
 				exec("sudo pihole -b -q -nr ".implode(" ", $blacklist));
 				$importedsomething = true;
@@ -116,7 +116,7 @@ if(isset($_POST["action"]))
 			if(isset($_POST["whitelist"]) && $file->getFilename() === "whitelist.txt")
 			{
 				$whitelist = process_file(file_get_contents($file));
-				echo "Processing whitelist.txt<br>\n";
+				echo "Processing whitelist.txt (".count($whitelist)." entries)<br>\n";
 				exec("sudo pihole -w -nr --nuke");
 				exec("sudo pihole -w -q -nr ".implode(" ", $whitelist));
 				$importedsomething = true;
@@ -125,7 +125,7 @@ if(isset($_POST["action"]))
 			if(isset($_POST["regexlist"]) && $file->getFilename() === "regex.list")
 			{
 				$regexlist = process_file(file_get_contents($file),false);
-				echo "Processing regex.list<br>\n";
+				echo "Processing regex.list (".count($regexlist)." entries)<br>\n";
 				exec("sudo pihole --regex -nr --nuke");
 				exec("sudo pihole --regex -q -nr ".implode(" ", $regexlist));
 				$importedsomething = true;

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -130,6 +130,17 @@ if(isset($_POST["action"]))
 				exec("sudo pihole --regex -q -nr ".implode(" ", $regexlist));
 				$importedsomething = true;
 			}
+
+			// Also try to import legacy wildcard list if found
+			if(isset($_POST["regexlist"]) && $file->getFilename() === "wildcardblocking.txt")
+			{
+				$wildlist = process_file(file_get_contents($file));
+				echo "Processing wildcardblocking.txt (".count($wildlist)." entries)<br>\n";
+				exec("sudo pihole --wild -nr --nuke");
+				exec("sudo pihole --wild -q -nr ".implode(" ", $wildlist));
+				$importedsomething = true;
+			}
+
 			if($importedsomething)
 			{
 				exec("sudo pihole restartdns");

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -14,14 +14,14 @@ if (php_sapi_name() !== "cli") {
 	check_csrf(isset($_POST["token"]) ? $_POST["token"] : "");
 }
 
-function archive_add_file($path,$name)
+function archive_add_file($path,$name,$subdir="")
 {
 	global $archive;
 	if(file_exists($path.$name))
-		$archive[$name] = file_get_contents($path.$name);
+		$archive[$subdir.$name] = file_get_contents($path.$name);
 }
 
-function archive_add_directory($path)
+function archive_add_directory($path,$subdir="")
 {
 	if($dir = opendir($path))
 	{
@@ -29,7 +29,7 @@ function archive_add_directory($path)
 		{
 			if($entry !== "." && $entry !== "..")
 			{
-				archive_add_file($path,$entry);
+				archive_add_file($path,$entry,$subdir);
 			}
 		}
 		closedir($dir);
@@ -161,7 +161,7 @@ else
 	archive_add_file("/etc/pihole/","setupVars.conf");
 	archive_add_file("/etc/pihole/","auditlog.list");
 	archive_add_file("/etc/pihole/","regex.list");
-	archive_add_directory("/etc/dnsmasq.d/");
+	archive_add_directory("/etc/dnsmasq.d/","dnsmasq.d/");
 
 	$archive->compress(Phar::GZ); // Creates a gziped copy
 	unlink($archive_file_name); // Unlink original tar file as it is not needed anymore

--- a/settings.php
+++ b/settings.php
@@ -1096,9 +1096,9 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                             Blacklist (exact)</label>
                                                     </div>
                                                     <div class="checkbox">
-                                                        <label><input type="checkbox" name="wildlist" value="true"
+                                                        <label><input type="checkbox" name="regexlist" value="true"
                                                                       checked>
-                                                            Blacklist (wildcard)</label>
+                                                            Regex filters</label>
                                                     </div>
                                                 </div>
                                             </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Add regex support for the Teleporter plugin

**How does this PR accomplish the above?:**

Instead of parsing and including the old wildcard blocking file (`/etc/dnsmasq.d/03-pihole-wildcard.conf`), we now directly include the regex filters file (`/etc/pihole/regex.list`).

Furthermore, we now show how many items have been loaded from the archive:
![screenshot at 2018-07-14 15-35-24](https://user-images.githubusercontent.com/16748619/42724941-e83282b6-877b-11e8-8264-d258a6ed5ad7.png)

**What documentation changes (if any) are needed to support this PR?:**

@jacobsalmela This makes Teleporter files for Pi-hole pre-v4.0 slightly incompatible with v4.0+. They can still be imported correctly, however, now unsupported old wildcard blocking files will be ignored.

Users should be asked to backup their configuration after switching to Pi-hole v4.0 to ensure that they backed up their (newly created) regex files.