### PR TITLE
Pass possible exception from SQLite3_connect_try() to the calling pro…

### DIFF
--- a/scripts/pi-hole/php/database.php
+++ b/scripts/pi-hole/php/database.php
@@ -33,7 +33,13 @@ function SQLite3_connect_try($filename, $mode, $trytoreconnect)
 		if($trytoreconnect)
 		{
 			sleep(3);
-			$db = SQLite3_connect_try($filename, $mode, false);
+			return SQLite3_connect_try($filename, $mode, false);
+		}
+		else
+		{
+			// If we should not try again (or are already trying again!), we return the exception string
+			// so the user gets it on the dashboard
+			return $filename.": ".$exception->getMessage();
 		}
 	}
 }
@@ -48,9 +54,9 @@ function SQLite3_connect($filename, $mode=SQLITE3_OPEN_READONLY)
 	{
 		die("No database available");
 	}
-	if(!$db)
+	if(is_string($db))
 	{
-		die("Error connecting to database");
+		die("Error connecting to database\n".$db);
 	}
 
 	// Add busy timeout so methods don't fail immediately when, e.g., FTL is currently reading from the DB


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Pass a human-readable error string to the user interface to help user helping themselves when connecting the database does not work.

![Screenshot from 2019-09-02 21-29-58](https://user-images.githubusercontent.com/16748619/64131591-d9572b80-cdc9-11e9-808f-6988e5def7d0.png)
(I triggered this error by renaming the database file)

**How does this PR accomplish the above?:**

Pass possible exception from `SQLite3_connect_try()` to the calling process. This makes this function return either valid SQLite3 objects (success) or strings (errors). 

**What documentation changes (if any) are needed to support this PR?:**

None