### PR TITLE
Don't require adlists to start in "http"

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -137,12 +137,17 @@ function readAdlists()
 	{
 		while (($line = fgets($handle)) !== false)
 		{
-			if(substr($line, 0, 5) === "#http")
+			if(substr($line, 0, 1) === "#")
 			{
-				// Commented list
-				array_push($list, [false,rtrim(substr($line, 1))]);
+				// Comments start either with "##" or "# "
+				if(substr($line, 1, 1) !== "#" &&
+			           substr($line, 1, 1) !== " ")
+				{
+					// Commented list
+					array_push($list, [false,rtrim(substr($line, 1))]);
+				}
 			}
-			elseif(substr($line, 0, 4) === "http")
+			elseif(strlen($line) > 1)
 			{
 				// Active list
 				array_push($list, [true,rtrim($line)]);

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -137,17 +137,21 @@ function readAdlists()
 	{
 		while (($line = fgets($handle)) !== false)
 		{
-			if(substr($line, 0, 1) === "#")
+			if(strlen($line) < 3)
+			{
+				continue;
+			}
+			elseif($line[0] === "#")
 			{
 				// Comments start either with "##" or "# "
-				if(substr($line, 1, 1) !== "#" &&
-			           substr($line, 1, 1) !== " ")
+				if($line[1] !== "#" &&
+			           $line[1] !== " ")
 				{
 					// Commented list
 					array_push($list, [false,rtrim(substr($line, 1))]);
 				}
 			}
-			elseif(strlen($line) > 1)
+			else
 			{
 				// Active list
 				array_push($list, [true,rtrim($line)]);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

This also displays lists that start in, e.g., "ftp://" or "file://" or are simply stored without a protocol. Currently, lists without a protocol or starting in, e.g. `file://` are not shown.

**How does this PR accomplish the above?:**

Do not require lists to start with `http`.

**What documentation changes (if any) are needed to support this PR?:**

We should maybe edit `adlist.default` and mention that comments should either start in `##` or `#[space]`.