### PR TITLE
Extend piechart functionality on dashboard

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -262,6 +262,16 @@ else
 			// Get specific client only
 			sendRequestFTL("getallqueries-client ".$_GET['client']);
 		}
+		else if(isset($_GET['querytype']))
+		{
+			// Get specific query type only
+			sendRequestFTL("getallqueries-qtype ".$_GET['querytype']);
+		}
+		else if(isset($_GET['forwarddest']))
+		{
+			// Get specific forward destination only
+			sendRequestFTL("getallqueries-forward ".$_GET['forwarddest']);
+		}
 		else if(is_numeric($_GET['getAllQueries']))
 		{
 			sendRequestFTL("getallqueries (".$_GET['getAllQueries'].")");

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -299,7 +299,7 @@ function updateQueryTypesPie() {
             }
             else if(e.which === 1) // which == 1 is left mouse button
             {
-                window.open("queries.php?querytype="+$(this).index(), "_self");
+                window.open("queries.php?querytype="+($(this).index()+1), "_self");
             }
         });
     }).done(function() {

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -281,7 +281,7 @@ function updateQueryTypesPie() {
         // Generate legend in separate div
         $("#query-types-legend").html(queryTypePieChart.generateLegend());
         $("#query-types-legend > ul > li").on("mousedown", function(e){
-            if(e.which == 2) // which == 2 is middle mouse button
+            if(e.which === 2) // which == 2 is middle mouse button
             {
                 $(this).toggleClass("strike");
                 var index = $(this).index();
@@ -297,7 +297,7 @@ function updateQueryTypesPie() {
                 }
                 ci.update();
             }
-            else if(e.which == 1) // which == 1 is left mouse button
+            else if(e.which === 1) // which == 1 is left mouse button
             {
                 window.open("queries.php?querytype="+$(this).index(), "_self");
             }
@@ -544,7 +544,7 @@ function updateForwardDestinationsPie() {
         // Generate legend in separate div
         $("#forward-destinations-legend").html(forwardDestinationPieChart.generateLegend());
         $("#forward-destinations-legend > ul > li").on("mousedown",function(e){
-            if(e.which == 2) // which == 2 is middle mouse button
+            if(e.which === 2) // which == 2 is middle mouse button
             {
                 $(this).toggleClass("strike");
                 var index = $(this).index();
@@ -560,7 +560,7 @@ function updateForwardDestinationsPie() {
                 }
                 ci.update();
             }
-            else if(e.which == 1) // which == 1 is left mouse button
+            else if(e.which === 1) // which == 1 is left mouse button
             {
                 var obj = encodeURIComponent(e.target.innerText);
                 window.open("queries.php?forwarddest="+obj, "_self");

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -280,7 +280,9 @@ function updateQueryTypesPie() {
         queryTypePieChart.options.animation.duration=0;
         // Generate legend in separate div
         $("#query-types-legend").html(queryTypePieChart.generateLegend());
-        $("#query-types-legend > ul > li").on("click",function(e){
+        $("#query-types-legend > ul > li").on("mousedown", function(e){
+            if(e.which == 2) // which == 2 is middle mouse button
+            {
                 $(this).toggleClass("strike");
                 var index = $(this).index();
                 var ci = e.view.queryTypePieChart;
@@ -294,6 +296,11 @@ function updateQueryTypesPie() {
                     }
                 }
                 ci.update();
+            }
+            else if(e.which == 1) // which == 1 is left mouse button
+            {
+                window.open("queries.php?querytype="+$(this).index(), "_self");
+            }
         });
     }).done(function() {
         // Reload graph after minute
@@ -536,7 +543,9 @@ function updateForwardDestinationsPie() {
         forwardDestinationPieChart.options.animation.duration=0;
         // Generate legend in separate div
         $("#forward-destinations-legend").html(forwardDestinationPieChart.generateLegend());
-        $("#forward-destinations-legend > ul > li").on("click",function(e){
+        $("#forward-destinations-legend > ul > li").on("mousedown",function(e){
+            if(e.which == 2) // which == 2 is middle mouse button
+            {
                 $(this).toggleClass("strike");
                 var index = $(this).index();
                 var ci = e.view.forwardDestinationPieChart;
@@ -550,6 +559,12 @@ function updateForwardDestinationsPie() {
                     }
                 }
                 ci.update();
+            }
+            else if(e.which == 1) // which == 1 is left mouse button
+            {
+                var obj = encodeURIComponent(e.target.innerText);
+                window.open("queries.php?forwarddest="+obj, "_self");
+            }
         });
     }).done(function() {
         // Reload graph after one minute

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -136,6 +136,14 @@ $(document).ready(function() {
     {
         APIstring += "&domain="+GETDict["domain"];
     }
+    else if("querytype" in GETDict)
+    {
+        APIstring += "&querytype="+GETDict["querytype"];
+    }
+    else if("forwarddest" in GETDict)
+    {
+        APIstring += "&forwarddest="+GETDict["forwarddest"];
+    }
     // If we don't ask filtering and also not for all queries, just request the most recent 100 queries
     else if(!("all" in GETDict))
     {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Allow users to open the Query Log for specific query types (only `A`, only `AAAA`, ...) and for specific forward destinations (cache, blocklist, a certain upstream DNS server, ...).

**How does this PR accomplish the above?:**

The current behavior (clicking on a legend item hides elements in the pie charts) is moved to a middle mouse button click. The new left button click event is to send the user to the Query Log applying the corresponding filtering.

**What documentation changes (if any) are needed to support this PR?:**

The default behavior changes. Although I don't think that it is used much, we should nevertheless mention it and also point out what the new functionality is.