### PR TITLE
Only try to convert exact domains using the IDN library

### DIFF
--- a/scripts/pi-hole/js/list.js
+++ b/scripts/pi-hole/js/list.js
@@ -123,6 +123,12 @@ function sub(index, entry, arg) {
     list = "#list-regex";
     heading = "#h3-regex";
     locallistType = arg;
+  } else {
+    // Extract possible IDN part
+    // This extracts "xn--allestrungen-9ib.de" from,
+    // e.g. "allestörungen.de (xn--allestrungen-9ib.de)"
+    var raw_domain = entry.split("(");
+    entry = raw_domain[raw_domain.length - 1].split(")")[0];
   }
 
   var alInfo = $("#alInfo");

--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -21,9 +21,12 @@ $domains = preg_split('/\s+/', trim($_POST['domain']));
 $comment = trim($_POST['comment']);
 
 // Convert domain name to IDNA ASCII form for international domains
-foreach($domains as &$domain)
-{
-	$domain = idn_to_ascii($domain);
+// Do this only for exact domains, not for regex filters
+if ($list === "white" || $list === "black") {
+	foreach($domains as &$domain)
+	{
+		$domain = idn_to_ascii($domain);
+	}
 }
 
 // Only check domains we add to the exact lists.

--- a/scripts/pi-hole/php/get.php
+++ b/scripts/pi-hole/php/get.php
@@ -30,12 +30,14 @@ function getTableContent($type) {
 
 	while($results !== false && $res = $results->fetchArray(SQLITE3_ASSOC))
 	{
-		$utf8_domain = idn_to_utf8($res['domain']);
-		// Convert domain name to international form
-		// if applicable
-		if($res['domain'] !== $utf8_domain)
-		{
-			$res['domain'] = $utf8_domain.' ('.$res['domain'].')';
+		if ($res['type'] === ListType::whitelist || $res['type'] === ListType::blacklist) {
+			$utf8_domain = idn_to_utf8($res['domain']);
+			// Convert domain name to international form
+			// if applicable
+			if($res['domain'] !== $utf8_domain)
+			{
+				$res['domain'] = $utf8_domain.' ('.$res['domain'].')';
+			}
 		}
 		array_push($entries, $res);
 	}

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -346,12 +346,14 @@ if ($_POST['action'] == 'get_groups') {
                 array_push($groups, $gres['group_id']);
             }
             $res['groups'] = $groups;
-            $utf8_domain = idn_to_utf8($res['domain']);
-            // Convert domain name to international form
-            // if applicable
-            if($res['domain'] !== $utf8_domain)
-            {
-                $res['domain'] = $utf8_domain.' ('.$res['domain'].')';
+            if ($res['type'] === ListType::whitelist || $res['type'] === ListType::blacklist) {
+                $utf8_domain = idn_to_utf8($res['domain']);
+                // Convert domain name to international form
+                // if applicable
+                if($res['domain'] !== $utf8_domain)
+                {
+                    $res['domain'] = $utf8_domain.' ('.$res['domain'].')';
+                }
             }
             array_push($data, $res);
         }
@@ -371,10 +373,10 @@ if ($_POST['action'] == 'get_groups') {
 
         $type = intval($_POST['type']);
 
-        // Convert domain name to IDNA ASCII form for international domains
-        $domain = idn_to_ascii($_POST['domain']);
-        if($type === ListType::whitelist || $type === ListType::blacklist)
-        {
+        if ($type === ListType::whitelist || $type === ListType::blacklist) {
+            // Convert domain name to IDNA ASCII form for international domains
+            $domain = idn_to_ascii($_POST['domain']);
+
             // If adding to the exact lists, we convert the domain lower case and check whether it is valid
             $domain = strtolower($domain);
             if(filter_var($domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false)

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -372,13 +372,14 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         $type = intval($_POST['type']);
+        $domain = $_POST['domain'];
 
         if ($type === ListType::whitelist || $type === ListType::blacklist) {
-            // Convert domain name to IDNA ASCII form for international domains
-            $domain = idn_to_ascii($_POST['domain']);
+            // Convert domain name to IDNA ASCII form for international
+            // domains and convert the domain to lower case
+            $domain = strtolower(idn_to_ascii($domain));
 
-            // If adding to the exact lists, we convert the domain lower case and check whether it is valid
-            $domain = strtolower($domain);
+            // Check validity of domain
             if(filter_var($domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false)
             {
                 throw new Exception('Domain ' . htmlentities(utf8_encode($domain)) . 'is not a valid domain.');


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix a bug reported on [Discourse](https://discourse.pi-hole.net/t/ghost-regex-blacklist-entry/27941). This bug has recently been added by #1130 

Also, this bugfix fixes another issue not yet being reported, that is international domains could not be removed from the "traditional" white-/blacklist pages but only through the new group management pages.

**How does this PR accomplish the above?:**

- Regex filters should not be sent to the IDN library for conversion
- We need to delete the domain as in the database (punnycode), not the converted (international) form

**What documentation changes (if any) are needed to support this PR?:**

None