### PR TITLE
Remove remaining absolute paths

### DIFF
--- a/scripts/pi-hole/js/debug.js
+++ b/scripts/pi-hole/js/debug.js
@@ -38,12 +38,12 @@ function eventsource() {
 
     // IE does not support EventSource - load whole content at once
     if (typeof EventSource !== "function") {
-        httpGet(ta,"/admin/scripts/pi-hole/php/debug.php?IE&token="+token+"&"+checked);
+        httpGet(ta,"scripts/pi-hole/php/debug.php?IE&token="+token+"&"+checked);
         return;
     }
 
     var host = window.location.host;
-    var source = new EventSource("/admin/scripts/pi-hole/php/debug.php?&token="+token+"&"+checked);
+    var source = new EventSource("scripts/pi-hole/php/debug.php?&token="+token+"&"+checked);
 
     // Reset and show field
     ta.empty();

--- a/scripts/pi-hole/js/queryads.js
+++ b/scripts/pi-hole/js/queryads.js
@@ -74,12 +74,12 @@ function eventsource() {
 
     // IE does not support EventSource - load whole content at once
     if (typeof EventSource !== "function") {
-        httpGet(ta,quiet,"/admin/scripts/pi-hole/php/queryads.php?domain="+domain.toLowerCase()+exact+"&IE");
+        httpGet(ta,quiet,"scripts/pi-hole/php/queryads.php?domain="+domain.toLowerCase()+exact+"&IE");
         return;
     }
 
     var host = window.location.host;
-    var source = new EventSource("/admin/scripts/pi-hole/php/queryads.php?domain="+domain.toLowerCase()+"&"+exact);
+    var source = new EventSource("scripts/pi-hole/php/queryads.php?domain="+domain.toLowerCase()+"&"+exact);
 
     // Reset and show field
     ta.empty();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Allowing the use of the web interface in sub directories.

Using the queryads.php page doesn't work when the installation is located in a subdirectory. No result or errors are returned. This PR aims to fix that.

**How does this PR accomplish the above?:**
It is fixed by using relative paths `scripts/...` instead of absolute ones `/admin/scripts/...`.

`{A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix}`
This request wasn't working before, didn't use the `/hole` subdirectory and therefore got a 404. The website just displayed an empty box which appeared as no response to the button press at all.
![Unbenannt](https://user-images.githubusercontent.com/22298664/69048105-f41a6300-09fc-11ea-967a-066fb22caa22.png)

**What documentation changes (if any) are needed to support this PR?:**

`{A detailed list of any necessary changes}`
Replaced `/admin/scripts/...` with `scripts/...` in *queryads.js* and *debug.js* which were all occurrences of `admin` with grep.
