### PR TITLE
Write newline after wildcard

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -48,7 +48,7 @@ if(!function_exists('hash_equals')) {
 function add_regex($regex, $mode=FILE_APPEND, $append="\n")
 {
     global $regexfile;
-    if(file_put_contents($regexfile, $append.$regex, $mode) === FALSE)
+    if(file_put_contents($regexfile, $regex.$append, $mode) === FALSE)
     {
         $err = error_get_last()["message"];
         echo "Unable to add regex \"".htmlspecialchars($regex)."\" to ${regexfile}<br>Error message: $err";


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Make the web interface add wildcards in the same way as the CLI, to avoid mashing two entries together.
See https://discourse.pi-hole.net/t/wildcard-entries-getting-tacked-on-the-end-of-previous-entry/12527

**How does this PR accomplish the above?:**

Write the newline after the entry instead of in front of it.

**What documentation changes (if any) are needed to support this PR?:**
None