### PR TITLE
Add ability for user to include comment when adding a blocklist

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -225,7 +225,7 @@ $("button[id^='adlist-btn-']").on("click", function (e) {
 	$("input[name=\"adlist-del-"+id+"\"]").prop("checked", !status);
 	// Untick and disable check box (or reset)
 	$("input[name=\"adlist-enable-"+id+"\"]").prop("checked", status).prop("disabled", !status);
-	// Strink through text (or reset)
+	// Strike through text (or reset)
 	$("a[id=\"adlist-text-"+id+"\"]").css("text-decoration", textType);
 	// Highlight that the button has to be clicked in order to make the change live
 	$("button[id=\"blockinglistsaveupdate\"]").addClass("btn-danger").css("font-weight", "bold");

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -707,9 +707,10 @@ function readAdlists()
 				if(strlen($_POST["newuserlists"]) > 1)
 				{
 					$domains = array_filter(preg_split('/\r\n|[\r\n]/', $_POST["newuserlists"]));
+					$comment = "'".$_POST["newusercomment"]."'";
 					foreach($domains as $domain)
 					{
-						exec("sudo pihole -a adlist add ".escapeshellcmd($domain));
+						exec("sudo pihole -a adlist add ".escapeshellcmd($domain)." ".escapeshellcmd($comment));
 					}
 				}
 

--- a/settings.php
+++ b/settings.php
@@ -294,9 +294,16 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                 </tbody>
                                             </table>
                                         </div>
-                                        <div class="form-group">
-                                            <input name="newuserlists" class="form-control" placeholder="Enter a URL to add a new blocklist">
-                                        </div>
+                                        <div class="form-group row">
+                                            <div class="col-xs-6">
+                                                <label for="newuserlists">Domain:</label>
+                                                <input name="newuserlists" type="text" class="form-control" placeholder="Enter a URL to add a new blocklist">
+                                            </div>
+                                            <div class="col-xs-6">
+                                                <label for="newusercomment">Comment:</label>
+                                                <input name="newusercomment" type="text" class="form-control" placeholder="Include a comment (optional)">
+                                            </div>                                            
+                                        </div>  
                                         <input type="hidden" name="field" value="adlists">
                                         <input type="hidden" name="token" value="<?php echo $token ?>">
                                     </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

The same as #1028, but for the adlist page.

![tv](https://user-images.githubusercontent.com/1998970/66786060-058cbe80-eed7-11e9-8d4d-d787a428ebf6.gif)

Relies on https://github.com/pi-hole/pi-hole/pull/2965 to be merged at the same time