### PR TITLE
Add query type selection for Long-term Query Log

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -101,7 +101,61 @@ if (isset($_GET['getAllQueries']) && $auth)
 	{
 		$from = intval($_GET["from"]);
 		$until = intval($_GET["until"]);
-		$stmt = $db->prepare("SELECT timestamp, type, domain, client, status FROM queries WHERE timestamp >= :from AND timestamp <= :until ORDER BY timestamp ASC");
+		$dbquery = "SELECT timestamp, type, domain, client, status FROM queries WHERE timestamp >= :from AND timestamp <= :until ";
+		if(isset($_GET["types"]))
+		{
+			$types = intval($_GET["types"]);
+			$typestr = "";
+			if($types & 1) // GRAVITY
+			{
+				$typestr = "1";
+			}
+			if($types & 2) // FORWARDED
+			{
+				if(strlen($typestr) > 0)
+				{
+					$typestr .= ",";
+				}
+				$typestr .= "2";
+			}
+			if($types & 4) // CACHED
+			{
+				if(strlen($typestr) > 0)
+				{
+					$typestr .= ",";
+				}
+				$typestr .= "3";
+			}
+			if($types & 8) // REGEX/WILDCARD
+			{
+				if(strlen($typestr) > 0)
+				{
+					$typestr .= ",";
+				}
+				$typestr .= "4";
+			}
+			if($types & 16) // BLACKLIST
+			{
+				if(strlen($typestr) > 0)
+				{
+					$typestr .= ",";
+				}
+				$typestr .= "5";
+			}
+			if($types & 32) // EXTERNAL
+			{
+				if(strlen($typestr) > 0)
+				{
+					$typestr .= ",";
+				}
+				$typestr .= "6";
+			}
+
+			// Append selector to DB query
+			$dbquery .= "AND status IN (".$typestr.") ";
+		}
+		$dbquery .= "ORDER BY timestamp ASC";
+		$stmt = $db->prepare($dbquery);
 		$stmt->bindValue(":from", intval($from), SQLITE3_INTEGER);
 		$stmt->bindValue(":until", intval($until), SQLITE3_INTEGER);
 		$results = $stmt->execute();

--- a/db_queries.php
+++ b/db_queries.php
@@ -42,39 +42,37 @@ $token = $_SESSION['token'];
 
 <div class="row">
     <div class="col-md-12">
-        <div class="form-group">
         <label>Query status:</label>
-            <div class="row">
-                <div class="col-md-2">
-                    <div class="checkbox">
-                        <label><input type="checkbox" id="type_gravity" checked>Blocked (exact)</label>
-                    </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-2">
+            <div class="checkbox">
+                <label><input type="checkbox" id="type_gravity" checked>Blocked (exact)</label>
             </div>
-                <div class="col-md-2">
-                    <div class="checkbox">
-                        <label><input type="checkbox" id="type_forwarded" checked>OK (forwarded)</label>
-                    </div>
-                </div>
-                <div class="col-md-2">
-                    <div class="checkbox">
-                        <label><input type="checkbox" id="type_cached" checked>OK (cached)</label>
-                    </div>
-                </div>
-                <div class="col-md-2">
-                    <div class="checkbox">
-                        <label><input type="checkbox" id="type_regex" checked>Blocked (regex/wildcard)</label>
-                    </div>
-                </div>
-                <div class="col-md-2">
-                    <div class="checkbox">
-                        <label><input type="checkbox" id="type_blacklist" checked>Blocked (blacklist)</label>
-                    </div>
-                </div>
-                <div class="col-md-2">
-                    <div class="checkbox">
-                        <label><input type="checkbox" id="type_external" checked>Blocked (external)</label>
-                    </div>
-                </div>
+        </div>
+        <div class="col-md-2">
+            <div class="checkbox">
+                <label><input type="checkbox" id="type_forwarded" checked>OK (forwarded)</label>
+            </div>
+        </div>
+        <div class="col-md-2">
+            <div class="checkbox">
+                <label><input type="checkbox" id="type_cached" checked>OK (cached)</label>
+            </div>
+        </div>
+        <div class="col-md-2">
+            <div class="checkbox">
+                <label><input type="checkbox" id="type_regex" checked>Blocked (regex/wildcard)</label>
+            </div>
+        </div>
+        <div class="col-md-2">
+            <div class="checkbox">
+                <label><input type="checkbox" id="type_blacklist" checked>Blocked (blacklist)</label>
+            </div>
+        </div>
+        <div class="col-md-2">
+            <div class="checkbox">
+                <label><input type="checkbox" id="type_external" checked>Blocked (external)</label>
             </div>
         </div>
     </div>

--- a/db_queries.php
+++ b/db_queries.php
@@ -40,6 +40,46 @@ $token = $_SESSION['token'];
     </div>
 </div>
 
+<div class="row">
+    <div class="col-md-12">
+        <div class="form-group">
+        <label>Query status:</label>
+            <div class="row">
+                <div class="col-md-2">
+                    <div class="checkbox">
+                        <label><input type="checkbox" id="type_gravity" checked>Blocked (exact)</label>
+                    </div>
+            </div>
+                <div class="col-md-2">
+                    <div class="checkbox">
+                        <label><input type="checkbox" id="type_forwarded" checked>OK (forwarded)</label>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="checkbox">
+                        <label><input type="checkbox" id="type_cached" checked>OK (cached)</label>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="checkbox">
+                        <label><input type="checkbox" id="type_regex" checked>Blocked (regex/wildcard)</label>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="checkbox">
+                        <label><input type="checkbox" id="type_blacklist" checked>Blocked (blacklist)</label>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="checkbox">
+                        <label><input type="checkbox" id="type_external" checked>Blocked (external)</label>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div id="timeoutWarning" class="alert alert-warning alert-dismissible fade in" role="alert" hidden="true">
     Depending on how large of a range you specified, the request may time out while Pi-hole tries to retrieve all the data.<br/><span id="err"></span>
 </div>

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -130,15 +130,46 @@ function handleAjaxError( xhr, textStatus, error ) {
     }
     else if(xhr.responseText.indexOf("Connection refused") >= 0)
     {
-        alert( "An error occured while loading the data: Connection refused. Is FTL running?" );
+        alert( "An error occurred while loading the data: Connection refused. Is FTL running?" );
     }
     else
     {
-        alert( "An unknown error occured while loading the data.\n"+xhr.responseText );
+        alert( "An unknown error occurred while loading the data.\n"+xhr.responseText );
     }
     $("#all-queries_processing").hide();
     tableApi.clear();
     tableApi.draw();
+}
+
+function getQueryTypes()
+{
+    var queryType = 0;
+    if($("#type_gravity").prop("checked"))
+    {
+        queryType = 1;
+    }
+    if($("#type_forwarded").prop("checked"))
+    {
+        queryType += 1 << 1;
+    }
+    if($("#type_cached").prop("checked"))
+    {
+        queryType += 1 << 2;
+    }
+    if($("#type_regex").prop("checked"))
+    {
+        queryType += 1 << 3;
+    }
+    if($("#type_blacklist").prop("checked"))
+    {
+        queryType += 1 << 4;
+    }
+    if($("#type_external").prop("checked"))
+    {
+        queryType += 1 << 5;
+    }
+    console.log(queryType);
+    return queryType;
 }
 
 var reloadCallback = function()
@@ -176,6 +207,12 @@ var reloadCallback = function()
 function refreshTableData() {
     timeoutWarning.show();
     var APIstring = "api_db.php?getAllQueries&from="+from+"&until="+until;
+    // Check if query type filtering is enabled
+    var queryType = getQueryTypes();
+    if(queryType != 63) // 63 (0b00111111) = all possible query types are selected
+    {
+        APIstring += "&types="+queryType;
+    }
     statistics = [0,0,0];
     tableApi.ajax.url(APIstring).load(reloadCallback);
 }
@@ -191,6 +228,12 @@ $(document).ready(function() {
     else
     {
         APIstring = "api_db.php?getAllQueries=empty";
+    }
+    // Check if query type filtering is enabled
+    var queryType = getQueryTypes();
+    if(queryType != 63) // 63 (0b00111111) = all possible query types are selected
+    {
+        APIstring += "&types="+queryType;
     }
 
     tableApi = $("#all-queries").DataTable( {

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -210,7 +210,6 @@ function refreshTableData() {
     var queryType = getQueryTypes();
     if(queryType !== "1,2,3,4,5,6")
     {
-        console.log(queryType);
         APIstring += "&types="+queryType;
     }
     statistics = [0,0,0];

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -168,7 +168,6 @@ function getQueryTypes()
     {
         queryType += 1 << 5;
     }
-    console.log(queryType);
     return queryType;
 }
 
@@ -209,7 +208,7 @@ function refreshTableData() {
     var APIstring = "api_db.php?getAllQueries&from="+from+"&until="+until;
     // Check if query type filtering is enabled
     var queryType = getQueryTypes();
-    if(queryType != 63) // 63 (0b00111111) = all possible query types are selected
+    if(queryType !== 63) // 63 (0b00111111) = all possible query types are selected
     {
         APIstring += "&types="+queryType;
     }
@@ -231,7 +230,7 @@ $(document).ready(function() {
     }
     // Check if query type filtering is enabled
     var queryType = getQueryTypes();
-    if(queryType != 63) // 63 (0b00111111) = all possible query types are selected
+    if(queryType !== 63) // 63 (0b00111111) = all possible query types are selected
     {
         APIstring += "&types="+queryType;
     }

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -143,32 +143,32 @@ function handleAjaxError( xhr, textStatus, error ) {
 
 function getQueryTypes()
 {
-    var queryType = 0;
+    var queryType = [];
     if($("#type_gravity").prop("checked"))
     {
-        queryType = 1;
+        queryType.push(1);
     }
     if($("#type_forwarded").prop("checked"))
     {
-        queryType += 1 << 1;
+        queryType.push(2);
     }
     if($("#type_cached").prop("checked"))
     {
-        queryType += 1 << 2;
+        queryType.push(3);
     }
     if($("#type_regex").prop("checked"))
     {
-        queryType += 1 << 3;
+        queryType.push(4);
     }
     if($("#type_blacklist").prop("checked"))
     {
-        queryType += 1 << 4;
+        queryType.push(5);
     }
     if($("#type_external").prop("checked"))
     {
-        queryType += 1 << 5;
+        queryType.push(6);
     }
-    return queryType;
+    return queryType.join(",");
 }
 
 var reloadCallback = function()
@@ -208,8 +208,9 @@ function refreshTableData() {
     var APIstring = "api_db.php?getAllQueries&from="+from+"&until="+until;
     // Check if query type filtering is enabled
     var queryType = getQueryTypes();
-    if(queryType !== 63) // 63 (0b00111111) = all possible query types are selected
+    if(queryType !== "1,2,3,4,5,6")
     {
+        console.log(queryType);
         APIstring += "&types="+queryType;
     }
     statistics = [0,0,0];


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Add a method to select the query types to be queried from the long-term Query Log
![screenshot at 2018-08-24 14-20-00](https://user-images.githubusercontent.com/16748619/44584317-d08c4c80-a7a8-11e8-8dd9-a907ee354e2b.png)

**How does this PR accomplish the above?:**

Add:

- Six check boxes on the long-term Query Log page - one for each of the query types currently known by *FTL*DNS. They are all checked by default.
- Backend capability in `api_db.php` to be able to query for specific query types if requested. We use the SQL syntax `WHERE status IN (1,2,3,...)` to request only those queries we are interested in (instead of requesting all of them and filtering them afterwards).

**What documentation changes (if any) are needed to support this PR?:**

None, new feature that should stay out of your way if you don't need it.