### PR TITLE
Add deprecation notification for FTLDNS branches

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -1205,4 +1205,7 @@ $(document).ready(function() {
         // Pull in data via AJAX
         updateForwardDestinationsPie();
     }
+
+    // Deprecation warning
+    $("#myModal").modal();
 });

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -203,6 +203,28 @@
     <div class="js-warn" id="js-warn-exit"><h1>Javascript Is Disabled</h1><p>Javascript seems to be disabled. This will break some site features.</p>
         <p>To enable Javascript click <a href="http://www.enable-javascript.com/" target="_blank">here</a></p><label for="js-hide">Close</label></div>
 </div>
+<!-- Modal box -->
+<div id="myModal" class="modal fade" role="dialog">
+  <div class="modal-dialog">
+
+    <!-- Modal content-->
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title">Important: Deprecation notification</h4>
+      </div>
+      <div class="modal-body">
+        <p>As of August, 6, 2018, we officially released Pi-hole v4.0. This mean that the code you have checked out using <code>pihole checkout FTLDNS</code> is no longer maintained.</p>
+        <p>Please switch back to Pi-hole's main branches using<br><code>sudo pihole checkout master</code><br><code>sudo pihole -up</code><br>to continue receiving updates and security patches.</p>
+        <p>Your Pi-hole team</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+
+  </div>
+</div>
 <!-- /JS Warning -->
 <?php
 if($auth) {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Show a deprecation notification for FTLDNS branches. The underlying issue to be addressed here is that many articles floating (floating around on the Internet and being in press in some recent large German Linux magazines) recommend checking out the `FTLDNS` branch.

**How does this PR accomplish the above?:**

We show a deprecation warning dialog on the dashboard (only on the index page). Users can decide to ignore this and continue to use the `FTLDNS` forever. However, as this is not recommended, we show the modal box on each visit of the dashboard (dismissal is only temporary, not global).

Small screen:
![screenshot at 2018-08-07 18-55-42](https://user-images.githubusercontent.com/16748619/43790887-390e5592-9a74-11e8-9d4c-8db38258a17d.png)

Large screen:
![screenshot at 2018-08-07 18-56-39](https://user-images.githubusercontent.com/16748619/43790879-31ff2d58-9a74-11e8-9e9d-c5c6eb6126cc.png)

Mobile phone:
![screen shot 2018-08-07 at 19 05 14](https://user-images.githubusercontent.com/16748619/43791102-df507cd2-9a74-11e8-9a65-ef7193ba253f.png)

**What documentation changes (if any) are needed to support this PR?:**

None