### PR TITLE
Fix Teleporter adlist export issue (development only bug)

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -339,7 +339,7 @@ else
 	archive_add_table("whitelist.regex.json", "regex_whitelist");
 	archive_add_table("blacklist.exact.json", "blacklist");
 	archive_add_table("blacklist.regex.json", "regex_blacklist");
-	archive_add_table("adlists.json", "adlist");
+	archive_add_table("adlist.json", "adlist");
 	archive_add_table("domain_audit.json", "domain_audit");
 	archive_add_file("/etc/pihole/","setupVars.conf");
 	archive_add_directory("/etc/dnsmasq.d/","dnsmasq.d/");


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix blocking lists data from being skipped during teleporter import.

This bug exists only in `development`. The current `master` branch does not export the blocking lists.

**How does this PR accomplish the above?:**

The bug is caused by the file being created as `adlists.json`, however, the importer expects `adlist.json`. By using the same name name for ex- and import, we fix the issue. Possibly existing archives can still be imported when this one containing file is renamed.

We chose `adlist` over `adlists` as the table that is contained in the JSON file is called `adlist`.

**What documentation changes (if any) are needed to support this PR?:**

None