### PR TITLE
Change "Click to select..." in Long term data pages to buttons

### DIFF
--- a/db_graph.php
+++ b/db_graph.php
@@ -32,7 +32,7 @@ $token = $_SESSION['token'];
           <div class="input-group-addon">
             <i class="far fa-clock"></i>
           </div>
-          <input type="text" class="form-control pull-right" id="querytime" value="Click to select date and time range">
+          <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range" style="text-align:left">
         </div>
         <!-- /.input group -->
       </div>

--- a/db_graph.php
+++ b/db_graph.php
@@ -32,7 +32,7 @@ $token = $_SESSION['token'];
           <div class="input-group-addon">
             <i class="far fa-clock"></i>
           </div>
-          <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range" style="text-align:left">
+          <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range">
         </div>
         <!-- /.input group -->
       </div>

--- a/db_lists.php
+++ b/db_lists.php
@@ -33,7 +33,7 @@ $token = $_SESSION['token'];
           <div class="input-group-addon">
             <i class="far fa-clock"></i>
           </div>
-          <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range" style="text-align:left">
+          <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range">
         </div>
         <!-- /.input group -->
       </div>

--- a/db_lists.php
+++ b/db_lists.php
@@ -33,7 +33,7 @@ $token = $_SESSION['token'];
           <div class="input-group-addon">
             <i class="far fa-clock"></i>
           </div>
-          <input type="text" class="form-control pull-right" id="querytime" value="Click to select date and time range">
+          <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range" style="text-align:left">
         </div>
         <!-- /.input group -->
       </div>

--- a/db_queries.php
+++ b/db_queries.php
@@ -33,7 +33,7 @@ $token = $_SESSION['token'];
           <div class="input-group-addon">
             <i class="far fa-clock"></i>
           </div>
-          <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range" style="text-align:left">
+          <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range">
         </div>
         <!-- /.input group -->
       </div>

--- a/db_queries.php
+++ b/db_queries.php
@@ -33,7 +33,7 @@ $token = $_SESSION['token'];
           <div class="input-group-addon">
             <i class="far fa-clock"></i>
           </div>
-          <input type="text" class="form-control pull-right" id="querytime" value="Click to select date and time range">
+          <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range" style="text-align:left">
         </div>
         <!-- /.input group -->
       </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Users are currently able to type in the "Click to select date and time range" box in the Long term data pages, and when tapped on mobile, it brings up the keyboard. However, it doesn't appear as this is intended to be the case (since it brings up a menu to select the date range), so this PR prevents this.

**How does this PR accomplish the above?:**

The input type of these fields are changed to `button`.

`style="text-align:left"` is added to ensure that the text in these buttons aren't aligned center (they are currently aligned left due to being type `text`, so this ensures it looks the same after being changed to `button`).

**What documentation changes (if any) are needed to support this PR?:**

None

---

Notes:
- Stemmed from a conversation https://github.com/pi-hole/AdminLTE/pull/1100#issuecomment-568057056
- Simply changing the `<input>` tag to a `<button>` tag seems to make the text in the button disappear without other changes, so changing the type of input to `button` seems to be the easier option (as I did in this PR)
