### PR TITLE
Always start with empty search field on Query Log page

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -275,9 +275,11 @@ $(document).ready(function() {
             var data = localStorage.getItem("query_log_table");
             // Return if not available
             if(data === null){ return null; }
-            // Ensure that we always start on the first page (most recent query)
             data = JSON.parse(data);
+            // Always start on the first page to show most recent queries
             data["start"] = 0;
+            // Always start with empty search field
+            data["search"]["search"] = "";
             // Apply loaded state to table
             return data;
         },


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix an issue I introduced in https://github.com/pi-hole/AdminLTE/pull/764 while lead to keeping not only the "Show X entries per page" but also the search field content, breaking some workflows.

**How does this PR accomplish the above?:**

Reset search field content on page loading.

**What documentation changes (if any) are needed to support this PR?:**

None