### PR TITLE
Fix query types in long term query log being incorrect

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -128,7 +128,37 @@ if (isset($_GET['getAllQueries']) && $auth)
 			while ($row = $results->fetchArray())
 			{
 				$c = resolveHostname($row[3],false);
-				$allQueries[] = [$row[0],$row[1] == 1 ? "IPv4" : "IPv6",$row[2],$c,$row[4]];
+
+				// Convert query type ID to name
+                // Names taken from FTL's query type names
+				switch($row[1]) {
+                    case 1:
+                        $query_type = "A";
+                        break;
+                    case 2:
+                        $query_type = "AAAA";
+                        break;
+                    case 3:
+                        $query_type = "ANY";
+                        break;
+                    case 4:
+                        $query_type = "SRV";
+                        break;
+                    case 5:
+                        $query_type = "SOA";
+                        break;
+                    case 6:
+                        $query_type = "PTR";
+                        break;
+                    case 7:
+                        $query_type = "TXT";
+                        break;
+                    default:
+                        $query_type = "UNKN";
+                        break;
+                }
+
+				$allQueries[] = [$row[0], $query_type, $row[2], $c, $row[4]];
 			}
 	}
 	$result = array('data' => $allQueries);

--- a/api_db.php
+++ b/api_db.php
@@ -130,33 +130,33 @@ if (isset($_GET['getAllQueries']) && $auth)
 				$c = resolveHostname($row[3],false);
 
 				// Convert query type ID to name
-                // Names taken from FTL's query type names
+				// Names taken from FTL's query type names
 				switch($row[1]) {
-                    case 1:
-                        $query_type = "A";
-                        break;
-                    case 2:
-                        $query_type = "AAAA";
-                        break;
-                    case 3:
-                        $query_type = "ANY";
-                        break;
-                    case 4:
-                        $query_type = "SRV";
-                        break;
-                    case 5:
-                        $query_type = "SOA";
-                        break;
-                    case 6:
-                        $query_type = "PTR";
-                        break;
-                    case 7:
-                        $query_type = "TXT";
-                        break;
-                    default:
-                        $query_type = "UNKN";
-                        break;
-                }
+					case 1:
+						$query_type = "A";
+						break;
+					case 2:
+						$query_type = "AAAA";
+						break;
+					case 3:
+						$query_type = "ANY";
+						break;
+					case 4:
+						$query_type = "SRV";
+						break;
+					case 5:
+						$query_type = "SOA";
+						break;
+					case 6:
+						$query_type = "PTR";
+						break;
+					case 7:
+						$query_type = "TXT";
+						break;
+					default:
+						$query_type = "UNKN";
+						break;
+				}
 
 				$allQueries[] = [$row[0], $query_type, $row[2], $c, $row[4]];
 			}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Besides A and AAAA, the other query types would show up as AAAA instead of their actual name.

**How does this PR accomplish the above?:**

The query types are taken from FTL's telnet API code, which are the source of the normal query log's query type names. [link](https://github.com/pi-hole/FTL/blob/7b01d2057f2b87dca9ea8204b4dbaf0272d4e1af/api.c#L590)

**What documentation changes (if any) are needed to support this PR?:**
None