### PR TITLE
Use HTTPS in DNSSEC resolver test link

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -869,7 +869,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                    server which supports DNSSEC when activating DNSSEC. Note that
                                                    the size of your log might increase significantly
                                                    when enabling DNSSEC. A DNSSEC resolver test can be found
-                                                   <a href="http://dnssec.vs.uni-due.de/" target="_blank">here</a>.</p>
+                                                   <a href="https://dnssec.vs.uni-due.de/" target="_blank">here</a>.</p>
                                                 <label>Conditional Forwarding</label>
                                                 <p>If not configured as your DHCP server, Pi-hole won't be able to
                                                    determine the names of devices on your local network.  As a


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Change the link to http://dnssec.vs.uni-due.de/ (the DNSSEC resolver test) found in Settings > DNS > Advanced DNS Settings to use HTTPS instead (https://dnssec.vs.uni-due.de/).

**How does this PR accomplish the above?:**

Change the `http` in line 872 of `settings.php` to `https`

**What documentation changes (if any) are needed to support this PR?:**

None