### PR TITLE
Prevent multiple static DHCP entries with same IP

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -558,6 +558,11 @@ function readAdlists()
 							$error .= "Static release for MAC address (".htmlspecialchars($mac).") already defined!<br>";
 							break;
 						}
+						if($ip !== "noip" && $lease["IP"] === $ip)
+						{
+							$error .= "Static release for IP address (".htmlspecialchars($ip).") already defined!<br>";
+							break;
+						}
 					}
 
 					if(!strlen($error))

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -560,7 +560,7 @@ function readAdlists()
 						}
 						if($ip !== "noip" && $lease["IP"] === $ip)
 						{
-							$error .= "Static release for IP address (".htmlspecialchars($ip).") already defined!<br>";
+							$error .= "Static lease for IP address (".htmlspecialchars($ip).") already defined!<br>";
 							break;
 						}
 					}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

*This PR is intentionally opened towards `release/v4.2` and not `development`*

**What does this PR aim to accomplish?:**

Prevent multiple static DHCP entries for the same IP address to get added. Fixes #889

![screenshot at 2019-01-15 17-16-20](https://user-images.githubusercontent.com/16748619/51193835-1aa5d400-18ea-11e9-97e1-a2e2e8965e0a.png)

**How does this PR accomplish the above?:**

Loop over all entries in the static leases file and ensure that the entry we want to add isn't already there. The check was already there (to prevent duplicated MAC addresses) and is only extended by this PR.

**What documentation changes (if any) are needed to support this PR?:**

None