### PR TITLE
Long-term data: Show date range only after user chose a valid range.

### DIFF
--- a/db_graph.php
+++ b/db_graph.php
@@ -32,7 +32,7 @@ $token = $_SESSION['token'];
           <div class="input-group-addon">
             <i class="fa fa-clock-o"></i>
           </div>
-          <input type="text" class="form-control pull-right" id="querytime">
+          <input type="text" class="form-control pull-right" id="querytime" value="Click to select date and time range">
         </div>
         <!-- /.input group -->
       </div>

--- a/db_lists.php
+++ b/db_lists.php
@@ -33,7 +33,7 @@ $token = $_SESSION['token'];
           <div class="input-group-addon">
             <i class="fa fa-clock-o"></i>
           </div>
-          <input type="text" class="form-control pull-right" id="querytime">
+          <input type="text" class="form-control pull-right" id="querytime" value="Click to select date and time range">
         </div>
         <!-- /.input group -->
       </div>

--- a/db_queries.php
+++ b/db_queries.php
@@ -33,7 +33,7 @@ $token = $_SESSION['token'];
           <div class="input-group-addon">
             <i class="fa fa-clock-o"></i>
           </div>
-          <input type="text" class="form-control pull-right" id="querytime">
+          <input type="text" class="form-control pull-right" id="querytime" value="Click to select date and time range">
         </div>
         <!-- /.input group -->
       </div>

--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -16,11 +16,13 @@ var until = moment(end__).utc().valueOf()/1000;
 
 var timeoutWarning = $("#timeoutWarning");
 
+var dateformat = "MMMM Do YYYY, HH:mm";
+
 $(function () {
     $("#querytime").daterangepicker(
     {
       timePicker: true, timePickerIncrement: 15,
-      locale: { format: "MMMM Do YYYY, HH:mm" },
+      locale: { format: dateformat },
       ranges: {
         "Today": [moment().startOf("day"), moment()],
         "Yesterday": [moment().subtract(1, "days").startOf("day"), moment().subtract(1, "days").endOf("day")],
@@ -31,7 +33,8 @@ $(function () {
         "This Year": [moment().startOf("year"), moment()],
         "All Time": [moment(0), moment()]
       },
-      "opens": "center", "showDropdowns": true
+      "opens": "center", "showDropdowns": true,
+      "autoUpdateInput": false
     },
     function (startt, endt) {
       from = moment(startt).utc().valueOf()/1000;
@@ -243,6 +246,7 @@ $(document).ready(function() {
 });
 
 $("#querytime").on("apply.daterangepicker", function(ev, picker) {
+    $(this).val(picker.startDate.format(dateformat) + " to " + picker.endDate.format(dateformat));
     $("#queries-over-time").show();
     updateQueriesOverTime();
 });

--- a/scripts/pi-hole/js/db_lists.js
+++ b/scripts/pi-hole/js/db_lists.js
@@ -17,6 +17,8 @@ var until = moment(end__).utc().valueOf()/1000;
 var timeoutWarning = $("#timeoutWarning");
 var listsStillLoading = 0;
 
+var dateformat = "MMMM Do YYYY, HH:mm";
+
 $(function () {
     $("#querytime").daterangepicker(
     {
@@ -32,7 +34,8 @@ $(function () {
         "This Year": [moment().startOf("year"), moment()],
         "All Time": [moment(0), moment()]
       },
-      "opens": "center", "showDropdowns": true
+      "opens": "center", "showDropdowns": true,
+      "autoUpdateInput": false
     },
     function (startt, endt) {
       from = moment(startt).utc().valueOf()/1000;
@@ -190,6 +193,7 @@ function updateTopAdsChart() {
 }
 
 $("#querytime").on("apply.daterangepicker", function(ev, picker) {
+    $(this).val(picker.startDate.format(dateformat) + " to " + picker.endDate.format(dateformat));
     timeoutWarning.show();
     listsStillLoading = 3;
     updateTopClientsChart();

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -18,6 +18,8 @@ var daterange;
 
 var timeoutWarning = $("#timeoutWarning");
 
+var dateformat = "MMMM Do YYYY, HH:mm";
+
 // Do we want to filter queries?
 var GETDict = {};
 location.search.substr(1).split("&").forEach(function(item) {GETDict[item.split("=")[0]] = item.split("=")[1];});
@@ -46,7 +48,8 @@ $(function () {
         "This Year": [moment().startOf("year"), moment()],
         "All Time": [moment(0), moment()]
       },
-      "opens": "center", "showDropdowns": true
+      "opens": "center", "showDropdowns": true,
+      "autoUpdateInput": false
     },
     function (startt, endt) {
       from = moment(startt).utc().valueOf()/1000;
@@ -332,6 +335,7 @@ $(document).ready(function() {
 } );
 
 $("#querytime").on("apply.daterangepicker", function(ev, picker) {
+    $(this).val(picker.startDate.format(dateformat) + " to " + picker.endDate.format(dateformat));
     refreshTableData();
 });
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix #897 

**How does this PR accomplish the above?:**

Show date range only after user chose a valid range.

The key is to set `"autoUpdateInput": false` and to fill in dates/times only as when triggered by the Apply action.

On load, we ask the user to click on the field to open the datetime picker:

![screenshot at 2019-01-22 23-25-22](https://user-images.githubusercontent.com/16748619/51569915-ff186b80-1e9d-11e9-8337-f42e9a1d5407.png)


**What documentation changes (if any) are needed to support this PR?:**

None