### PR TITLE
Add DHCP leases export/import from teleporter

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -234,8 +234,13 @@ $("button[id^='adlist-btn-']").on("click", function (e) {
 
 // Change "?tab=" parameter in URL for save and reload
 $(".nav-tabs a").on("shown.bs.tab", function (e) {
-    window.history.pushState("", "", "?tab=" + e.target.hash.substring(1));
-    window.scrollTo(0, 0);
+	var tab = e.target.hash.substring(1);
+    window.history.pushState("", "", "?tab=" + tab);
+	if(tab === "piholedhcp")
+	{
+		location.reload();
+	}
+	window.scrollTo(0, 0);
 });
 
 // Auto dismissal for info notifications

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -6,7 +6,7 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-if(basename($_SERVER['SCRIPT_FILENAME']) !== "settings.php")
+if(!in_array(basename($_SERVER['SCRIPT_FILENAME']), array("settings.php", "teleporter.php"), true))
 {
 	die("Direct access to this script is forbidden!");
 }
@@ -66,18 +66,15 @@ function validEmail($email)
 		&& escapeshellcmd($email) === $email;
 }
 
-$dhcp_static_leases = array();
-function readStaticLeasesFile()
-{
-	global $dhcp_static_leases;
-	$dhcp_static_leases = array();
+function processStaticLeasesFile($file_path) {
+	$dhcp_static_leases_local = array();
 	try
 	{
-		$dhcpstatic = @fopen('/etc/dnsmasq.d/04-pihole-static-dhcp.conf', 'r');
+		$dhcpstatic = @fopen($file_path, 'r');
 	}
 	catch(Exception $e)
 	{
-		echo "Warning: Failed to read /etc/dnsmasq.d/04-pihole-static-dhcp.conf, this is not an error";
+		echo "Warning: Failed to read $file_path, this is not an error";
 		return false;
 	}
 
@@ -93,21 +90,34 @@ function readStaticLeasesFile()
 		{
 			if(validIP($one) && strlen($two) == 0)
 				// dhcp-host=mac,IP - no HOST
-				array_push($dhcp_static_leases,["hwaddr"=>$mac, "IP"=>$one, "host"=>""]);
+				array_push($dhcp_static_leases_local,["hwaddr"=>$mac, "IP"=>$one, "host"=>""]);
 			elseif(strlen($two) == 0)
 				// dhcp-host=mac,hostname - no IP
-				array_push($dhcp_static_leases,["hwaddr"=>$mac, "IP"=>"", "host"=>$one]);
+				array_push($dhcp_static_leases_local,["hwaddr"=>$mac, "IP"=>"", "host"=>$one]);
 			else
 				// dhcp-host=mac,IP,hostname
-				array_push($dhcp_static_leases,["hwaddr"=>$mac, "IP"=>$one, "host"=>$two]);
+				array_push($dhcp_static_leases_local,["hwaddr"=>$mac, "IP"=>$one, "host"=>$two]);
 		}
 		else if(validIP($one) && validDomain($mac))
 		{
 			// dhcp-host=hostname,IP - no MAC
-			array_push($dhcp_static_leases,["hwaddr"=>"", "IP"=>$one, "host"=>$mac]);
+			array_push($dhcp_static_leases_local,["hwaddr"=>"", "IP"=>$one, "host"=>$mac]);
 		}
 	}
-	return true;
+	return $dhcp_static_leases_local;
+}
+
+$dhcp_static_leases = array();
+function readStaticLeasesFile()
+{
+	global $dhcp_static_leases;
+	$dhcp_static_leases = array();
+	$result = processStaticLeasesFile('/etc/dnsmasq.d/04-pihole-static-dhcp.conf');
+	if($result !== false) {
+		$dhcp_static_leases = $result;
+			return true;
+	}
+	return $result;
 }
 
 function isequal(&$argument, &$compareto) {
@@ -183,6 +193,66 @@ function readAdlists()
 		$db->close();
 	}
 	return $list;
+}
+
+function addDHCPLease($mac, $ip, $hostname) {
+	$result = array('message' => "", 'value' => false);
+
+	if(!validMAC($mac))
+	{
+		$result['message'] .= "MAC address (".htmlspecialchars($mac).") is invalid!<br>";
+	}
+	$mac = strtoupper($mac);
+
+	if(!validIP($ip) && strlen($ip) > 0)
+	{
+		$result['message'] .= "IP address (".htmlspecialchars($ip).") is invalid!<br>";
+	}
+
+	if(!validDomain($hostname) && strlen($hostname) > 0)
+	{
+		$result['message'] .= "Host name (".htmlspecialchars($hostname).") is invalid!<br>";
+	}
+
+	if(strlen($hostname) == 0 && strlen($ip) == 0)
+	{
+		$result['message'] .= "You can not omit both the IP address and the host name!<br>";
+	}
+
+	if(strlen($hostname) == 0)
+		$hostname = "nohost";
+
+	if(strlen($ip) == 0)
+		$ip = "noip";
+
+	// Test if this lease is already included
+	readStaticLeasesFile();
+	global $dhcp_static_leases;
+	foreach($dhcp_static_leases as $lease) {
+		if($lease["hwaddr"] === $mac)
+		{
+			$result['message'] .= "Static release for MAC address (".htmlspecialchars($mac).") already defined!<br>";
+			break;
+		}
+		if($ip !== "noip" && $lease["IP"] === $ip)
+		{
+			$result['message'] .= "Static lease for IP address (".htmlspecialchars($ip).") already defined!<br>";
+			break;
+		}
+		if($lease["host"] === $hostname)
+		{
+			$result['message'] .= "Static lease for hostname (".htmlspecialchars($hostname).") already defined!<br>";
+			break;
+		}
+	}
+
+	if(!strlen($result['message']))
+	{
+		exec("sudo pihole -a addstaticdhcp ".$mac." ".$ip." ".$hostname);
+		$result['message'] = "A new static address has been added";
+		$result['value'] = true;
+	}
+	return $result;
 }
 
 	// Read available adlists
@@ -534,61 +604,11 @@ function readAdlists()
 
 				if(isset($_POST["addstatic"]))
 				{
-					$mac = $_POST["AddMAC"];
-					$ip = $_POST["AddIP"];
-					$hostname = $_POST["AddHostname"];
-
-					if(!validMAC($mac))
-					{
-						$error .= "MAC address (".htmlspecialchars($mac).") is invalid!<br>";
-					}
-					$mac = strtoupper($mac);
-
-					if(!validIP($ip) && strlen($ip) > 0)
-					{
-						$error .= "IP address (".htmlspecialchars($ip).") is invalid!<br>";
-					}
-
-					if(!validDomain($hostname) && strlen($hostname) > 0)
-					{
-						$error .= "Host name (".htmlspecialchars($hostname).") is invalid!<br>";
-					}
-
-					if(strlen($hostname) == 0 && strlen($ip) == 0)
-					{
-						$error .= "You can not omit both the IP address and the host name!<br>";
-					}
-
-					if(strlen($hostname) == 0)
-						$hostname = "nohost";
-
-					if(strlen($ip) == 0)
-						$ip = "noip";
-
-					// Test if this lease is already included
-					readStaticLeasesFile();
-					foreach($dhcp_static_leases as $lease) {
-						if($lease["hwaddr"] === $mac)
-						{
-							$error .= "Static release for MAC address (".htmlspecialchars($mac).") already defined!<br>";
-							break;
-						}
-						if($ip !== "noip" && $lease["IP"] === $ip)
-						{
-							$error .= "Static lease for IP address (".htmlspecialchars($ip).") already defined!<br>";
-							break;
-						}
-						if($lease["host"] === $hostname)
-						{
-							$error .= "Static lease for hostname (".htmlspecialchars($hostname).") already defined!<br>";
-							break;
-						}
-					}
-
-					if(!strlen($error))
-					{
-						exec("sudo pihole -a addstaticdhcp ".$mac." ".$ip." ".$hostname);
-						$success .= "A new static address has been added";
+					$result = addDHCPLease($_POST["AddMAC"], $_POST["AddIP"], $_POST["AddHostname"]);
+					if($result['value']) {
+						$success .= $result['message'];
+					} else {
+						$error .= $result['message'];
 					}
 					break;
 				}

--- a/settings.php
+++ b/settings.php
@@ -1162,6 +1162,11 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                                       checked>
                                                             Audit log</label>
                                                     </div>
+                                                    <div class="checkbox">
+                                                        <label><input type="checkbox" name="dhcpleases" value="true"
+                                                                      checked>
+                                                            DHCP Leases</label>
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div class="col-lg-6 col-md-12">

--- a/settings.php
+++ b/settings.php
@@ -1140,7 +1140,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                     <div class="box-body">
                                         <div class="row">
                                             <div class="col-lg-6 col-md-12">
-                                                <label>Import ...</label>
+                                                <label>Import...</label>
                                                 <div class="form-group">
                                                     <div class="checkbox">
                                                         <label><input type="checkbox" name="whitelist" value="true"
@@ -1173,9 +1173,9 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                             Audit log</label>
                                                     </div>
                                                     <div class="checkbox">
-                                                        <label><input type="checkbox" name="dhcpleases" value="true"
+                                                        <label><input type="checkbox" name="staticdhcpleases" value="true"
                                                                       checked>
-                                                            DHCP Leases</label>
+                                                            Static DHCP Leases</label>
                                                     </div>
                                                 </div>
                                             </div>


### PR DESCRIPTION
Signed-off-by: trimalcione <okchtioui@gmail.com>

**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

It adds a feature to Teleporter, in particular the export and import of DHCP leases.

**How does this PR accomplish the above?:**

For the export:
it adds the entire folder _dnsmasq.d_ to the archive to export. In _dnsmasq.d/04-pihole-static-dhcp.conf_ there are all the DHCP leases saved.

For the import:
it reads the leases from the archive uploaded. Then the entries are checked and validated, in order to avoid adding entries with errors in the _04-pihole-static-dhcp.conf_ file used from dnsmasq.d service. After the entry is validated, it is imported.
The validation method for checking and adding the DHCP leases is the same used from the interface, I did no new implementations, I just did some refactoring.

**What documentation changes (if any) are needed to support this PR?:**

To update the GIF of [this section](https://github.com/pi-hole/AdminLTE#the-ability-to-easily-manage-and-configure-pi-hole-features)
