### PR TITLE
Use gravity updated timestamp from database

### DIFF
--- a/scripts/pi-hole/php/gravity.php
+++ b/scripts/pi-hole/php/gravity.php
@@ -6,46 +6,56 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-function gravity_last_update($raw = false){
-    /*
-    @walter-exit <walter@exclusive-it.nl> | April 23rd, 2018:
-    Checks when the gravity list was last updated, if it exists at all.
-    Returns the info in human-readable format for use on the dashboard,
-    or raw for use by the API.
-    */
-    $gravitylist = "/etc/pihole/gravity.list";
-    if (file_exists($gravitylist)){
-        $date_file_created_unix = filemtime($gravitylist);
-        $date_file_created = date_create("@".$date_file_created_unix);
-        $date_now = date_create("now");
-        $gravitydiff = date_diff($date_file_created,$date_now);
-        if($raw){
-            $output = array(
-                "file_exists"=> true,
-                "absolute" => $date_file_created_unix,
-                "relative" => array(
-                    "days" =>  $gravitydiff->format("%a"),
-                    "hours" =>  $gravitydiff->format("%H"),
-                    "minutes" =>  $gravitydiff->format("%I"),
-                )
-            );
-        }else{
-            if($gravitydiff->d > 1){
-                $output = $gravitydiff->format("Blocking list updated %a days, %H:%I ago");
-            }elseif($gravitydiff->d == 1){
-                $output = $gravitydiff->format("Blocking list updated one day, %H:%I ago");
-            }else{
-                $output = $gravitydiff->format("Blocking list updated %H:%I ago");
-            }
-        }
-    }else{
-        if($raw){
-            $output = array("file_exists"=>false);
-        }else{
-            $output = "Blocking list not found";	
-        }
-    }
-    return $output;
-}
+require "scripts/pi-hole/php/database.php";
 
+function gravity_last_update($raw = false)
+{
+	$db = SQLite3_connect(getGravityDBFilename());
+	$date_file_created_unix = $db->querySingle("SELECT value FROM info WHERE property = 'updated';");
+	if($date_file_created_unix !== false)
+	{
+		$date_file_created = date_create("@".intval($date_file_created_unix));
+		$date_now = date_create("now");
+		$gravitydiff = date_diff($date_file_created,$date_now);
+		if($raw)
+		{
+			$output = array(
+			"file_exists"=> true,
+			"absolute" => $date_file_created_unix,
+			"relative" => array(
+				"days" =>  $gravitydiff->format("%a"),
+				"hours" =>  $gravitydiff->format("%H"),
+				"minutes" =>  $gravitydiff->format("%I"),
+				)
+			);
+		}
+		else
+		{
+			if($gravitydiff->d > 1)
+			{
+				$output = $gravitydiff->format("Blocking list updated %a days, %H:%I ago");
+			}
+			elseif($gravitydiff->d == 1)
+			{
+				$output = $gravitydiff->format("Blocking list updated one day, %H:%I ago");
+			}
+			else
+			{
+				$output = $gravitydiff->format("Blocking list updated %H:%I ago");
+			}
+		}
+	}
+	else
+	{
+		if($raw)
+		{
+			$output = array("file_exists" => false);
+		}
+		else
+		{
+			$output = "Gravity database not available";
+		}
+	}
+	return $output;
+}
 ?>

--- a/scripts/pi-hole/php/gravity.php
+++ b/scripts/pi-hole/php/gravity.php
@@ -12,14 +12,26 @@ function gravity_last_update($raw = false)
 {
 	$db = SQLite3_connect(getGravityDBFilename());
 	$date_file_created_unix = $db->querySingle("SELECT value FROM info WHERE property = 'updated';");
-	if($date_file_created_unix !== false)
+	if($date_file_created_unix === false)
 	{
-		$date_file_created = date_create("@".intval($date_file_created_unix));
-		$date_now = date_create("now");
-		$gravitydiff = date_diff($date_file_created,$date_now);
 		if($raw)
 		{
-			$output = array(
+			// Array output
+			return array("file_exists" => false);
+		}
+		else
+		{
+			// String output
+			return "Gravity database not available";
+		}
+	}
+	$date_file_created = date_create("@".intval($date_file_created_unix));
+	$date_now = date_create("now");
+	$gravitydiff = date_diff($date_file_created,$date_now);
+	if($raw)
+	{
+		// Array output
+		return array(
 			"file_exists"=> true,
 			"absolute" => $date_file_created_unix,
 			"relative" => array(
@@ -28,34 +40,20 @@ function gravity_last_update($raw = false)
 				"minutes" =>  $gravitydiff->format("%I"),
 				)
 			);
-		}
-		else
-		{
-			if($gravitydiff->d > 1)
-			{
-				$output = $gravitydiff->format("Blocking list updated %a days, %H:%I ago");
-			}
-			elseif($gravitydiff->d == 1)
-			{
-				$output = $gravitydiff->format("Blocking list updated one day, %H:%I ago");
-			}
-			else
-			{
-				$output = $gravitydiff->format("Blocking list updated %H:%I ago");
-			}
-		}
 	}
-	else
+
+	if($gravitydiff->d > 1)
 	{
-		if($raw)
-		{
-			$output = array("file_exists" => false);
-		}
-		else
-		{
-			$output = "Gravity database not available";
-		}
+		// String output (more than one day ago)
+		return $gravitydiff->format("Blocking list updated %a days, %H:%I (hh:mm) ago");
 	}
-	return $output;
+	elseif($gravitydiff->d == 1)
+	{
+		// String output (one day ago)
+		return $gravitydiff->format("Blocking list updated one day, %H:%I (hh:mm) ago");
+	}
+
+	// String output (less than one day ago)
+	return $gravitydiff->format("Blocking list updated %H:%I (hh:mm) ago");
 }
 ?>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix #989 (bug existing only in `development`)

**How does this PR accomplish the above?:**

Use update timestamp added in https://github.com/pi-hole/pi-hole/pull/2903 to display the time gravity was last run (successfully).

**What documentation changes (if any) are needed to support this PR?:**

None