### PR TITLE
Fill long-term data daterange field with initialization value

### DIFF
--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -21,6 +21,7 @@ $(function () {
     {
       timePicker: true, timePickerIncrement: 15,
       locale: { format: "MMMM Do YYYY, HH:mm" },
+      startDate: start__, endDate: end__,
       ranges: {
         "Today": [moment().startOf("day"), moment()],
         "Yesterday": [moment().subtract(1, "days").startOf("day"), moment().subtract(1, "days").endOf("day")],

--- a/scripts/pi-hole/js/db_lists.js
+++ b/scripts/pi-hole/js/db_lists.js
@@ -22,6 +22,7 @@ $(function () {
     {
       timePicker: true, timePickerIncrement: 15,
       locale: { format: "MMMM Do YYYY, HH:mm" },
+      startDate: start__, endDate: end__,
       ranges: {
         "Today": [moment().startOf("day"), moment()],
         "Yesterday": [moment().subtract(1, "days").startOf("day"), moment().subtract(1, "days").endOf("day")],

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -36,6 +36,7 @@ $(function () {
     {
       timePicker: true, timePickerIncrement: 15,
       locale: { format: "MMMM Do YYYY, HH:mm" },
+      startDate: start__, endDate: end__,
       ranges: {
         "Today": [moment().startOf("day"), moment()],
         "Yesterday": [moment().subtract(1, "days").startOf("day"), moment().subtract(1, "days").endOf("day")],


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix #898

**How does this PR accomplish the above?:**

We internally define an initial date range. However, as we forgot to tell the daterange picker about this date range, it showed some default value instead which did not correspond to what the user expects from the shows string.


**What documentation changes (if any) are needed to support this PR?:**

None, this is a pure bugfix.