### PR TITLE
Feature: Batch audit requests

### DIFF
--- a/scripts/pi-hole/js/auditlog.js
+++ b/scripts/pi-hole/js/auditlog.js
@@ -5,7 +5,7 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 // Define global variables
-var timeLineChart, queryTypeChart, forwardDestinationChart;
+var timeLineChart, queryTypeChart, forwardDestinationChart, auditList = [], auditTimeout;
 
 // Credit: http://stackoverflow.com/questions/1787322/htmlspecialchars-equivalent-in-javascript/4835406#4835406
 function escapeHtml(text) {
@@ -96,7 +96,7 @@ $(document).ready(function() {
         }
         else
         {
-            add(url,"audit");
+            auditUrl(url);
         }
     });
 
@@ -109,10 +109,26 @@ $(document).ready(function() {
         }
         else
         {
-            add(url,"audit");
+            auditUrl(url);
         }
     });
 });
+
+function auditUrl(url) {
+    if (auditList.indexOf(url) > -1) {
+        return;
+    }
+    if (auditTimeout) {
+        clearTimeout(auditTimeout);
+    }
+    auditList.push(url);
+    // wait 3 seconds to see if more domains need auditing
+    // and batch them all into a single request
+    auditTimeout = setTimeout(function() {
+        add(auditList.join(' '), "audit");
+        auditList = [];
+    }, 3000);
+}
 
 
 $("#gravityBtn").on("click", function() {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Auditing gets a bit slow on the RPi 3+ after the audit list gets large enough. Often, when I audit domains, I'll click `audit` quickly on many items in the list and then wait for the refresh. This change batches all the audit requests into a single request (audit actions taken within a three second grace period) - theoretically using less resources.

**How does this PR accomplish the above?:**

The API already supports adding multiple domains at once to a list. Since the API already supports it, all I had to do was add a timeout when auditing domains to wait and see if the user is auditing more then one domain or not. I ended up using three seconds to wait for more auditing domains - I feel like this is a decent trade-off between slowing down single-audit users vs. multi-audit users. If the user is just clicking the same domain multiple times - then it is ignore and more time is not added to the timeout.

**What documentation changes (if any) are needed to support this PR?:**

No documentation changes needed as far as I'm aware.
