### PR TITLE
Remove null coalescing operator from list.php

### DIFF
--- a/list.php
+++ b/list.php
@@ -8,7 +8,7 @@
 
 require "scripts/pi-hole/php/header.php";
 
-$list = $_GET['l'] ?? '';
+$list = isset($_GET['l']) ? $_GET['l'] : '';
 
 if ($list == "white")
 {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix bug described here: https://discourse.pi-hole.net/t/white-black-list-page-not-currently-working/27075/9

**How does this PR accomplish the above?:**

Remove null coalescing operator from list.php. This feature is only availabe in PHP 7.

**What documentation changes (if any) are needed to support this PR?:**

None