### PR TITLE
Fix the sidebar toggle from overflowing when hovered over

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -100,7 +100,7 @@
     }
 }
 
-.main-header>.navbar {
+.main-header>.navbar, .navbar>.sidebar-toggle {
   height: 50px;
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Fix #945

**How does this PR accomplish the above?:**
Require the toggle button's height to match the nav bar.
Thanks to @Th3M3 for finding the issue and solution.

**What documentation changes (if any) are needed to support this PR?:**
None