### PR TITLE
Add button for pihole arpflush on Pi-hole settings page

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -82,19 +82,19 @@ $(".confirm-flushlogs").confirm({
 	dialogClass: "modal-dialog modal-mg"
 });
 
-$(".confirm-disablelogging").confirm({
-	text: "Are you sure you want to disable logging and flush your Pi-hole logs?",
+$(".confirm-flusharp").confirm({
+	text: "Are you sure you want to flush your network table?",
 	title: "Confirmation required",
 	confirm(button) {
-		$("#disablelogsform").submit();
+		$("#flusharpform").submit();
 	},
 	cancel(button) {
 		// nothing to do
 	},
-	confirmButton: "Yes, disable logs and flush my logs",
+	confirmButton: "Yes, flush my network table",
 	cancelButton: "No, go back",
 	post: true,
-	confirmButtonClass: "btn-danger",
+	confirmButtonClass: "btn-warning",
 	cancelButtonClass: "btn-success",
 	dialogClass: "modal-dialog modal-mg"
 });

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -738,7 +738,7 @@ function readAdlists()
 			// Flush network table
 			case "flusharp":
 				exec("sudo pihole arpflush quiet", $output);
-				$error = implode($output, "<br>");
+				$error = implode("<br>", $output);
 				if(strlen($error) == 0)
 				{
 					$success .= "The network table has been flushed";

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -735,6 +735,15 @@ function readAdlists()
 					$error .= "Invalid privacy level (".$level.")!";
 				}
 				break;
+			// Flush network table
+			case "flusharp":
+				exec("sudo pihole arpflush quiet", $output);
+				$error = implode($output, "<br>");
+				if(strlen($error) == 0)
+				{
+					$success .= "The network table has been flushed";
+				}
+				break;
 
 			default:
 				// Option not found

--- a/settings.php
+++ b/settings.php
@@ -1331,9 +1331,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                         </div>
                                         <p class="hidden-md hidden-lg"></p>
                                         <div class="col-md-4">
-                                            <?php if ($piHoleLogging) { ?>
-                                                <button type="button" class="btn btn-danger confirm-disablelogging form-control">Disable query logging and flush logs</button>
-                                            <?php } ?>
+                                                <button type="button" class="btn btn-warning confirm-flusharp form-control">Flush network table</button>
                                         </div>
                                         <p class="hidden-md hidden-lg"></p>
                                         <div class="col-md-4">
@@ -1359,9 +1357,8 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                         <input type="hidden" name="field" value="flushlogs">
                                         <input type="hidden" name="token" value="<?php echo $token ?>">
                                     </form>
-                                    <form role="form" method="post" id="disablelogsform">
-                                        <input type="hidden" name="field" value="Logging">
-                                        <input type="hidden" name="action" value="Disable">
+                                    <form role="form" method="post" id="flusharpform">
+                                        <input type="hidden" name="field" value="flusharp">
                                         <input type="hidden" name="token" value="<?php echo $token ?>">
                                     </form>
                                     <form role="form" method="post" id="disablelogsform-noflush">


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Front end implementation for https://github.com/pi-hole/pi-hole/pull/2769 (merge the core PR first!)

**How does this PR accomplish the above?:**

Replace "Disable and flush logs" button by a new "Flush network table" button. The previous functionality is still available, flushing and disabling logging are now two separate clicks.

![Screenshot from 2019-05-30 22-05-26](https://user-images.githubusercontent.com/16748619/58661153-6f8d3880-8327-11e9-8889-d72930d0857e.png)


**What documentation changes (if any) are needed to support this PR?:**
Should be added to the docs pages.