### PR TITLE
I have a different service running on FTL default port and so FTL ser…

### DIFF
--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -26,7 +26,7 @@ function sendRequestFTL($requestin)
 	global $socket;
 
 	$request = ">".$requestin;
-	fwrite($socket, $request) or die("Could not send data to server\n");
+	fwrite($socket, $request) or die('{"error":"Could not send data to server"}');
 }
 
 function getResponseFTL()
@@ -35,9 +35,16 @@ function getResponseFTL()
 
 	$response = [];
 
+	$errCount = 0;
 	while(true)
 	{
 		$out = fgets($socket);
+		file_put_contents('/tmp/pihole.txt', $out, FILE_APPEND);
+		if ($out == "") $errCount++;
+		if ($errCount > 100) {
+			// Tried 100 times, but never got proper reply, fail to prevent busy loop
+			die('{"error":"Tried 100 times to connect to FTL server, but never got proper reply. Please check Port and logs!"}');
+		}
 		if(strrpos($out,"---EOM---") !== false)
 			break;
 

--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -39,7 +39,6 @@ function getResponseFTL()
 	while(true)
 	{
 		$out = fgets($socket);
-		file_put_contents('/tmp/pihole.txt', $out, FILE_APPEND);
 		if ($out == "") $errCount++;
 		if ($errCount > 100) {
 			// Tried 100 times, but never got proper reply, fail to prevent busy loop

--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -10,6 +10,14 @@ require_once('func.php');
 $ERRORLOG = getenv('PHP_ERROR_LOG');
 if (empty($ERRORLOG)) {
     $ERRORLOG = '/var/log/lighttpd/error.log';
+
+    if (!file_exists($ERRORLOG) || !is_writable($ERRORLOG)) {
+	    $ERRORLOG = '/var/log/apache2/error.log';
+
+	    if (!file_exists($ERRORLOG) || !is_writable($ERRORLOG)) {
+		    $ERRORLOG = '/tmp/pi-hole-error.log';
+	    }
+    }
 }
 
 function pi_log($message) {


### PR DESCRIPTION
I have a different service running on FTL default port and so FTL service was not properly started. I searched quite a long time to discover why the Dashboard never loaded and finally found the reason.

This patch counts empty lines and dies properly with a JSON error. This fixed my issue.

Also I have pi-hole running with apache2 and so no /var/log/lighttpd/error.log exists.
Fix: Try apache2 logging location and if not found then write log to a /tmp file.

Signed-off-by: Philipp Kolmann <philipp@kolmann.at>

**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

* If FTL Server is not answering on the expected port, don't run into PHP execution timeouts
* If no lighttpd is installed, try different error log locations

**How does this PR accomplish the above?:**

* If the answer from FTL Server is over 100 times empty, bail out.
* try different ERRORLOG locations

**What documentation changes (if any) are needed to support this PR?:**

none
