### PR TITLE
Fix teleporter's ability to import v4.x archives

### DIFF
--- a/scripts/pi-hole/php/database.php
+++ b/scripts/pi-hole/php/database.php
@@ -107,6 +107,16 @@ function add_to_table($db, $table, $domains, $comment, $wildcardstyle=false, $re
 			return "Error: Unable to begin transaction for $table table.";
 	}
 
+	// To which column should the record be added to?
+	if ($table === "adlist")
+	{
+		$field = "address";
+	}
+	else
+	{
+		$field = "domain";
+	}
+
 	// Get initial count of domains in this table
 	if($type === -1)
 	{
@@ -121,11 +131,11 @@ function add_to_table($db, $table, $domains, $comment, $wildcardstyle=false, $re
 	// Prepare INSERT SQLite statememt
 	if($type === -1)
 	{
-		$querystr = "INSERT OR IGNORE INTO $table (domain,comment) VALUES (:domain, :comment);";
+		$querystr = "INSERT OR IGNORE INTO $table ($field,comment) VALUES (:$field, :comment);";
 	}
 	else
 	{
-		$querystr = "INSERT OR IGNORE INTO $table (domain,comment,type) VALUES (:domain, :comment, $type);";
+		$querystr = "INSERT OR IGNORE INTO $table ($field,comment,type) VALUES (:$field, :comment, $type);";
 	}
 	$stmt = $db->prepare($querystr);
 
@@ -135,7 +145,7 @@ function add_to_table($db, $table, $domains, $comment, $wildcardstyle=false, $re
 		if($returnnum)
 			return 0;
 		else
-			return "Error: Failed to prepare statement for $table table (type = $type).";
+			return "Error: Failed to prepare statement for $table table (type = $type, field = $field).";
 	}
 
 	// Loop over domains and inject the lines into the database
@@ -149,7 +159,7 @@ function add_to_table($db, $table, $domains, $comment, $wildcardstyle=false, $re
 		if($wildcardstyle)
 			$domain = "(\\.|^)".str_replace(".","\\.",$domain)."$";
 
-		$stmt->bindValue(":domain", $domain, SQLITE3_TEXT);
+		$stmt->bindValue(":$field", $domain, SQLITE3_TEXT);
 		$stmt->bindValue(":comment", $comment, SQLITE3_TEXT);
 
 		if($stmt->execute() && $stmt->reset())

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -185,7 +185,7 @@ function archive_restore_table($file, $table, $flush=false)
 /**
  * Create table rows from an uploaded archive file
  *
- * @param $file object The file of the file in the archive to import
+ * @param $file object The file in the archive to import
  * @param $table string The target table
  * @param $flush boolean Whether to flush the table before importing the archived data
  * @param $wildcardstyle boolean Whether to format the input domains in legacy wildcard notation
@@ -193,22 +193,66 @@ function archive_restore_table($file, $table, $flush=false)
  */
 function archive_insert_into_table($file, $table, $flush=false, $wildcardstyle=false)
 {
-	global $db, $flushed_tables;
+	global $db;
 
 	$domains = array_filter(explode("\n",file_get_contents($file)));
 	// Return early if we cannot extract the lines in the file
 	if(is_null($domains))
 		return 0;
 
-	// Flush table if requested, only flush each table once
-	if($flush && !in_array($table, $flushed_tables))
-	{
-		$db->exec("DELETE FROM ".$table);
-		array_push($flushed_tables, $table);
+	// Generate comment
+	$prefix = "phar:///tmp/";
+	if (substr($file, 0, strlen($prefix)) == $prefix) {
+		$file = substr($file, strlen($prefix));
+	}
+	$comment = "Imported from ".$file;
+
+	// Determine table and type to import to
+	$type = null;
+	if($table === "whitelist") {
+		$table = "domainlist";
+		$type = ListType::whitelist;
+	} else if($table === "blacklist") {
+		$table = "domainlist";
+		$type = ListType::blacklist;
+	} else if($table === "regex_blacklist") {
+		$table = "domainlist";
+		$type = ListType::regex_blacklist;
+	} else if($table === "domain_audit") {
+		$table = "domain_audit";
+	}
+
+	// Flush table if requested
+	if($flush) {
+		flush_table($table, $type);
 	}
 
 	// Add domains to requested table
-	return add_to_table($db, $table, $domains, $wildcardstyle, true);
+	return add_to_table($db, $table, $domains, $comment, $wildcardstyle, true, $type);
+}
+
+/**
+ * Flush table if requested. This subroutine flushes each table only once
+ *
+ * @param $table string The target table
+ * @param $type integer Type of item to flush in table (applies only to domainlist table)
+ */
+function flush_table($table, $type=null)
+{
+	global $db, $flushed_tables;
+
+	if(!in_array($table, $flushed_tables))
+	{
+		if($type !== null) {
+			$sql = "DELETE FROM ".$table." WHERE type = ".$type;
+			array_push($flushed_tables, $table.$type);
+		} else {
+			$sql = "DELETE FROM ".$table;
+			array_push($flushed_tables, $table);
+		}
+		echo $sql."<br>";
+		$db->exec($sql);
+	}
 }
 
 function archive_add_directory($path,$subdir="")

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -220,6 +220,10 @@ function archive_insert_into_table($file, $table, $flush=false, $wildcardstyle=f
 		$type = ListType::regex_blacklist;
 	} else if($table === "domain_audit") {
 		$table = "domain_audit";
+		$type = -1; // -1 -> not used inside add_to_table()
+	} else if($table === "adlist") {
+		$table = "adlist";
+		$type = -1; // -1 -> not used inside add_to_table()
 	}
 
 	// Flush table if requested
@@ -250,7 +254,6 @@ function flush_table($table, $type=null)
 			$sql = "DELETE FROM ".$table;
 			array_push($flushed_tables, $table);
 		}
-		echo $sql."<br>";
 		$db->exec($sql);
 	}
 }
@@ -355,7 +358,14 @@ if(isset($_POST["action"]))
 			if(isset($_POST["auditlog"]) && $file->getFilename() === "auditlog.list")
 			{
 				$num = archive_insert_into_table($file, "domain_audit", $flushtables);
-				echo "Processed blacklist (regex) (".$num." entries)<br>\n";
+				echo "Processed audit log (".$num." entries)<br>\n";
+				$importedsomething = true;
+			}
+
+			if(isset($_POST["adlist"]) && $file->getFilename() === "adlists.list")
+			{
+				$num = archive_insert_into_table($file, "adlist", $flushtables);
+				echo "Processed adlists (".$num." entries)<br>\n";
 				$importedsomething = true;
 			}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix teleporter's ability to import v4.x archives
This bug was reported on [Discourse](https://discourse.pi-hole.net/t/teleporter-file-from-v4/27527)

**How does this PR accomplish the above?:**

The transition from having multiple tables to a common `domainlist` inside teleporter was incomplete. While we migrated the code that imports the (new!) JSON format in the generated archives, the legacy files (`.list` files) were handled by code defined in another PHP file (`database.php`). This required some changes in the importing routines which are part of this PR.

While I was at it, I added generating an automatic comment similar to what we add during the v4.x -> v5.0 migration:
![Screenshot from 2020-01-28 22-23-44](https://user-images.githubusercontent.com/16748619/73307543-b026b400-421e-11ea-8a97-acfc308b83ac.png)


**What documentation changes (if any) are needed to support this PR?:**

None