### PR TITLE
Prevent possible attacks via admin email setting

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -476,13 +476,13 @@ function readAdlists()
 				{
 					$adminemail = 'noadminemail';
 				}
-				elseif(!filter_var($adminemail, FILTER_VALIDATE_EMAIL))
+				elseif(!filter_var($adminemail, FILTER_VALIDATE_EMAIL) || strpos($adminemail, "'") !== false)
 				{
 					$error .= "Administrator email address (".htmlspecialchars($adminemail).") is invalid!<br>";
 				}
 				else
 				{
-					exec('sudo pihole -a -e '.$adminemail);
+					exec('sudo pihole -a -e \''.$adminemail.'\'');
 				}
 				if(isset($_POST["boxedlayout"]))
 				{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Prevent a possible attack via the admin email setting. This could only be triggered if you are logged into the web interface, so the risk is low.

**How does this PR accomplish the above?:**

The admin email is now treated as a single string (surrounded by single quotes), and it is not allowed to contain its own single quotes.

**What documentation changes (if any) are needed to support this PR?:**
None