### PR TITLE
Prevent PHP Fatal error:  Maximum execution time of 30 seconds exceeded

### DIFF
--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -26,7 +26,7 @@ function sendRequestFTL($requestin)
 	global $socket;
 
 	$request = ">".$requestin;
-	fwrite($socket, $request) or die("Could not send data to server\n");
+	fwrite($socket, $request) or die('{"error":"Could not send data to server"}');
 }
 
 function getResponseFTL()
@@ -35,9 +35,15 @@ function getResponseFTL()
 
 	$response = [];
 
+	$errCount = 0;
 	while(true)
 	{
 		$out = fgets($socket);
+		if ($out == "") $errCount++;
+		if ($errCount > 100) {
+			// Tried 100 times, but never got proper reply, fail to prevent busy loop
+			die('{"error":"Tried 100 times to connect to FTL server, but never got proper reply. Please check Port and logs!"}');
+		}
 		if(strrpos($out,"---EOM---") !== false)
 			break;
 


### PR DESCRIPTION
I have a different service running on FTL default port and so FTL service was not properly started. I searched quite a long time to discover why the Dashboard never loaded and finally found the reason.

This patch counts empty lines and dies properly with a JSON error. This fixed my issue.

**By submitting this pull request, I confirm the following:** 

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))
