### PR TITLE
Fix generated long-term graph links

### DIFF
--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -330,7 +330,7 @@ $("#queryOverTimeChart").click(function(evt) {
 
     //get value by index
     var from = label / 1000;
-    var until = label / 1000 + 600;
+    var until = label / 1000 + interval;
     window.location.href = "db_queries.php?from=" + from + "&until=" + until;
   }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix issue mentioned by @Th3M3 in #1121 

> And I see another issue when clicking on one chart's bar, because the requested until-timestamp from the following db_queries.php is not as it has been shown in the tooltip.
> Currently the requested until-timestamp is hardcoded to + 600 in https://github.com/pi-hole/AdminLTE/blob/devel/scripts/pi-hole/js/db_graph.js#L294.

**How does this PR accomplish the above?:**

Use correct interval for the database query when clicking on one of the long-term graph bars.

**What documentation changes (if any) are needed to support this PR?:**

None