### PR TITLE
Add support for privacy level 4 (no stats)

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -675,7 +675,7 @@ function readAdlists()
 
 			case "privacyLevel":
 				$level = intval($_POST["privacylevel"]);
-				if($level >= 0 && $level <= 3)
+				if($level >= 0 && $level <= 4)
 				{
 					exec("sudo pihole -a privacylevel ".$level);
 					$success .= "The privacy level has been updated";

--- a/settings.php
+++ b/settings.php
@@ -1031,7 +1031,12 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                     <div class="radio">
                                                         <label><input type="radio" name="privacylevel" value="3"
                                                                       <?php if ($privacylevel === 3){ ?>checked<?php }
-                                                                      ?>>Paranoia mode: This disables basically everything except the live anonymous statistics<br>No history is saved at all to the database, and nothing is shown in the query log. Also, there are no top item lists.</label>
+                                                                      ?>>Anonymous mode: This disables basically everything except the live anonymous statistics<br>No history is saved at all to the database, and nothing is shown in the query log. Also, there are no top item lists.</label>
+                                                    </div>
+                                                    <div class="radio">
+                                                        <label><input type="radio" name="privacylevel" value="4"
+                                                                      <?php if ($privacylevel === 4){ ?>checked<?php }
+                                                            ?>>No Statistics mode: This disables all statistics processing. Even the query counters will not be available.<br>Additionally, you can disable logging to the file <code>/var/log/pihole.log</code> using <code>sudo pihole logging off</code>.</label>
                                                     </div>
                                                 </div>
                                                 <p>The privacy level may be changed at any time without having to restart the DNS resolver. However, note that queries with (partially) hidden details cannot be disclosed with a subsequent reduction of the privacy level.</p>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Allow privacy level 4 to be set through the web interface. Also finishes renaming privacy level 3 to anonymous mode.

**How does this PR accomplish the above?:**
Add the new privacy level to the list and increase the max privacy level check.
Requires pi-hole/pi-hole#2383

**What documentation changes (if any) are needed to support this PR?:**
None