### PR TITLE
Always show the full requested range in the long-term API results

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -382,6 +382,13 @@ if (isset($_GET['getGraphData']) && $auth)
 	$from = intval((intval($_GET['from'])/$interval)*$interval);
 	$until = intval((intval($_GET['until'])/$interval)*$interval);
 
+	// Count permitted queries in intervals
+	$stmt = $db->prepare('SELECT (timestamp/:interval)*:interval interval, COUNT(*) FROM queries WHERE (status != 0 )'.$limit.' GROUP by interval ORDER by interval');
+	$stmt->bindValue(":from", $from, SQLITE3_INTEGER);
+	$stmt->bindValue(":until", $until, SQLITE3_INTEGER);
+	$stmt->bindValue(":interval", $interval, SQLITE3_INTEGER);
+	$results = $stmt->execute();
+
 	// Parse the DB result into graph data, filling in missing interval sections with zero
 	function parseDBData($results, $interval, $from, $until) {
 		$data = array();
@@ -403,13 +410,6 @@ if (isset($_GET['getGraphData']) && $auth)
 
 		return $data;
 	}
-
-	// Count permitted queries in intervals
-	$stmt = $db->prepare('SELECT (timestamp/:interval)*:interval interval, COUNT(*) FROM queries WHERE (status != 0 )'.$limit.' GROUP by interval ORDER by interval');
-	$stmt->bindValue(":from", $from, SQLITE3_INTEGER);
-	$stmt->bindValue(":until", $until, SQLITE3_INTEGER);
-	$stmt->bindValue(":interval", $interval, SQLITE3_INTEGER);
-	$results = $stmt->execute();
 
 	$domains = parseDBData($results, $interval, $from, $until);
 

--- a/api_db.php
+++ b/api_db.php
@@ -404,9 +404,16 @@ if (isset($_GET['getGraphData']) && $auth)
 				if($max === null || $max < $row[0])
 					$max = $row[0];
 
-				// Get the non-zero graph data
+				// $data[timestamp] = value_in_this_interval
 				$data[$row[0]] = intval($row[1]);
 			}
+
+			// Fall back to $from and $until if we read
+			// no data in the fetchArray while loop above
+			if($min === null)
+				$min = $from;
+			if($max === null)
+				$max = $until;
 
 			// Fill the missing intervals with zero
 			for($i = min($min,$from); $i < max($max,$until); $i += $interval) {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Always show the full requested range in the long-term API results

**How does this PR accomplish the above?:**

Fill data with zero at the end when the daterange is extending into the future. Similarly, fill data will zero at the beginning if the requested range extends into a region without recorded queries. This ensures that we can always show the entire requested interval, even if it begins with zeroes. Example:
![screenshot from 2019-01-20 11-53-52](https://user-images.githubusercontent.com/16748619/51438306-f01d9780-1caa-11e9-9efa-5d573bcb26b4.png)

**What documentation changes (if any) are needed to support this PR?:**

None