### PR TITLE
Add a route to restart the dns resolved from API

### DIFF
--- a/api.php
+++ b/api.php
@@ -30,6 +30,21 @@ if (isset($_GET['status']))
 		$data = array_merge($data, array("status" => "disabled"));
 	}
 }
+elseif (isset($_GET['restartdns']) && $auth)
+{
+    if (isset($_GET["auth"])) {
+        if ($_GET["auth"] !== $pwhash)
+            die("Not authorized!");
+    } else {
+        // Skip token validation if explicit auth string is provided
+        check_csrf($_GET['token']);
+    }
+    exec('sudo pihole restartdns', $output, $ret);
+    if ($ret !== 0)
+        $data = array_merge($data, array("restartdns" => "fail"));
+    else
+        $data = array_merge($data, array("restartdns" => "success"));
+}
 elseif (isset($_GET['enable']) && $auth)
 {
 	if(isset($_GET["auth"]))


### PR DESCRIPTION
Signed-off-by: fortunate-man <redacted>

**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

The current API does not provide a route to restart the dns resolver (have checked API docs and the api code in this repo), even though the web interface has an option to do so, so does the Pi-hole CLI.

**How does this PR accomplish the above?:**

I have simply added another case to `api.php`. It will invoke `sudo pihole restartdns` if authentication is provided (Pi-hole API token).

**What documentation changes (if any) are needed to support this PR?:**

The API docs will need to be updated with this new route. Should just be a couple of new lines.
