### PR TITLE
Implement finer grained external blocking displaying

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -278,7 +278,19 @@ $(document).ready(function() {
               case 6:
                 blocked = true;
                 color = "red";
-                fieldtext = "Blocked <br class='hidden-lg'>(external)";
+                fieldtext = "Blocked <br class='hidden-lg'>(external, IP)";
+                buttontext = "" ;
+                break;
+              case 7:
+                blocked = true;
+                color = "red";
+                fieldtext = "Blocked <br class='hidden-lg'>(external, NULL)";
+                buttontext = "" ;
+                break;
+              case 8:
+                blocked = true;
+                color = "red";
+                fieldtext = "Blocked <br class='hidden-lg'>(external, NXRA)";
                 buttontext = "" ;
                 break;
               default:

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -213,7 +213,19 @@ $(document).ready(function() {
             case "6":
                 blocked = true;
                 color = "red";
-                fieldtext = "Blocked <br class='hidden-lg'>(external)";
+                fieldtext = "Blocked <br class='hidden-lg'>(external, IP)";
+                buttontext = "" ;
+                break;
+            case "7":
+                blocked = true;
+                color = "red";
+                fieldtext = "Blocked <br class='hidden-lg'>(external, NULL)";
+                buttontext = "" ;
+                break;
+            case "8":
+                blocked = true;
+                color = "red";
+                fieldtext = "Blocked <br class='hidden-lg'>(external, NXRA)";
                 buttontext = "" ;
                 break;
             default:

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -170,7 +170,7 @@ $(document).ready(function() {
                 dnssec_status = "<br><span style=\"color:red\">ABANDONED</span>";
                 break;
             case "5":
-                dnssec_status = "<br><span style=\"color:red\">UNKNOWN</span>";
+                dnssec_status = "<br><span style=\"color:orange\">UNKNOWN</span>";
                 break;
             default: // No DNSSEC
                 dnssec_status = "";
@@ -231,7 +231,7 @@ $(document).ready(function() {
             default:
                 blocked = false;
                 color = "black";
-                fieldtext = "Unknown";
+                fieldtext = "Unknown ("+parseInt(data[4])+")";
                 buttontext = "";
             }
             $(row).css("color", color);
@@ -278,7 +278,7 @@ $(document).ready(function() {
                     replytext = "upstream error";
                     break;
                 default:
-                    replytext = "? ("+data[6]+")";
+                    replytext = "? ("+parseInt(data[6])+")";
                 }
             }
             else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Implement finer grained external blocking displaying

Exemplary output with Quad9 as upstream provider (NXDOMAIN + RA bit signaling the externally blocked status):

![screenshot from 2019-02-04 17-44-31](https://user-images.githubusercontent.com/16748619/52222992-0def1d00-28a5-11e9-93fc-801c55985a1d.png)


**How does this PR accomplish the above?:**

Acknowledge the new blocking status messages `QUERY_EXTERNAL_BLOCKED_IP, QUERY_EXTERNAL_BLOCKED_NULL, QUERY_EXTERNAL_BLOCKED_NXRA` added in `pihole-FTL` by https://github.com/pi-hole/FTL/pull/490
