### PR TITLE
Improve CNAME inspection details on Query Log

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -199,7 +199,7 @@ $(document).ready(function() {
           colorClass = "text-red";
           fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist)";
 
-          if (data.length > 9 && data[9] > -1) {
+          if (data.length > 9 && data[9] > 0) {
             fieldtext =
               "<a href='groups-domains.php?domainid=" +
               data[9] +
@@ -251,7 +251,7 @@ $(document).ready(function() {
           colorClass = "text-red";
           fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist, CNAME)";
 
-          if (data.length > 9 && data[9] > -1) {
+          if (data.length > 9 && data[9] > 0) {
             fieldtext =
               "<a href='groups-domains.php?domainid=" +
               data[9] +

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -207,7 +207,7 @@ $(document).ready(function() {
               colorClass +
               ">" +
               fieldtext +
-              ' <i class="fas fa-link"></i></a>';
+              ' <i class="fas fa-link" title="Click to show the regex match"></i></a>';
           }
 
           buttontext =
@@ -259,7 +259,7 @@ $(document).ready(function() {
               colorClass +
               ">" +
               fieldtext +
-              ' <i class="fas fa-link"></i></a>';
+              ' <i class="fas fa-link" title="Click to show the regex match"></i></a>';
           }
 
           buttontext =

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -288,7 +288,8 @@ $(document).ready(function() {
             new_tab.focus();
           }
         });
-        $("td:eq(4)", row).css("cursor", "pointer");
+        $("td:eq(4)", row).addClass("underline");
+        $("td:eq(4)", row).addClass("pointer");
       }
 
       // Add domain in CNAME chain causing the query to have been blocked

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -250,6 +250,18 @@ $(document).ready(function() {
           blocked = true;
           colorClass = "text-red";
           fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist, CNAME)";
+
+          if (data.length > 9 && data[9] > -1) {
+            fieldtext =
+              "<a href='groups-domains.php?domainid=" +
+              data[9] +
+              "' class=" +
+              colorClass +
+              ">" +
+              fieldtext +
+              ' <i class="fas fa-link"></i></a>';
+          }
+
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -170,7 +170,8 @@ $(document).ready(function() {
         fieldtext,
         buttontext,
         colorClass,
-        isCNAME = false;
+        isCNAME = false,
+        regexLink = false;
 
       switch (data[4]) {
         case "1":
@@ -200,14 +201,7 @@ $(document).ready(function() {
           fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist)";
 
           if (data.length > 9 && data[9] > 0) {
-            fieldtext =
-              "<a href='groups-domains.php?domainid=" +
-              data[9] +
-              "' class=" +
-              colorClass +
-              ">" +
-              fieldtext +
-              ' <i class="fas fa-link" title="Click to show the regex match"></i></a>';
+            regexLink = true;
           }
 
           buttontext =
@@ -252,14 +246,7 @@ $(document).ready(function() {
           fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist, CNAME)";
 
           if (data.length > 9 && data[9] > 0) {
-            fieldtext =
-              "<a href='groups-domains.php?domainid=" +
-              data[9] +
-              "' class=" +
-              colorClass +
-              ">" +
-              fieldtext +
-              ' <i class="fas fa-link" title="Click to show the regex match"></i></a>';
+            regexLink = true;
           }
 
           buttontext =
@@ -284,6 +271,25 @@ $(document).ready(function() {
       $(row).addClass(colorClass);
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(6)", row).html(buttontext);
+
+      if (regexLink) {
+        $("td:eq(4)", row).hover(
+          function() {
+            this.title = "Click to show matching regex filter";
+            this.style.color = "#72afd2";
+          },
+          function() {
+            this.style.color = "";
+          }
+        );
+        $("td:eq(4)", row).click(function() {
+          var new_tab = window.open("groups-domains.php?domainid=" + data[9], "_blank");
+          if (new_tab) {
+            new_tab.focus();
+          }
+        });
+        $("td:eq(4)", row).css("cursor", "pointer");
+      }
 
       // Add domain in CNAME chain causing the query to have been blocked
       var domain = data[2];

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -243,3 +243,11 @@
 td.highlight {
     background-color: yellow;
 }
+
+.underline {
+    text-decoration: underline;
+}
+
+.pointer {
+    cursor: pointer;
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Add link to responsible regex also when blocking happened during a CNAME inspection.

**How does this PR accomplish the above?:**

Show link when information is available. https://github.com/pi-hole/FTL/pull/693 adds this for deeply regex blocked queries.

**What documentation changes (if any) are needed to support this PR?:**

None