### PR TITLE
Check if ERRORLOG exists and is writeable

### DIFF
--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -10,6 +10,14 @@ require_once('func.php');
 $ERRORLOG = getenv('PHP_ERROR_LOG');
 if (empty($ERRORLOG)) {
     $ERRORLOG = '/var/log/lighttpd/error.log';
+
+    if (!file_exists($ERRORLOG) || !is_writable($ERRORLOG)) {
+        $ERRORLOG = '/var/log/apache2/error.log';
+        
+        if (!file_exists($ERRORLOG) || !is_writable($ERRORLOG)) {
+            $ERRORLOG = '/tmp/pi-hole-error.log';
+        }
+    }
 }
 $regexfile = "/etc/pihole/regex.list";
 


### PR DESCRIPTION
I have pi-hole running with apache2 and so no /var/log/lighttpd/error.log exists.

Try apache2 logging location and if not found then write log to a /tmp file.

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X ] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X ] I have made only one major change in my proposed changes.
- [ X] I have commented my proposed changes within the code.
- [ X] I have tested my proposed changes.
- [ X] I am willing to help maintain this change if there are issues with it later.
- [ X] I give this submission freely and claim no ownership.
- [ X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))
