### PR TITLE
Fix audit log button being too wide

### DIFF
--- a/auditlog.php
+++ b/auditlog.php
@@ -75,13 +75,7 @@
     <!-- /.col -->
 </div>
 <!-- /.row -->
-<div class="container">
-  <div class="row justify-content-md-right">
-    <div class="col-2">
-      <button class="btn btn-lg btn-primary btn-block" id="gravityBtn" disabled="true">Update black-/whitelists</button>
-    </div>
-  </div>
-</div>
+<button class="btn btn-lg btn-primary btn-block" id="gravityBtn" disabled="true">Update black-/whitelists</button>
 
 <script src="scripts/pi-hole/js/auditlog.js"></script>
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Fix the button from being wider than the page:
![image](https://user-images.githubusercontent.com/4417660/56874156-e2378b00-69ec-11e9-8d61-6b04b99a3987.png)

**How does this PR accomplish the above?:**
All of the divs surrounding the button tag were unnecessary.
![image](https://user-images.githubusercontent.com/4417660/56874173-0e530c00-69ed-11e9-95d8-080f78c211a9.png)

**What documentation changes (if any) are needed to support this PR?:**
None