### PR TITLE
Keep a trailing newline in the regex list when deleting an item

### DIFF
--- a/scripts/pi-hole/php/sub.php
+++ b/scripts/pi-hole/php/sub.php
@@ -36,7 +36,7 @@ switch($type) {
         $list = array_diff($list, array($_POST['domain'], ""));
         $list = implode("\n", $list);
 
-        if(file_put_contents($regexfile, $list) === FALSE)
+        if(file_put_contents($regexfile, $list."\n") === FALSE)
         {
             $err = error_get_last()["message"];
             echo "Unable to remove regex \"".htmlspecialchars($_POST['domain'])."\" from ${regexfile}<br>Error message: $err";


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Fix #874

**How does this PR accomplish the above?:**
Ensure that a trailing newline is kept when an item is deleted from the regex list via the web interface.

**What documentation changes (if any) are needed to support this PR?:**
None