### PR TITLE
Lists: Highlight if domains are disabled

### DIFF
--- a/scripts/pi-hole/js/list.js
+++ b/scripts/pi-hole/js/list.js
@@ -14,7 +14,8 @@ var fullName = listType === "white" ? "Whitelist" : "Blacklist";
 
 function addListEntry(entry, index, list, button, type)
 {
-    var used = entry.enabled === "1" ? "used" : "not-used";
+    var used = (entry.enabled === "1" && entry.group_enabled === "1") ? "used" : "not-used";
+    var groupmessage = entry.group_enabled === "1" ? "" : "(disabled due to group)";
     var comment = entry.comment.length > 0 ? "&nbsp;-&nbsp;" + entry.comment : "";
     var date_added = new Date(parseInt(entry.date_added)*1000);
     var date_modified = new Date(parseInt(entry.date_modified)*1000);
@@ -23,7 +24,7 @@ function addListEntry(entry, index, list, button, type)
     list.append(
         "<li id=\"" + index + "\" class=\"list-group-item " + used + " clearfix\">" +
         "<span title=\"" + tooltip + "\" data-toggle=\"tooltip\" data-placement=\"right\">" +
-        entry.domain + comment + "</span>" +
+        entry.domain + comment + " " + groupmessage + "</span>" +
         "<button class=\"btn btn-danger btn-xs pull-right\" type=\"button\">" +
         "<span class=\"glyphicon glyphicon-trash\"></span></button></li>"
     );

--- a/scripts/pi-hole/js/list.js
+++ b/scripts/pi-hole/js/list.js
@@ -14,9 +14,17 @@ var fullName = listType === "white" ? "Whitelist" : "Blacklist";
 
 function addListEntry(entry, index, list, button, type)
 {
-    var used = (entry.enabled === "1" && entry.group_enabled === "1") ? "used" : "not-used";
-    var groupmessage = entry.group_enabled === "1" ? "" : "(disabled due to group)";
+    var disabled = [];
+    if(entry.enabled === "0")
+       disabled.push("individual");
+    // For entry.group_enabled we either get "0" (= disabled by a group),
+    // "1" (= enabled by a group), or "" (= not managed by a group)
+    if(entry.group_enabled === "0")
+        disabled.push("group");
+
+    var used = disabled.length === 0 ? "used" : "not-used";
     var comment = entry.comment.length > 0 ? "&nbsp;-&nbsp;" + entry.comment : "";
+    var disabled_message = disabled.length > 0 ? "&nbsp;-&nbsp;disabled due to " + disabled.join(" + ") + " setting" : "";
     var date_added = new Date(parseInt(entry.date_added)*1000);
     var date_modified = new Date(parseInt(entry.date_modified)*1000);
     var tooltip = "Added: " + date_added.toLocaleString() +
@@ -24,7 +32,7 @@ function addListEntry(entry, index, list, button, type)
     list.append(
         "<li id=\"" + index + "\" class=\"list-group-item " + used + " clearfix\">" +
         "<span title=\"" + tooltip + "\" data-toggle=\"tooltip\" data-placement=\"right\">" +
-        entry.domain + comment + " " + groupmessage + "</span>" +
+        entry.domain + comment + disabled_message + "</span>" +
         "<button class=\"btn btn-danger btn-xs pull-right\" type=\"button\">" +
         "<span class=\"glyphicon glyphicon-trash\"></span></button></li>"
     );

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -20,14 +20,18 @@ $db = SQLite3_connect($GRAVITYDB);
 function getTableContent($listname) {
 	global $db;
 	$entries = array();
-	$results = $db->query("SELECT a.*,b.enabled AS group_enabled FROM $listname a INNER JOIN domain_groups b ON b.id = a.group_id");
+	$querystr = implode(" ",array("SELECT DISTINCT ${listname}.*,\"group\".enabled as group_enabled",
+	                              "FROM $listname",
+	                              "LEFT JOIN ${listname}_by_group ON ${listname}_by_group.whitelist_id = ${listname}.id",
+	                              "LEFT JOIN \"group\" ON \"group\".id = ${listname}_by_group.group_id;"));
+	$results = $db->query($querystr);
 
 	while($results !== false && $res = $results->fetchArray(SQLITE3_ASSOC))
 	{
 		array_push($entries, $res);
 	}
 
-	return array($listname => $entries);
+	return array($listname => $entries, "querystring" => $querystr);
 }
 
 function filterArray(&$inArray) {

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -20,10 +20,11 @@ $db = SQLite3_connect($GRAVITYDB);
 function getTableContent($listname) {
 	global $db;
 	$entries = array();
-	$querystr = implode(" ",array("SELECT DISTINCT ${listname}.*,\"group\".enabled as group_enabled",
+	$querystr = implode(" ",array("SELECT ${listname}.*,\"group\".enabled as group_enabled",
 	                              "FROM $listname",
 	                              "LEFT JOIN ${listname}_by_group ON ${listname}_by_group.whitelist_id = ${listname}.id",
-	                              "LEFT JOIN \"group\" ON \"group\".id = ${listname}_by_group.group_id;"));
+	                              "LEFT JOIN \"group\" ON \"group\".id = ${listname}_by_group.group_id",
+	                              "GROUP BY domain;"));
 	$results = $db->query($querystr);
 
 	while($results !== false && $res = $results->fetchArray(SQLITE3_ASSOC))

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -22,7 +22,7 @@ function getTableContent($listname) {
 	$entries = array();
 	$querystr = implode(" ",array("SELECT ${listname}.*,\"group\".enabled as group_enabled",
 	                              "FROM $listname",
-	                              "LEFT JOIN ${listname}_by_group ON ${listname}_by_group.whitelist_id = ${listname}.id",
+	                              "LEFT JOIN ${listname}_by_group ON ${listname}_by_group.${listname}_id = ${listname}.id",
 	                              "LEFT JOIN \"group\" ON \"group\".id = ${listname}_by_group.group_id",
 	                              "GROUP BY domain;"));
 	$results = $db->query($querystr);

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -32,7 +32,7 @@ function getTableContent($listname) {
 		array_push($entries, $res);
 	}
 
-	return array($listname => $entries, "querystring" => $querystr);
+	return array($listname => $entries);
 }
 
 function filterArray(&$inArray) {

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -20,7 +20,7 @@ $db = SQLite3_connect($GRAVITYDB);
 function getTableContent($listname) {
 	global $db;
 	$entries = array();
-	$results = $db->query("SELECT * FROM $listname");
+	$results = $db->query("SELECT a.*,b.enabled AS group_enabled FROM $listname a INNER JOIN domain_groups b ON b.id = a.group_id");
 
 	while($results !== false && $res = $results->fetchArray(SQLITE3_ASSOC))
 	{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Show if entry is disabled and why. This PR is a consequence of https://github.com/pi-hole/pi-hole/pull/2803 and does not work without this.

If a domains is disabled, this is highlighted by an extra text behind the user comment:
![Screenshot from 2019-06-16 20-06-53](https://user-images.githubusercontent.com/16748619/59567847-5e586180-9073-11e9-980f-a0fa6ec2c626.png)

**How does this PR accomplish the above?:**

Generate and pass `group_enabled` boolean to web interface to show if entry was disabled due to group setting. Although it is not planned to add group-based management of domains to the current web interface, showing the status may nevertheless help in debugging if users interact the database directly.

**What documentation changes (if any) are needed to support this PR?:**

The effect of this PR is self-explanatory and does not need to be documented on its own.