### PR TITLE
Strip spaces from user input

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -196,7 +196,7 @@ function readAdlists()
 				{
 					if(array_key_exists("custom".$i,$_POST))
 					{
-						$exploded = explode("#", str_replace(" ","",$_POST["custom".$i."val"]), 2);
+						$exploded = explode("#", trim($_POST["custom".$i."val"]," "), 2);
 						$IP = $exploded[0];
 						if(count($exploded) > 1)
 						{
@@ -369,7 +369,7 @@ function readAdlists()
 
 				$clientlist = "";
 				$first = true;
-				foreach(str_replace(" ","",$clients) as $client)
+				foreach(trim($clients," ") as $client)
 				{
 					if(!validDomainWildcard($client) && !validIP($client))
 					{
@@ -509,9 +509,9 @@ function readAdlists()
 
 				if(isset($_POST["addstatic"]))
 				{
-					$mac = str_replace(" ","",$_POST["AddMAC"]);
-					$ip = str_replace(" ","",$_POST["AddIP"]);
-					$hostname = str_replace(" ","",$_POST["AddHostname"]);
+					$mac = trim($_POST["AddMAC"]," ");
+					$ip = trim($_POST["AddIP"]," ");
+					$hostname = trim($_POST["AddHostname"]," ");
 
 					if(!validMAC($mac))
 					{
@@ -560,7 +560,7 @@ function readAdlists()
 
 				if(isset($_POST["removestatic"]))
 				{
-					$mac = str_replace(" ","",$_POST["removestatic"]);
+					$mac = trim($_POST["removestatic"]," ");
 					if(!validMAC($mac))
 					{
 						$error .= "MAC address (".htmlspecialchars($mac).") is invalid!<br>";
@@ -578,27 +578,27 @@ function readAdlists()
 				if(isset($_POST["active"]))
 				{
 					// Validate from IP
-					$from = str_replace(" ","",$_POST["from"]);
+					$from = trim($_POST["from"]," ");
 					if (!validIP($from))
 					{
 						$error .= "From IP (".htmlspecialchars($from).") is invalid!<br>";
 					}
 
 					// Validate to IP
-					$to = str_replace(" ","",$_POST["to"]);
+					$to = trim($_POST["to"]," ");
 					if (!validIP($to))
 					{
 						$error .= "To IP (".htmlspecialchars($to).") is invalid!<br>";
 					}
 
 					// Validate router IP
-					$router = str_replace(" ","",$_POST["router"]);
+					$router = trim($_POST["router"]," ");
 					if (!validIP($router))
 					{
 						$error .= "Router IP (".htmlspecialchars($router).") is invalid!<br>";
 					}
 
-					$domain = str_replace(" ","",$_POST["domain"]);
+					$domain = trim($_POST["domain"]," ");
 
 					// Validate Domain name
 					if(!validDomain($domain))
@@ -606,7 +606,7 @@ function readAdlists()
 						$error .= "Domain name ".htmlspecialchars($domain)." is invalid!<br>";
 					}
 
-					$leasetime = str_replace(" ","",$_POST["leasetime"]);
+					$leasetime = trim($_POST["leasetime"]," ");
 
 					// Validate Lease time length
 					if(!is_numeric($leasetime) || intval($leasetime) < 0)

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -196,7 +196,7 @@ function readAdlists()
 				{
 					if(array_key_exists("custom".$i,$_POST))
 					{
-						$exploded = explode("#", $_POST["custom".$i."val"], 2);
+						$exploded = explode("#", str_replace(" ","",$_POST["custom".$i."val"]), 2);
 						$IP = $exploded[0];
 						if(count($exploded) > 1)
 						{
@@ -369,7 +369,7 @@ function readAdlists()
 
 				$clientlist = "";
 				$first = true;
-				foreach($clients as $client)
+				foreach(str_replace(" ","",$clients) as $client)
 				{
 					if(!validDomainWildcard($client) && !validIP($client))
 					{
@@ -509,9 +509,9 @@ function readAdlists()
 
 				if(isset($_POST["addstatic"]))
 				{
-					$mac = $_POST["AddMAC"];
-					$ip = $_POST["AddIP"];
-					$hostname = $_POST["AddHostname"];
+					$mac = str_replace(" ","",$_POST["AddMAC"]);
+					$ip = str_replace(" ","",$_POST["AddIP"]);
+					$hostname = str_replace(" ","",$_POST["AddHostname"]);
 
 					if(!validMAC($mac))
 					{
@@ -560,7 +560,7 @@ function readAdlists()
 
 				if(isset($_POST["removestatic"]))
 				{
-					$mac = $_POST["removestatic"];
+					$mac = str_replace(" ","",$_POST["removestatic"]);
 					if(!validMAC($mac))
 					{
 						$error .= "MAC address (".htmlspecialchars($mac).") is invalid!<br>";
@@ -578,27 +578,27 @@ function readAdlists()
 				if(isset($_POST["active"]))
 				{
 					// Validate from IP
-					$from = $_POST["from"];
+					$from = str_replace(" ","",$_POST["from"]);
 					if (!validIP($from))
 					{
 						$error .= "From IP (".htmlspecialchars($from).") is invalid!<br>";
 					}
 
 					// Validate to IP
-					$to = $_POST["to"];
+					$to = str_replace(" ","",$_POST["to"]);
 					if (!validIP($to))
 					{
 						$error .= "To IP (".htmlspecialchars($to).") is invalid!<br>";
 					}
 
 					// Validate router IP
-					$router = $_POST["router"];
+					$router = str_replace(" ","",$_POST["router"]);
 					if (!validIP($router))
 					{
 						$error .= "Router IP (".htmlspecialchars($router).") is invalid!<br>";
 					}
 
-					$domain = $_POST["domain"];
+					$domain = str_replace(" ","",$_POST["domain"]);
 
 					// Validate Domain name
 					if(!validDomain($domain))
@@ -606,7 +606,7 @@ function readAdlists()
 						$error .= "Domain name ".htmlspecialchars($domain)." is invalid!<br>";
 					}
 
-					$leasetime = $_POST["leasetime"];
+					$leasetime = str_replace(" ","",$_POST["leasetime"]);
 
 					// Validate Lease time length
 					if(!is_numeric($leasetime) || intval($leasetime) < 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Prevent potential user confusion in cases where there is an extraneous space in the setting they have entered.
(This can occur when copy and pasting information into the input fields of the settings page, resulting in leading or trailing spaces. eg https://github.com/pi-hole/pi-hole/issues/2369 )

**How does this PR accomplish the above?:**

Removes spaces from input strings for fields such as ip addresses, mac addresses etc that should never contain any spaces. (Validity checks still applied to strings after spaces are removed)

**What documentation changes (if any) are needed to support this PR?:**

none
