### PR TITLE
Acknowledge possible custom time interval

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,6 +8,19 @@
     $indexpage = true;
     require "scripts/pi-hole/php/header.php";
     require_once("scripts/pi-hole/php/gravity.php");
+
+    function getinterval()
+    {
+        global $piholeFTLConf;
+        if(isset($piholeFTLConf["MAXLOGAGE"]))
+        {
+             return round(floatval($piholeFTLConf["MAXLOGAGE"]), 1);
+        }
+        else
+        {
+             return "24";
+        }
+    }
 ?>
 <!-- Small boxes (Stat box) -->
 <div class="row">
@@ -69,7 +82,7 @@
     <div class="col-md-12">
     <div class="box" id="queries-over-time">
         <div class="box-header with-border">
-          <h3 class="box-title">Queries over last 24 hours</h3>
+          <h3 class="box-title">Queries over last <?php echo getinterval(); ?> hours</h3>
         </div>
         <div class="box-body">
           <div class="chart">

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -152,6 +152,16 @@
     $FTLpid = intval(pidofFTL());
     $FTL = ($FTLpid !== 0 ? true : false);
 
+    $piholeFTLConfFile = "/etc/pihole/pihole-FTL.conf";
+    if(is_readable($piholeFTLConfFile))
+    {
+        $piholeFTLConf = parse_ini_file($piholeFTLConfFile);
+    }
+    else
+    {
+        $piholeFTLConf = array();
+    }
+
 ?>
 <!DOCTYPE html>
 <!-- Pi-hole: A black hole for Internet advertisements

--- a/settings.php
+++ b/settings.php
@@ -9,7 +9,6 @@ require "scripts/pi-hole/php/header.php";
 require "scripts/pi-hole/php/savesettings.php";
 // Reread ini file as things might have been changed
 $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
-$piholeFTLConfFile = "/etc/pihole/pihole-FTL.conf";
 if(is_readable($piholeFTLConfFile))
 {
 	$piholeFTLConf = parse_ini_file($piholeFTLConfFile);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

We currently show a static text "Queries over last 24 hours". However, a user might use [`MAXLOGAGE`](https://docs.pi-hole.net/ftldns/configfile/#maxlogage) to change the interval of shown data to 48 hours or even more. In this case, the title of the graph should be reflecting this.

**How does this PR accomplish the above?:**

We try to obtain the correct value from `/etc/pihole-FTL.conf`. If this is not possible (because it is not set), we default to show "24 hours" in agreement with the default setting FTL uses in this case.