### PR TITLE
Update dashboard for better fit of small boxes

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@
 ?>
 <!-- Small boxes (Stat box) -->
 <div class="row">
-    <div class="col-lg-3 col-xs-12">
+    <div class="col-lg-3 col-sm-6">
         <!-- small box -->
         <div class="small-box bg-green" id="total_queries" title="only A + AAAA queries">
             <div class="inner">
@@ -24,7 +24,7 @@
         </div>
     </div>
     <!-- ./col -->
-    <div class="col-lg-3 col-xs-12">
+    <div class="col-lg-3 col-sm-6">
         <!-- small box -->
         <div class="small-box bg-aqua">
             <div class="inner">
@@ -37,7 +37,7 @@
         </div>
     </div>
     <!-- ./col -->
-    <div class="col-lg-3 col-xs-12">
+    <div class="col-lg-3 col-sm-6">
         <!-- small box -->
         <div class="small-box bg-yellow">
             <div class="inner">
@@ -50,7 +50,7 @@
         </div>
     </div>
     <!-- ./col -->
-    <div class="col-lg-3 col-xs-12">
+    <div class="col-lg-3 col-sm-6">
         <!-- small box -->
         <div class="small-box bg-red" title="<?php echo gravity_last_update(); ?>">
             <div class="inner">


### PR DESCRIPTION

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Better readability of the dashboard on small and medium devices

`{A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues}`
On the raspberrypi official touchscreen (and other screens that fit "small" and "medium"), the small boxes take up the 12 columns which forces to scroll and is generally ineffective as a quick glance dashboard.

**How does this PR accomplish the above?:**
 I have updated to col-sm-6 so there are 2 boxes on 2 rows so now you can see all those stats plus the queries last 24 without having to scroll. the col-xs-12 is not necessary as it will default to that.
`{A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix}`

**What documentation changes (if any) are needed to support this PR?:**
NONE

`{A detailed list of any necessary changes}`
updated to col-sm-6 from col-xs-12

