### PR TITLE
Add CNAME blocking states and show more details in CNAME blocking

### DIFF
--- a/db_queries.php
+++ b/db_queries.php
@@ -45,34 +45,39 @@ $token = $_SESSION['token'];
         <label>Query status:</label>
     </div>
     <div class="form-group">
-        <div class="col-md-2">
+        <div class="col-md-3">
             <div class="checkbox">
-                <label><input type="checkbox" id="type_gravity" checked>Blocked (exact)</label>
+                <label><input type="checkbox" id="type_forwarded" checked><strong>Permitted: </strong>forwarded</label>
+            </div>
+            <div class="checkbox">
+                <label><input type="checkbox" id="type_cached" checked><strong>Permitted: </strong>cached</label>
             </div>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
             <div class="checkbox">
-                <label><input type="checkbox" id="type_forwarded" checked>OK (forwarded)</label>
+                <label><input type="checkbox" id="type_gravity" checked><strong>Blocked: </strong>gravity</label>
+            </div>
+            <div class="checkbox">
+                <label><input type="checkbox" id="type_external" checked><strong>Blocked: </strong>external</label>
             </div>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
             <div class="checkbox">
-                <label><input type="checkbox" id="type_cached" checked>OK (cached)</label>
+                <label><input type="checkbox" id="type_blacklist" checked><strong>Blocked: </strong>exact blacklist</label>
+            </div>
+            <div class="checkbox">
+                <label><input type="checkbox" id="type_regex" checked><strong>Blocked: </strong>regex blacklist</label>
             </div>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
             <div class="checkbox">
-                <label><input type="checkbox" id="type_regex" checked>Blocked (regex/wildcard)</label>
+                <label><input type="checkbox" id="type_gravity_CNAME" checked><strong>Blocked: </strong>gravity (CNAME)</label>
             </div>
-        </div>
-        <div class="col-md-2">
             <div class="checkbox">
-                <label><input type="checkbox" id="type_blacklist" checked>Blocked (blacklist)</label>
+                <label><input type="checkbox" id="type_blacklist_CNAME" checked><strong>Blocked: </strong>exact blacklist (CNAME)</label>
             </div>
-        </div>
-        <div class="col-md-2">
             <div class="checkbox">
-                <label><input type="checkbox" id="type_external" checked>Blocked (external)</label>
+                <label><input type="checkbox" id="type_regex_CNAME" checked><strong>Blocked: </strong>regex blacklist (CNAME)</label>
             </div>
         </div>
     </div>

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -195,6 +195,18 @@ function getQueryTypes() {
     queryType.push([6, 7, 8]);
   }
 
+  if ($("#type_gravity_CNAME").prop("checked")) {
+    queryType.push(9);
+  }
+
+  if ($("#type_regex_CNAME").prop("checked")) {
+    queryType.push(10);
+  }
+
+  if ($("#type_blacklist_CNAME").prop("checked")) {
+    queryType.push(11);
+  }
+
   return queryType.join(",");
 }
 
@@ -282,13 +294,13 @@ $(document).ready(function() {
           break;
         case 4:
           color = "red";
-          fieldtext = "Blocked <br class='hidden-lg'>(regex/wildcard)";
+          fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         case 5:
           color = "red";
-          fieldtext = "Blocked <br class='hidden-lg'>(blacklist)";
+          fieldtext = "Blocked <br class='hidden-lg'>(exact blacklist)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
@@ -306,6 +318,24 @@ $(document).ready(function() {
           color = "red";
           fieldtext = "Blocked <br class='hidden-lg'>(external, NXRA)";
           buttontext = "";
+          break;
+        case 9:
+          color = "red";
+          fieldtext = "Blocked (gravity, CNAME)";
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          break;
+        case 10:
+          color = "red";
+          fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist, CNAME)";
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          break;
+        case 11:
+          color = "red";
+          fieldtext = "Blocked <br class='hidden-lg'>(exact blacklist, CNAME)";
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         default:
           color = "black";

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -11,6 +11,7 @@ var table;
 var groups = [];
 var token = $("#token").html();
 var info = null;
+var GETDict = {};
 
 function showAlert(type, icon, title, message) {
   var opts = {};
@@ -88,6 +89,13 @@ function datetime(date) {
 }
 
 $(document).ready(function() {
+  window.location.search
+    .substr(1)
+    .split("&")
+    .forEach(function(item) {
+      GETDict[item.split("=")[0]] = item.split("=")[1];
+    });
+
   $("#btnAdd").on("click", addDomain);
 
   get_groups();
@@ -186,6 +194,13 @@ function initTable() {
         );
       }
 
+      // Highlight row
+      if ("domainid" in GETDict && data.id === parseInt(GETDict.domainid)) {
+        $(row)
+          .find("td")
+          .addClass("highlight");
+      }
+
       // Select assigned groups
       sel.val(data.groups);
       // Initialize multiselect
@@ -230,6 +245,18 @@ function initTable() {
       data.columns[0].visible = false;
       // Apply loaded state to table
       return data;
+    },
+    initComplete: function() {
+      if ("domainid" in GETDict) {
+        var pos = table
+          .column(0, { order: "current" })
+          .data()
+          .indexOf(parseInt(GETDict.domainid));
+        if (pos >= 0) {
+          var page = Math.floor(pos / table.page.info().length);
+          table.page(page).draw(false);
+        }
+      }
     }
   });
 

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -418,14 +418,16 @@ $(document).ready(function() {
       // Domain
       api.$("td:eq(2)").click(function() {
         if (autofilter()) {
-          api.search(this.textContent).draw();
+          var domain = this.textContent.split("\n")[0];
+          api.search(domain).draw();
           $("#resetButton").show();
         }
       });
       api.$("td:eq(2)").hover(
         function() {
           if (autofilter()) {
-            this.title = "Click to show only queries with domain " + this.textContent;
+            var domain = this.textContent.split("\n")[0];
+            this.title = "Click to show only queries with domain " + domain;
             this.style.color = "#72afd2";
           } else {
             this.title = "";

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -257,6 +257,10 @@ $(document).ready(function() {
           buttontext = "";
       }
 
+      if (data.length > 9 && data[9] > -1) {
+        fieldtext += "<br><a href='groups-domains.php?domainid=" + data[9] + "'>Jump to regex</a>";
+      }
+
       $(row).addClass(colorClass);
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(6)", row).html(buttontext);

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -166,7 +166,12 @@ $(document).ready(function() {
       }
 
       // Query status
-      var blocked, fieldtext, buttontext, colorClass;
+      var blocked,
+        fieldtext,
+        buttontext,
+        colorClass,
+        isCNAME = false;
+
       switch (data[4]) {
         case "1":
           blocked = true;
@@ -192,14 +197,14 @@ $(document).ready(function() {
         case "4":
           blocked = true;
           colorClass = "text-red";
-          fieldtext = "Blocked <br class='hidden-lg'>(regex/wildcard)";
+          fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         case "5":
           blocked = true;
           colorClass = "text-red";
-          fieldtext = "Blocked <br class='hidden-lg'>(blacklist)";
+          fieldtext = "Blocked <br class='hidden-lg'>(exact blacklist)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
@@ -221,6 +226,30 @@ $(document).ready(function() {
           fieldtext = "Blocked <br class='hidden-lg'>(external, NXRA)";
           buttontext = "";
           break;
+        case "9":
+          blocked = true;
+          colorClass = "text-red";
+          fieldtext = "Blocked (gravity, CNAME)";
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          isCNAME = true;
+          break;
+        case "10":
+          blocked = true;
+          colorClass = "text-red";
+          fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist, CNAME)";
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          isCNAME = true;
+          break;
+        case "11":
+          blocked = true;
+          colorClass = "text-red";
+          fieldtext = "Blocked <br class='hidden-lg'>(exact blacklist, CNAME)";
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          isCNAME = true;
+          break;
         default:
           blocked = false;
           colorClass = "text-black";
@@ -228,14 +257,16 @@ $(document).ready(function() {
           buttontext = "";
       }
 
-      // Add extra label when blocking happend during deep CNAME inspection
-      if (blocked && data.length > 6 && data[6] === "3") {
-        fieldtext += "<br>CNAME";
-      }
-
       $(row).addClass(colorClass);
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(6)", row).html(buttontext);
+
+      // Add domain in CNAME chain causing the query to have been blocked
+      var domain = data[2];
+      var CNAME_domain = data[8];
+      if (isCNAME) {
+        $("td:eq(2)", row).text(domain + "\n(blocked " + CNAME_domain + ")");
+      }
 
       // Check for existence of sixth column and display only if not Pi-holed
       var replytext;

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -198,6 +198,18 @@ $(document).ready(function() {
           blocked = true;
           colorClass = "text-red";
           fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist)";
+
+          if (data.length > 9 && data[9] > -1) {
+            fieldtext =
+              "<a href='groups-domains.php?domainid=" +
+              data[9] +
+              "' class=" +
+              colorClass +
+              ">" +
+              fieldtext +
+              ' <i class="fas fa-link"></i></a>';
+          }
+
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
@@ -255,10 +267,6 @@ $(document).ready(function() {
           colorClass = "text-black";
           fieldtext = "Unknown (" + parseInt(data[4]) + ")";
           buttontext = "";
-      }
-
-      if (data.length > 9 && data[9] > -1) {
-        fieldtext += "<br><a href='groups-domains.php?domainid=" + data[9] + "'>Jump to regex</a>";
       }
 
       $(row).addClass(colorClass);

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -239,3 +239,7 @@
 .text-vivid-blue {
     color: #36f !important;
 }
+
+td.highlight {
+    background-color: yellow;
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

1. Implement support for new CNAME-related blocking modes signaling that something was blocked "under the surface" of a query
![Screenshot at 2020-01-29 23-22-12](https://user-images.githubusercontent.com/16748619/73403330-81c4d980-42ef-11ea-9c46-7cf1e5627397.png)


2. Show domain that was the actual reason for blocking in case we blocked as a result of a deep CNAME inspection
![Screenshot at 2020-01-29 22-57-40](https://user-images.githubusercontent.com/16748619/73403325-7f627f80-42ef-11ea-9cb5-a15dcb197edb.png)



**How does this PR accomplish the above?:**

Display new information passed in from https://github.com/pi-hole/FTL/pull/685

**What documentation changes (if any) are needed to support this PR?:**

None