### PR TITLE
Clarify wording of DNSSEC Unknown status

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -170,7 +170,7 @@ $(document).ready(function() {
                 dnssec_status = "<br><span style=\"color:red\">ABANDONED</span>";
                 break;
             case "5":
-                dnssec_status = "<br><span style=\"color:red\">?</span>";
+                dnssec_status = "<br><span style=\"color:red\">UNKNOWN</span>";
                 break;
             default: // No DNSSEC
                 dnssec_status = "";


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Clarify the red question mark that appears in the DNSSEC section of the query log for queries loaded from FTL's database. Those queries have the DNSSEC status set to unknown, because that information is not stored in the database: https://github.com/pi-hole/FTL/pull/461

**How does this PR accomplish the above?:**
Change the question mark to "UNKNOWN"

**What documentation changes (if any) are needed to support this PR?:**
None