### PR TITLE
Add API support for list actions

### DIFF
--- a/api.php
+++ b/api.php
@@ -97,6 +97,35 @@ elseif (isset($_GET['versions']))
 	$data = array_merge($data, $latest);
 	$data = array_merge($data, $branches);
 }
+elseif (isset($_GET['list']))
+{
+	if (isset($_GET['add']))
+	{
+		if (!$auth)
+			die("Not authorized!");
+
+		// Set POST parameters and invoke script to add domain to list
+		$_POST['domain'] = $_GET['add'];
+		$_POST['list'] = $_GET['list'];
+		require("scripts/pi-hole/php/add.php");
+	}
+	elseif (isset($_GET['sub']))
+	{
+		if (!$auth)
+			die("Not authorized!");
+
+		// Set POST parameters and invoke script to remove domain from list
+		$_POST['domain'] = $_GET['sub'];
+		$_POST['list'] = $_GET['list'];
+		require("scripts/pi-hole/php/sub.php");
+	}
+	else
+	{
+		require("scripts/pi-hole/php/get.php");
+	}
+
+	return;
+}
 
 // Other API functions
 require("api_FTL.php");

--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -7,12 +7,15 @@
 *  Please see LICENSE file for your rights under this license. */ ?>
 
 <?php
-require('auth.php');
+require_once('auth.php');
 
 $type = $_POST['list'];
 
-// All of the verification for list editing
-list_verify($type);
+// Perform all of the verification for list editing
+// when NOT invoked and authenticated from API
+if (!$api) {
+    list_verify($type);
+}
 
 switch($type) {
     case "white":

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -14,7 +14,7 @@ $listtype = $_GET['list'];
 
 $basedir = "/etc/pihole/";
 
-require "func.php";
+require_once "func.php";
 
 switch ($listtype) {
     case "white":

--- a/scripts/pi-hole/php/sub.php
+++ b/scripts/pi-hole/php/sub.php
@@ -7,12 +7,15 @@
 *  Please see LICENSE file for your rights under this license. */ ?>
 
 <?php
-require('auth.php');
+require_once('auth.php');
 
 $type = $_POST['list'];
 
-// All of the verification for list editing
-list_verify($type);
+// Perform all of the verification for list editing
+// when NOT invoked and authenticated from API
+if (!$api) {
+    list_verify($type);
+}
 
 switch($type) {
     case "white":


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Currently, the API (via `api.php`) does not support adding, removing, and listing domains in the whitelist/ blacklist.  The only way at this time to accomplish these operations is by interfacing directly with the same scripts used by the web interface. For example, to get all whitelisted domains, a `GET /admin/scripts/pi-hole/php/get.php?list=white` request can be sent without any authentication required.  However, to add/remove a domain, a `POST /admin/scripts/pi-hole/php/add.php` or `POST /admin/scripts/pi-hole/php/sub.php` request must be sent with a body containing the plain-text password or CSRF token, which is cumbersome and insecure.

This PR aims to add direct API support for these operations to `api.php` and utilize the existing API authentication mechanisms (API token).

**How does this PR accomplish the above?:**

To minimize code duplication and maximize code reuse, I've implemented in `api.php` three new **GET** request parameters, `list`, `add`, and `sub`, which simply pass their values to the existing `get.php`, `add.php`, and `sub.php` scripts, and are invoked depending on the parameter combination specified.  The following permutations are supported:

### list
- Gets all domains from a list (`white` or `black`)
- No authorization necessary (**NOTE:** This is because the existing `get.php` script has no security around it.  If this is a bug/ unintended, then I will create an issue, fix `get.php`, and update this PR.)
- Example:
  `api.php?list=white`

  ```
  [
     [
        "aax-us-east.amazon-adsystem.com",
        "fls-na.amazon.com",
        "s.amazon-adsystem.com",
        "mikesouza.io",
        "example.com"
     ]
  ]
  ```
  `api.php?list=black`

  ```
  [
     [
        "example.com"
     ],
     [
        "www[0-9].example.com",
        "(^|\\.)*\\.example\\.com$"
     ]
  ]
  ```

### list & add
- Add domain to list (`white`, `black`, `wild`, `regex`)
- Authorization and token required
- Examples:
  `api.php?list=white&add=example.com&auth=TheAPITokenWhichIsJustYourHashedPassword`
  `api.php?list=black&add=example.com&auth=TheAPITokenWhichIsJustYourHashedPassword`
  `api.php?list=wild&add=*.example.com&auth=TheAPITokenWhichIsJustYourHashedPassword`
  `api.php?list=regex&add=cdn[0-9]+.example.com&auth=TheAPITokenWhichIsJustYourHashedPassword`

  `[✓] Pi-hole blocking is Enabled`

### list & sub
- Remove domain from list (`white`, `black`, `regex`)
- Authorization and token required
- Examples:
  `api.php?list=white&sub=example.com&auth=TheAPITokenWhichIsJustYourHashedPassword`
  `api.php?list=black&sub=example.com&auth=TheAPITokenWhichIsJustYourHashedPassword`
  `api.php?list=regex&sub=cdn[0-9]+.example.com&auth=TheAPITokenWhichIsJustYourHashedPassword`

  **NOTE:**  You'll notice that unlike **list & add**,  list=`wild` is not supported.  This is because the existing `sub.php` script does not currently support a list type of `wild`, but the `add.php` does.  I have stashed changes to `sub.php` not in this PR that would make the API more consistent.  We can discuss this further if you'd like.

**What documentation changes (if any) are needed to support this PR?:**

If this gets accepted, the [Discourse topic](https://discourse.pi-hole.net/t/pi-hole-api/1863) with the API will need to be updated.  I will gladly provide this once the PR is accepted.