### PR TITLE
Ensure gravity_last_updated values are correctly handled as integers

### DIFF
--- a/scripts/pi-hole/php/gravity.php
+++ b/scripts/pi-hole/php/gravity.php
@@ -25,7 +25,9 @@ function gravity_last_update($raw = false)
 			return "Gravity database not available";
 		}
 	}
-	$date_file_created = date_create("@".intval($date_file_created_unix));
+	// Now that we know that $date_file_created_unix is a valid response, we can convert it to an integer
+	$date_file_created_unix = intval($date_file_created_unix);
+	$date_file_created = date_create("@".$date_file_created_unix);
 	$date_now = date_create("now");
 	$gravitydiff = date_diff($date_file_created,$date_now);
 	if($raw)
@@ -35,9 +37,9 @@ function gravity_last_update($raw = false)
 			"file_exists"=> true,
 			"absolute" => $date_file_created_unix,
 			"relative" => array(
-				"days" =>  $gravitydiff->format("%a"),
-				"hours" =>  $gravitydiff->format("%H"),
-				"minutes" =>  $gravitydiff->format("%I"),
+				"days" =>  intval($gravitydiff->format("%a")),
+				"hours" =>  intval($gravitydiff->format("%H")),
+				"minutes" =>  intval($gravitydiff->format("%I")),
 				)
 			);
 	}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix #1041

**How does this PR accomplish the above?:**

Ensure the numbers are correctly treated as integers, not as strings.

**Before**
![Screenshot from 2019-11-07 21-42-37](https://user-images.githubusercontent.com/16748619/68426049-976eab00-01a7-11ea-8e82-332a16bb4535.png)

**After**
![Screenshot from 2019-11-07 21-42-21](https://user-images.githubusercontent.com/16748619/68426053-989fd800-01a7-11ea-9450-bd80d5e602b4.png)

**What documentation changes (if any) are needed to support this PR?:**

None