### PR TITLE
FTL.php: parse port path from pihole-FTL.conf

### DIFF
--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -6,12 +6,37 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
+$piholeFTLConfFile = "/etc/pihole/pihole-FTL.conf";
+
+function piholeFTLConfig()
+{
+	static $piholeFTLConfig;
+	global $piholeFTLConfFile;
+
+	if(isset($piholeFTLConfig))
+	{
+		return $piholeFTLConfig;
+	}
+
+	if(is_readable($piholeFTLConfFile))
+	{
+		$piholeFTLConfig = parse_ini_file($piholeFTLConfFile);
+	}
+	else
+	{
+		$piholeFTLConfig = array();
+	}
+
+	return $piholeFTLConfig;
+}
+
 function connectFTL($address, $port=4711)
 {
 	if($address == "127.0.0.1")
 	{
+		$config = piholeFTLConfig();
 		// Read port
-		$portfile = file_get_contents("/var/run/pihole-FTL.port");
+		$portfile = file_get_contents($config["PORTFILE"]);
 		if(is_numeric($portfile))
 			$port = intval($portfile);
 	}

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -8,6 +8,7 @@
 
     require "scripts/pi-hole/php/auth.php";
     require "scripts/pi-hole/php/password.php";
+    require_once "scripts/pi-hole/php/FTL.php";
     $scriptname = basename($_SERVER['SCRIPT_FILENAME']);
 
     check_cors();
@@ -162,16 +163,7 @@
     $FTLpid = intval(pidofFTL());
     $FTL = ($FTLpid !== 0 ? true : false);
 
-    $piholeFTLConfFile = "/etc/pihole/pihole-FTL.conf";
-    if(is_readable($piholeFTLConfFile))
-    {
-        $piholeFTLConf = parse_ini_file($piholeFTLConfFile);
-    }
-    else
-    {
-        $piholeFTLConf = array();
-    }
-
+    $piholeFTLConf = piholeFTLConfig();
 ?>
 <!doctype html>
 <!-- Pi-hole: A black hole for Internet advertisements

--- a/settings.php
+++ b/settings.php
@@ -7,16 +7,10 @@
 *    Please see LICENSE file for your rights under this license. */
 require "scripts/pi-hole/php/header.php";
 require "scripts/pi-hole/php/savesettings.php";
+require_once "scripts/pi-hole/php/FTL.php";
 // Reread ini file as things might have been changed
 $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
-if(is_readable($piholeFTLConfFile))
-{
-	$piholeFTLConf = parse_ini_file($piholeFTLConfFile);
-}
-else
-{
-	$piholeFTLConf = array();
-}
+$piholeFTLConf = piholeFTLConfig();
 
 // Handling of PHP internal errors
 $last_error = error_get_last();

--- a/settings.php
+++ b/settings.php
@@ -302,8 +302,8 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                             <div class="col-xs-6">
                                                 <label for="newusercomment">Comment:</label>
                                                 <input name="newusercomment" type="text" class="form-control" placeholder="Include a comment (optional)">
-                                            </div>                                            
-                                        </div>  
+                                            </div>
+                                        </div>
                                         <input type="hidden" name="field" value="adlists">
                                         <input type="hidden" name="token" value="<?php echo $token ?>">
                                     </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

In some places paths are hardcoded, and in some places they are read from config file. 

**How does this PR accomplish the above?:**

This patch adds a function to FTL.php to read pihole-FTL.conf file and uses it to resolve port path.

**What documentation changes (if any) are needed to support this PR?:**

None.