### PR TITLE
Expand upon DNSSEC warning

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -834,7 +834,9 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                 </div>
                                                 <p>Validate DNS replies and cache DNSSEC data. When forwarding DNS
                                                    queries, Pi-hole requests the DNSSEC records needed to validate
-                                                   the replies. Use Google, Norton, DNS.WATCH, Quad9, or another DNS
+                                                   the replies. If a domain fails validation or the upstream does
+                                                   support DNSSEC, this setting can cause issues resolving domains.
+                                                   Use Google, Norton, DNS.WATCH, Quad9, or another DNS
                                                    server which supports DNSSEC when activating DNSSEC. Note that
                                                    the size of your log might increase significantly
                                                    when enabling DNSSEC. A DNSSEC resolver test can be found

--- a/settings.php
+++ b/settings.php
@@ -834,8 +834,9 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                 </div>
                                                 <p>Validate DNS replies and cache DNSSEC data. When forwarding DNS
                                                    queries, Pi-hole requests the DNSSEC records needed to validate
-                                                   the replies. Use Google, Norton, DNS.WATCH or Quad9 DNS servers when activating
-                                                   DNSSEC. Note that the size of your log might increase significantly
+                                                   the replies. Use Google, Norton, DNS.WATCH, Quad9, or another DNS
+                                                   server which supports DNSSEC when activating DNSSEC. Note that
+                                                   the size of your log might increase significantly
                                                    when enabling DNSSEC. A DNSSEC resolver test can be found
                                                    <a href="http://dnssec.vs.uni-due.de/" target="_blank">here</a>.</p>
                                                 <label>Conditional Forwarding</label>

--- a/settings.php
+++ b/settings.php
@@ -834,7 +834,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                 </div>
                                                 <p>Validate DNS replies and cache DNSSEC data. When forwarding DNS
                                                    queries, Pi-hole requests the DNSSEC records needed to validate
-                                                   the replies. If a domain fails validation or the upstream does
+                                                   the replies. If a domain fails validation or the upstream does not
                                                    support DNSSEC, this setting can cause issues resolving domains.
                                                    Use Google, Norton, DNS.WATCH, Quad9, or another DNS
                                                    server which supports DNSSEC when activating DNSSEC. Note that


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Improve DNSSEC warning to note that any DNSSEC resolver can be used with the DNSSEC option.

**How does this PR accomplish the above?:**

Now it explains that any DNSSEC-supporting resolver can be used with DNSSEC.

**What documentation changes (if any) are needed to support this PR?:**

None