### PR TITLE
Warn if dashboard is NOT accessed over pi.hole

### DIFF
--- a/index.php
+++ b/index.php
@@ -77,6 +77,19 @@
     </div>
     <!-- ./col -->
 </div>
+<!-- Hostname warning box -->
+<div class="row" hidden="true" id="hostname-warning">
+    <div class="col-lg-12">
+        <!-- small box -->
+        <div class="small-box bg-red">
+            <div class="inner">
+                <h4><strong>Warning:</strong> Your client may not be configured to use your Pi-hole as DNS resolver&nbsp;
+                <button type="button" class="btn btn-danger btn-xs pull-right confirm-hidewarning">Click here for further information</button></h4>
+            </div>
+        </div>
+    </div>
+    <!-- ./col -->
+</div>
 
 <div class="row">
     <div class="col-md-12">
@@ -352,4 +365,5 @@ else
     require "scripts/pi-hole/php/footer.php";
 ?>
 
+<script src="scripts/vendor/jquery.confirm.min.js"></script>
 <script src="scripts/pi-hole/js/index.js"></script>

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -1264,4 +1264,31 @@ $(document).ready(function() {
         // Pull in data via AJAX
         updateForwardDestinationsPie();
     }
+
+    // Check if site was accessed over pi.hole
+    // If not: Show warning (but don't do it if the user decided earlier to hide this warning)
+    if(location.host !== "pi.hole" && localStorage.getItem("hostname-warning") !== "hidden")
+    {
+        $("#hostname-warning").attr("hidden", false);
+    }
 });
+
+$(".confirm-hidewarning").confirm({
+    text: "This warning is displayed because you visited this page over "+location.host+" and not <a href=\"http://pi.hole/admin\">pi.hole/admin</a>.<br>You can hide this warning on this client if this is okay.",
+    title: "Confirmation required",
+    confirm(button) {
+        localStorage.setItem("hostname-warning", "hidden");
+        $("#hostname-warning").attr("hidden", true);
+    },
+    cancel(button) {
+        // nothing to do
+    },
+    confirmButton: "Permanently hide this warning",
+    cancelButton: "Go back",
+    post: true,
+    confirmButtonClass: "btn-danger",
+    cancelButtonClass: "btn-success",
+    dialogClass: "modal-dialog modal-mg" // Bootstrap classes for mid-size modal
+});
+
+$(".confirm-hidewarning").show();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Warn users that they may not have their DNS correctly configured when they visit the dashboard over the IP of the Pi-hole (and not the `pi.hole` domain).

**How does this PR accomplish the above?:**

Show warning if dashboard is accessed over something else than `pi.hole/admin`. The warning can be permanently hidden on the client as there are situations where users chose to access the dashboard over, e.g., their own domain. The hiding decision is stored in the browser's local storage. Hence, the warning is shown at least *once* per client that accesses the dashboard "incorrectly".

![screenshot from 2018-11-28 19-10-36](https://user-images.githubusercontent.com/16748619/49172487-82578e00-f341-11e8-822b-5179829de980.png)
![screenshot from 2018-11-28 19-10-20](https://user-images.githubusercontent.com/16748619/49172488-82578e00-f341-11e8-8531-9959e64136e7.png)



**What documentation changes (if any) are needed to support this PR?:**

Probably none.