### PR TITLE
Use the renamed adlist table when getting adlists

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -174,7 +174,7 @@ function readAdlists()
 	$db = SQLite3_connect(getGravityDBFilename());
 	if ($db)
 	{
-		$results = $db->query("SELECT * FROM adlists");
+		$results = $db->query("SELECT * FROM adlist");
 
 		while($results !== false && $res = $results->fetchArray(SQLITE3_ASSOC))
 		{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Fix an error shown on the settings page:
![image](https://user-images.githubusercontent.com/4417660/60683851-08473480-9e4f-11e9-9ecb-c2b9567589d5.png)

**How does this PR accomplish the above?:**
Use the `adlist` table instead of `adlists`, as it renamed as part of pi-hole/pi-hole#2803

**What documentation changes (if any) are needed to support this PR?:**
None