### PR TITLE
Be able to show more response types on Query Log page

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -230,6 +230,22 @@ $(document).ready(function() {
                 {
                     $("td:eq(5)", row).html("IP");
                 }
+                else if (data[6] === "5")
+                {
+                    $("td:eq(5)", row).html("SERVFAIL");
+                }
+                else if (data[6] === "6")
+                {
+                    $("td:eq(5)", row).html("REFUSED");
+                }
+                else if (data[6] === "7")
+                {
+                    $("td:eq(5)", row).html("NOTIMP");
+                }
+                else if (data[6] === "8")
+                {
+                    $("td:eq(5)", row).html("upstream error");
+                }
                 else
                 {
                     $("td:eq(5)", row).html("? ("+data[6]+")");


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Add more response types to the Query Log page. This implements a feature that will be provided by a future version of *FTL*DNS.

**How does this PR accomplish the above?:**

Add further int -> string pairs

**What documentation changes (if any) are needed to support this PR?:**

None