### PR TITLE
Replace fa-refresh with fa-sync

### DIFF
--- a/auditlog.php
+++ b/auditlog.php
@@ -35,7 +35,7 @@
             </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -62,7 +62,7 @@
             </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>

--- a/db_graph.php
+++ b/db_graph.php
@@ -55,7 +55,7 @@ $token = $_SESSION['token'];
           </div>
         </div>
         <div class="overlay" hidden="true">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>

--- a/db_lists.php
+++ b/db_lists.php
@@ -75,7 +75,7 @@ else
             </div>
         </div>
         <div class="overlay" hidden>
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -102,7 +102,7 @@ else
             </div>
         </div>
         <div class="overlay" hidden>
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -129,7 +129,7 @@ else
             </div>
         </div>
         <div class="overlay" hidden>
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>

--- a/index.php
+++ b/index.php
@@ -90,7 +90,7 @@
           </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -115,7 +115,7 @@
           </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -137,7 +137,7 @@
           </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -156,7 +156,7 @@
           </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -197,7 +197,7 @@
           </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -214,7 +214,7 @@
           </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -254,7 +254,7 @@ else
             </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -281,7 +281,7 @@ else
             </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -310,7 +310,7 @@ else
             </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>
@@ -338,7 +338,7 @@ else
             </div>
         </div>
         <div class="overlay">
-          <i class="fa fa-refresh fa-spin"></i>
+          <i class="fa fa-sync fa-spin"></i>
         </div>
         <!-- /.box-body -->
       </div>

--- a/list.php
+++ b/list.php
@@ -42,7 +42,7 @@ function getFullName() {
     <?php }else{ ?>
         <button id="btnAdd" class="btn btn-default" type="button">Add</button>
     <?php } ?>
-        <button id="btnRefresh" class="btn btn-default" type="button"><i class="fa fa-refresh"></i></button>
+        <button id="btnRefresh" class="btn btn-default" type="button"><i class="fa fa-sync"></i></button>
     </span>
 </div>
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Fix #941

**How does this PR accomplish the above?:**
Font Awesome 5 replaced the refresh icon from 4 with fa-sync:
https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4#name-changes

**What documentation changes (if any) are needed to support this PR?:**
None