### PR TITLE
Long-term queries: Request all externally blocked variants when the checkbox is enabled

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -170,7 +170,9 @@ function getQueryTypes()
     }
     if($("#type_external").prop("checked"))
     {
-        queryType.push(6);
+        // Multiple IDs correspond to this status
+        // We request queries with all of them
+        queryType.push([6,7,8]);
     }
     return queryType.join(",");
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/bXlob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Allow all types of externally blocked queries to be requested in the long-term queries table

**How does this PR accomplish the above?:**

Query all three possible types of externally blocked queries instead of only one.

**What documentation changes (if any) are needed to support this PR?:**

None