### PR TITLE
Ignore commented lines in list files

### DIFF
--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -38,9 +38,9 @@ function getListContent($listname) {
     $rawList = file_get_contents(checkfile($basedir.$listname));
     $list = explode("\n", $rawList);
 
-    // Get rid of empty lines
+    // Get rid of empty lines and comments
     for($i = sizeof($list)-1; $i >= 0; $i--) {
-        if(strlen($list[$i]) < 1)
+        if(strlen($list[$i]) < 1 || $list[$i][0] === '#')
             unset($list[$i]);
     }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Fix comments in lists (such as the regex list) appearing on the web interface.

**How does this PR accomplish the above?:**
Ignore lines starting with `#`

**What documentation changes (if any) are needed to support this PR?:**
None