### PR TITLE
Add extra label when blocking happend during deep CNAME inspection

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -228,6 +228,11 @@ $(document).ready(function() {
           buttontext = "";
       }
 
+      // Add extra label when blocking happend during deep CNAME inspection
+      if (blocked && data.length > 6 && data[6] === "3") {
+        fieldtext += "<br>CNAME";
+      }
+
       $(row).addClass(colorClass);
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(6)", row).html(buttontext);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Illustrate when blocking happened during a (possibly deep) CNAME inspection:
![Screenshot from 2020-01-21 23-34-16](https://user-images.githubusercontent.com/16748619/72849404-df7d7400-3ca6-11ea-8b2b-d3ce48942c43.png)

Whitelisting makes sense even if the inspection was deep as explicitly whitelisted domains along the path mark the entire path as permitted.

**How does this PR accomplish the above?:**

Add extra label when blocking happend during deep CNAME inspection

**What documentation changes (if any) are needed to support this PR?:**

None