### PR TITLE
Ensure API results are UTF-8 encoded

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -104,7 +104,8 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
-			$top_queries[$tmp[2]] = intval($tmp[1]);
+			$domain = utf8_encode($tmp[2]);
+			$top_queries[$domain] = intval($tmp[1]);
 		}
 
 		if($_GET['topItems'] === "audit")
@@ -125,10 +126,11 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
+			$domain = utf8_encode($tmp[2]);
 			if(count($tmp) > 3)
-				$top_ads[$tmp[2]." (".$tmp[3].")"] = intval($tmp[1]);
+				$top_ads[$domain." (".$tmp[3].")"] = intval($tmp[1]);
 			else
-				$top_ads[$tmp[2]] = intval($tmp[1]);
+				$top_ads[$domain] = intval($tmp[1]);
 		}
 
 		$result = array('top_queries' => $top_queries,
@@ -163,10 +165,14 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
+			$clientip = utf8_encode($tmp[2]);
 			if(count($tmp) > 3 && strlen($tmp[3]) > 0)
-				$top_clients[$tmp[3]."|".$tmp[2]] = intval($tmp[1]);
+			{
+				$clientname = utf8_encode($tmp[3]);
+				$top_clients[$clientname."|".$clientip] = intval($tmp[1]);
+			}
 			else
-				$top_clients[$tmp[2]] = intval($tmp[1]);
+				$top_clients[$clientip] = intval($tmp[1]);
 		}
 
 		$result = array('top_sources' => $top_clients);
@@ -195,10 +201,14 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
+			$clientip = utf8_encode($tmp[2]);
 			if(count($tmp) > 3 && strlen($tmp[3]) > 0)
-				$top_clients[$tmp[3]."|".$tmp[2]] = intval($tmp[1]);
+			{
+				$clientname = utf8_encode($tmp[3]);
+				$top_clients[$clientname."|".$clientip] = intval($tmp[1]);
+			}
 			else
-				$top_clients[$tmp[2]] = intval($tmp[1]);
+				$top_clients[$clientip] = intval($tmp[1]);
 		}
 
 		$result = array('top_sources_blocked' => $top_clients);
@@ -220,10 +230,14 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
+			$forwardip = utf8_encode($tmp[2]);
 			if(count($tmp) > 3 && strlen($tmp[3]) > 0)
-				$forward_dest[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
+			{
+				$forwardname = utf8_encode($tmp[3]);
+				$forward_dest[$forwardname."|".$forwardip] = floatval($tmp[1]);
+			}
 			else
-				$forward_dest[$tmp[2]] = floatval($tmp[1]);
+				$forward_dest[$forwardip] = floatval($tmp[1]);
 		}
 
 		$result = array('forward_destinations' => $forward_dest);
@@ -238,6 +252,7 @@ else
 		foreach($return as $ret)
 		{
 			$tmp = explode(": ",$ret);
+			// Reply cannot contain non-ASCII characters
 			$querytypes[$tmp[0]] = floatval($tmp[1]);
 		}
 
@@ -253,6 +268,7 @@ else
 		foreach($return as $ret)
 		{
 			$tmp = explode(": ",$ret);
+			// Reply cannot contain non-ASCII characters
 			$cacheinfo[$tmp[0]] = floatval($tmp[1]);
 		}
 
@@ -301,6 +317,10 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
+			// UTF-8 encode domain
+			$tmp[2] = utf8_encode($tmp[2]);
+			// UTF-8 encode client host name
+			$tmp[3] = utf8_encode($tmp[3]);;
 			array_push($allQueries,$tmp);
 		}
 
@@ -311,7 +331,7 @@ else
 	if(isset($_GET["recentBlocked"]))
 	{
 		sendRequestFTL("recentBlocked");
-		die(getResponseFTL()[0]);
+		die(utf8_encode(getResponseFTL()[0]));
 		unset($data);
 	}
 
@@ -323,13 +343,15 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
+			$forwardip = utf8_encode($tmp[2]);
 			if(count($tmp) > 3)
 			{
-				$forward_dest[$tmp[3]."|".$tmp[2]] = floatval($tmp[1]);
+				$forwardname = utf8_encode($tmp[3]);
+				$forward_dest[$forwardname."|".$forwardip] = floatval($tmp[1]);
 			}
 			else
 			{
-				$forward_dest[$tmp[2]] = floatval($tmp[1]);
+				$forward_dest[$forwardip] = floatval($tmp[1]);
 			}
 		}
 
@@ -363,8 +385,8 @@ else
 		{
 			$tmp = explode(" ", $line);
 			$client_names[] = array(
-				"name" => $tmp[0],
-				"ip" => $tmp[1]
+				"name" => utf8_encode($tmp[0]),
+				"ip" => utf8_encode($tmp[1])
 			);
 		}
 

--- a/api_db.php
+++ b/api_db.php
@@ -79,6 +79,9 @@ if(isset($_GET["network"]) && $auth)
 		$network_addresses = $db->query("SELECT ip FROM network_addresses WHERE network_id = $id ORDER BY lastSeen DESC");
 		while($network_addresses !== false && $ip = $network_addresses->fetchArray(SQLITE3_ASSOC))
 			array_push($res["ip"],$ip["ip"]);
+		// UTF-8 encode host name and vendor
+		$res["name"] = utf8_encode($res["name"]);
+		$res["macVendor"] = utf8_encode($res["macVendor"]);
 		array_push($network, $res);
 	}
 
@@ -148,8 +151,8 @@ if (isset($_GET['getAllQueries']) && $auth)
 						$query_type = "UNKN";
 						break;
 				}
-
-				$allQueries[] = [$row[0], $query_type, $row[2], $c, $row[4]];
+				// array:        time     type         domain                client           status
+				$allQueries[] = [$row[0], $query_type, utf8_encode($row[2]), utf8_encode($c), $row[4]];
 			}
 	}
 	$result = array('data' => $allQueries);
@@ -182,8 +185,8 @@ if (isset($_GET['topClients']) && $auth)
 	if(!is_bool($results))
 		while ($row = $results->fetchArray())
 		{
-
-			$c = resolveHostname($row[0],false);
+			// Try to resolve host name and convert to UTF-8
+			$c = utf8_encode(resolveHostname($row[0],false));
 
 			if(array_key_exists($c, $clientnums))
 			{
@@ -233,8 +236,8 @@ if (isset($_GET['topDomains']) && $auth)
 	if(!is_bool($results))
 		while ($row = $results->fetchArray())
 		{
-			// Convert client to lower case
-			$c = strtolower($row[0]);
+			// Convert domain to lower case UTF-8
+			$c = utf8_encode(strtolower($row[0]));
 			if(array_key_exists($c, $domains))
 			{
 				// Entry already exists, add to it (might appear multiple times due to mixed capitalization in the database)
@@ -283,7 +286,7 @@ if (isset($_GET['topAds']) && $auth)
 	if(!is_bool($results))
 		while ($row = $results->fetchArray())
 		{
-			$addomains[$row[0]] = intval($row[1]);
+			$addomains[utf8_encode($row[0])] = intval($row[1]);
 		}
 	$result = array('top_ads' => $addomains);
 	$data = array_merge($data, $result);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix #1037 

**How does this PR accomplish the above?:**

The IETF IDNA (Internationalizing Domain Names in Applications) Working Group decided that internationalized domain names should be converted to a suitable ASCII-based form that could be handled by web browsers and other user applications. [[source](https://en.wikipedia.org/wiki/Internationalized_domain_name)]

However, some, maybe buggy, devices still query international characters without punycoding them even though the vast majority of software is behaving correctly. This has been identified in #1037.

This PR fixes the issue that PHP's internal JSON encoder is unable to handle non-ASCII characters and fails in case such domains are present in the domain database. Note that the entire rest of the Pi-hole ecosystem is constructed to run perfectly fine with non-ASCII characters.

The fix lies in ensuring that the corresponding characters are UTF-8 encoded *before* passing them to `json_encode()`. Unfortunately, it turned out that a post-processing of the already compiled multi-dimensional `$data` object is very slow, so we add `utf8_encode()` everywhere in the code a string, maybe containing international characters, is read from either FTL or the database.

We ensure to escape:
- Domains
- Client host names
- Vendor names (Network Table)

### Important: Note that this change adds a new dependency `php-xml` which must be added with a second PR to pi-hole/pi-hole.