### PR TITLE
Do not sort regex list

### DIFF
--- a/scripts/pi-hole/js/list.js
+++ b/scripts/pi-hole/js/list.js
@@ -95,7 +95,6 @@ function refresh(fade) {
                 // Add regex domains if present in returned list data
                 if(data.length === 2)
                 {
-                    data[1] = data[1].sort();
                     data[1].forEach(function (entry, index) {
                         // Whitelist entry or Blacklist (exact entry) are in the zero-th
                         // array returned by get.php


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Ensure that comments in the file `/etc/pihole/regex.list` stay next to the lines they correspond to if users added them manually in the `regex.list` file. Currently, all comment lines (starting with `#`) are shown at the beginning of the regex filter listing.

**How does this PR accomplish the above?:**

Remove lexicographic sorting of array.

**What documentation changes (if any) are needed to support this PR?:**

None