### PR TITLE
Improve "Wrong Token." message

### DIFF
--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -102,7 +102,7 @@ function check_csrf($token) {
     }
 
     if(!hash_equals($_SESSION['token'], $token)) {
-        log_and_die("Wrong token! Check if cookies are enabled on your system.");
+        log_and_die("Wrong token! Please re-login on the Pi-hole dashboard.");
     }
 }
 

--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -93,8 +93,16 @@ function check_csrf($token) {
         session_start();
     }
 
-    if(!isset($_SESSION['token']) || empty($token) || !hash_equals($_SESSION['token'], $token)) {
-        log_and_die("Wrong token");
+    if(!isset($_SESSION['token'])) {
+        log_and_die("Session expired! Please re-login on the Pi-hole dashboard.");
+    }
+
+    if(empty($token)) {
+        log_and_die("Empty token! Check if cookies are enabled on your system.");
+    }
+
+    if(!hash_equals($_SESSION['token'], $token)) {
+        log_and_die("Wrong token! Check if cookies are enabled on your system.");
     }
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

The `Wrong Token.` error message is shown whenever the token is wrong or not available. This commit adds more details into this message to help user's in their own troubleshooting.

This should improve situations like described here: https://discourse.pi-hole.net/t/regex-wrong-token/12232

**How does this PR accomplish the above?:**

Differentiate one `if` with three conditions into three individual `if`s, each with its own error message.

**What documentation changes (if any) are needed to support this PR?:**

None.