### PR TITLE
Change "Pi-holed" to "Blocked" on the Query Log

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -206,7 +206,7 @@ $(document).ready(function() {
                 blocked = true;
                 color = "red";
                 fieldtext = "Blocked <br class='hidden-lg'>(external)";
-                buttontext = "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>" ;
+                buttontext = "" ;
                 break;
             default:
                 blocked = false;

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -175,7 +175,7 @@ $(document).ready(function() {
             case "1":
                 blocked = true;
                 color = "red";
-                fieldtext = "Pi-holed"+dnssec_status;
+                fieldtext = "Blocked (gravity)";
                 buttontext = "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>";
                 break;
             case "2":
@@ -193,13 +193,19 @@ $(document).ready(function() {
             case "4":
                 blocked = true;
                 color = "red";
-                fieldtext = "Pi-holed <br class='hidden-lg'>(wildcard)";
+                fieldtext = "Blocked <br class='hidden-lg'>(regex/wildcard)";
                 buttontext = "";
                 break;
             case "5":
                 blocked = true;
                 color = "red";
-                fieldtext = "Pi-holed <br class='hidden-lg'>(blacklist)";
+                fieldtext = "Blocked <br class='hidden-lg'>(blacklist)";
+                buttontext = "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>" ;
+                break;
+            case "6":
+                blocked = true;
+                color = "red";
+                fieldtext = "Blocked <br class='hidden-lg'>(external)";
                 buttontext = "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>" ;
                 break;
             default:

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -194,7 +194,7 @@ $(document).ready(function() {
                 blocked = true;
                 color = "red";
                 fieldtext = "Blocked <br class='hidden-lg'>(regex/wildcard)";
-                buttontext = "";
+                buttontext = "<button style=\"color:green; white-space: nowrap;\"><i class=\"fa fa-pencil-square-o\"></i> Whitelist</button>" ;
                 break;
             case "5":
                 blocked = true;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Reduce the theming of Pi-hole: Replace "Pi-holed" by a more neutral "Blocked" on the Query Log page.

**How does this PR accomplish the above?:**

- Change "Pi-holed" to "Blocked" on the Query Log
- I also add a new "Blocked (external)" status that will be used by a future version of FTL.
- Furthermore, I removed the addition of the `dnssec` status to the "Blocked (gravity)" status as requests answered from the blocking lists do not have a DNSSEC status.

**What documentation changes (if any) are needed to support this PR?:**

Unclear, probably none. The new phrasing should be clearer than what we had before.