### PR TITLE
Fix computation of percentages in the over-time graph

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -792,8 +792,9 @@ $(document).ready(function() {
           label: function(tooltipItems, data) {
             if (tooltipItems.datasetIndex === 1) {
               var percentage = 0.0;
-              var total = parseInt(data.datasets[0].data[tooltipItems.index]);
+              var permitted = parseInt(data.datasets[0].data[tooltipItems.index]);
               var blocked = parseInt(data.datasets[1].data[tooltipItems.index]);
+              var total = permitted + blocked;
               if (total > 0) {
                 percentage = (100.0 * blocked) / total;
               }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix computation of percentages in the over-time graph

**How does this PR accomplish the above?:**

Fix ratio to be computed against number of total, not permitted queries.

**What documentation changes (if any) are needed to support this PR?:**

None