### PR TITLE
add local hostname with trailing period to list of CORS domains

### DIFF
--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -32,6 +32,7 @@ function check_cors() {
         $ipv4,
         $ipv6,
         str_replace(array("[","]"), array("",""), $_SERVER["SERVER_NAME"]),
+        str_replace(array("[","]"), array("",""), $_SERVER["SERVER_NAME"]). ".",
         "pi.hole",
         "localhost"
     );


### PR DESCRIPTION
Signed-off-by: Dustin Cowles <dustin@dustincowles.com>

**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Allows the pi-hole host to be accessed via a local resolved domain with a trailing period. To enable this, the CORS domains need to include the server hostname with a trailing period at the end, otherwise save buttons return a CORS error.

**How does this PR accomplish the above?:**

Appends the server name with a trailing period to the list used by check_cors()

**What documentation changes (if any) are needed to support this PR?:**

N/A