### PR TITLE
improved ux for the remember me checkbox (login)

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -185,7 +185,7 @@ $(document).keypress(function(e) {
 
 // Submit the login form directly when the remember me checkbox was checked
 $("#logincookie").on("change", function() {
-    if ($("#loginpw").val()) {
+    if ($("#loginpw").val() && this.checked) {
         $("#loginform").submit();
     }
 });

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -183,6 +183,13 @@ $(document).keypress(function(e) {
     }
 });
 
+// Submit the login form directly when the remember me checkbox was checked
+$("#logincookie").on("change", function() {
+    if ($("#loginpw").val()) {
+        $("#loginform").submit();
+    }
+});
+
 function testCookies()
 {
     if (navigator.cookieEnabled)


### PR DESCRIPTION
This adds the login form submission when the remember me checkbox was
triggered and a password was supplied before.

Signed-off-by: Max Schmitt <max@schmitt.mx>

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

This pull request improves the user experience of the login behavior.

**How does this PR accomplish the above?:**

It adds like nextcloud.com e.g. does a login form submission once the remember me checkbox has checked and a password was supplied.

