### PR TITLE
Add DNS cache information to Settings page

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -245,6 +245,21 @@ else
 		$data = array_merge($data, $result);
 	}
 
+	if (isset($_GET['getCacheInfo']) && $auth)
+	{
+		sendRequestFTL("cacheinfo");
+		$return = getResponseFTL();
+		$querytypes = array();
+		foreach($return as $ret)
+		{
+			$tmp = explode(": ",$ret);
+			$querytypes[$tmp[0]] = floatval($tmp[1]);
+		}
+
+		$result = array('cacheinfo' => $querytypes);
+		$data = array_merge($data, $result);
+	}
+
 	if (isset($_GET['getAllQueries']) && $auth)
 	{
 		if(isset($_GET['from']) && isset($_GET['until']))

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -249,14 +249,14 @@ else
 	{
 		sendRequestFTL("cacheinfo");
 		$return = getResponseFTL();
-		$querytypes = array();
+		$cacheinfo = array();
 		foreach($return as $ret)
 		{
 			$tmp = explode(": ",$ret);
-			$querytypes[$tmp[0]] = floatval($tmp[1]);
+			$cacheinfo[$tmp[0]] = floatval($tmp[1]);
 		}
 
-		$result = array('cacheinfo' => $querytypes);
+		$result = array('cacheinfo' => $cacheinfo);
 		$data = array_merge($data, $result);
 	}
 

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -161,7 +161,7 @@ function loadCacheInfo()
         }
         else
         {
-            $("#cache-live-freed").parent("tr").removeClass("lookatme")
+            $("#cache-live-freed").parent("tr").removeClass("lookatme");
         }
 
         // Update cache info every 10 seconds

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -140,6 +140,35 @@ $("#DHCPchk").click(function() {
 	$("#dhcpnotice").prop("hidden", !this.checked).addClass("lookatme");
 });
 
+function loadCacheInfo()
+{
+    $.getJSON("api.php?getCacheInfo", function(data) {
+        if("FTLnotrunning" in data)
+        {
+            return;
+        }
+
+        // Fill table with obtained values
+        $("#cache-size").text(parseInt(data["cacheinfo"]["cache-size"]));
+        $("#cache-inserted").text(parseInt(data["cacheinfo"]["cache-inserted"]));
+
+        // Highlight early cache removals when present
+        var cachelivefreed = parseInt(data["cacheinfo"]["cache-live-freed"]);
+        $("#cache-live-freed").text(cachelivefreed);
+        if(cachelivefreed > 0)
+        {
+            $("#cache-live-freed").parent("tr").addClass("lookatme");
+        }
+        else
+        {
+            $("#cache-live-freed").parent("tr").removeClass("lookatme")
+        }
+
+        // Update cache info every 10 seconds
+        setTimeout(loadCacheInfo, 10000);
+    });
+}
+
 var leasetable, staticleasetable;
 $(document).ready(function() {
 	if(document.getElementById("DHCPLeasesTable"))
@@ -169,6 +198,8 @@ $(document).ready(function() {
         leasetable.draw();
         staticleasetable.draw();
     });
+
+    loadCacheInfo();
 
 } );
 

--- a/settings.php
+++ b/settings.php
@@ -1221,8 +1221,27 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                         </th>
                                                         <td><?php echo formatSizeUnits(1e3 * floatval(get_FTL_data("rss"))); ?></td>
                                                     </tr>
+                                                    <tr>
+                                                        <th scope="row">
+                                                            <span title="Size of the DNS domain cache">DNS cache size:</span>
+                                                        </th>
+                                                        <td id="cache-size">&nbsp;</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <th scope="row">
+                                                            <span title="Number of cache insertions">DNS cache insertions:</span>
+                                                        </th>
+                                                        <td id="cache-inserted">&nbsp;</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <th scope="row">
+                                                            <span title="Number of cache entries that had to be removed although they are not expired (increase cache size to reduce this number)">DNS cache evictions:</span>
+                                                        </th>
+                                                        <td id="cache-live-freed">&nbsp;</td>
+                                                    </tr>
                                                 </tbody>
                                             </table>
+                                            See also our <a href="https://docs.pi-hole.net/ftldns/dns-cache/" target="_blank">DNS cache documentation</a>.
                                             <?php } else { ?>
                                             <div>The FTL service is offline!</div>
                                             <?php } ?>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Add cache information to the Settings page. This allows users to get a quick overview if their DNS cache size is sufficient or may even be too large.

If DNS cache entries are evicted (cache size too small), we highlight the eviction count to catch the user's attention:

![ezgif-3-cd42e4f2c1](https://user-images.githubusercontent.com/16748619/44405363-5619bd80-a559-11e8-8093-1f229c6fe3ff.gif)


**How does this PR accomplish the above?:**

Query a new API endpoint `api.php?getCacheInfo` calling an already existing FTL routine.

**What documentation changes (if any) are needed to support this PR?:**

None, but I assume we want to include it in the v4.1 blog post @jacobsalmela 