### PR TITLE
Fix a PHP error generated by "Query Lists".

### DIFF
--- a/scripts/pi-hole/php/queryads.php
+++ b/scripts/pi-hole/php/queryads.php
@@ -6,7 +6,9 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-ob_end_flush();
+while (ob_get_level() > 0) {
+    ob_end_flush();
+}
 ini_set("output_buffering", "0");
 ob_implicit_flush(true);
 header('Content-Type: text/event-stream');


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix a PHP error generated by "Query Lists".

Example:
2019/01/18 00:56:46 [error] 19780#19780: *20783 FastCGI sent in stderr: "PHP message: PHP Notice:  ob_end_flush(): failed to delete and flush buffer. No buffer to delete or flush in /var/www/html/admin/scripts/pi-hole/php/queryads.php on line 9" while reading response header from upstream, client: xxx.xxx.xx.xx, server: some.server.lan, request: "GET /admin/scripts/pi-hole/php/queryads.php?domain=windows& HTTP/1.1", upstream: "fastcgi://unix:/run/php/pihole.sock:", host: "some.server.lan", referrer: "https://some.server.lan/admin/queryads.php"