### PR TITLE
Add responsive class to new group tables

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -183,6 +183,10 @@ function initTable() {
         "</button>";
       $("td:eq(4)", row).html(button);
     },
+    dom:
+      "<'row'<'col-sm-4'l><'col-sm-8'f>>" +
+      "<'row'<'col-sm-12'<'table-responsive'tr>>>" +
+      "<'row'<'col-sm-5'i><'col-sm-7'p>>",
     lengthMenu: [
       [10, 25, 50, 100, -1],
       [10, 25, 50, 100, "All"]

--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -189,6 +189,10 @@ function initTable() {
         "</button>";
       $("td:eq(2)", row).html(button);
     },
+    dom:
+      "<'row'<'col-sm-4'l><'col-sm-8'f>>" +
+      "<'row'<'col-sm-12'<'table-responsive'tr>>>" +
+      "<'row'<'col-sm-5'i><'col-sm-7'p>>",
     lengthMenu: [
       [10, 25, 50, 100, -1],
       [10, 25, 50, 100, "All"]

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -200,6 +200,10 @@ function initTable() {
         "</button>";
       $("td:eq(5)", row).html(button);
     },
+    dom:
+      "<'row'<'col-sm-4'l><'col-sm-8'f>>" +
+      "<'row'<'col-sm-12'<'table-responsive'tr>>>" +
+      "<'row'<'col-sm-5'i><'col-sm-7'p>>",
     lengthMenu: [
       [10, 25, 50, 100, -1],
       [10, 25, 50, 100, "All"]

--- a/scripts/pi-hole/js/groups.js
+++ b/scripts/pi-hole/js/groups.js
@@ -144,6 +144,10 @@ $(document).ready(function() {
         $("td:eq(3)", row).html(button);
       }
     },
+    dom:
+      "<'row'<'col-sm-4'l><'col-sm-8'f>>" +
+      "<'row'<'col-sm-12'<'table-responsive'tr>>>" +
+      "<'row'<'col-sm-5'i><'col-sm-7'p>>",
     lengthMenu: [
       [10, 25, 50, 100, -1],
       [10, 25, 50, 100, "All"]


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix issue brought up on Discourse: https://discourse.pi-hole.net/t/screen-adlist-group-management-on-ipad-air-2/27111 

**How does this PR accomplish the above?:**

Add responsive class to new group tables to ensure they render properly on very narrow screens


**Before**
![Screenshot_2020-01-20 Pi-hole Admin Console(1)](https://user-images.githubusercontent.com/16748619/72754442-13ce3300-3bc8-11ea-8d03-286981a4b0e1.png)

**After**
![Screenshot_2020-01-20 Pi-hole Admin Console](https://user-images.githubusercontent.com/16748619/72754444-1597f680-3bc8-11ea-8127-d5611bc2046a.png)


**What documentation changes (if any) are needed to support this PR?:**

None