### PR TITLE
Use simpler regex format for wildcards

### DIFF
--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -37,7 +37,7 @@ switch($type) {
         // Escape "." so it won't be interpreted as the wildcard character
         $domain = str_replace(".","\.",$_POST['domain']);
         // Add regex filter for legacy wildcard behavior
-        add_regex("\.?".$domain."$");
+        add_regex("(^|\.)".$domain."$");
         break;
     case "regex":
         add_regex($_POST['domain']);

--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -37,7 +37,7 @@ switch($type) {
         // Escape "." so it won't be interpreted as the wildcard character
         $domain = str_replace(".","\.",$_POST['domain']);
         // Add regex filter for legacy wildcard behavior
-        add_regex("((^)|(\.))".$domain."$");
+        add_regex("\.?".$domain."$");
         break;
     case "regex":
         add_regex($_POST['domain']);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Use a simpler wildcard regex format proposed [here](https://discourse.pi-hole.net/t/sugestings-about-name-giving-lists/11216/3?u=mcat12)

**How does this PR accomplish the above?:**
Use `\.?domain\.com$` instead of `((^)|(\.))domain\.com$`

**What documentation changes (if any) are needed to support this PR?:**
None

See also pi-hole/pi-hole#2318