### PR TITLE
Add info that users should run pihole -g

### DIFF
--- a/gravity.php
+++ b/gravity.php
@@ -15,7 +15,7 @@
 <!-- Alerts -->
 <div id="alInfo" class="alert alert-info alert-dismissible fade in" role="alert" hidden="true">
     <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    Updating...
+    Updating...this may take a while. <strong>Please do not navigate away from or close this page.</strong>
 </div>
 <div id="alSuccess" class="alert alert-success alert-dismissible fade in" role="alert" hidden="true">
     <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>

--- a/groups-adlists.php
+++ b/groups-adlists.php
@@ -37,6 +37,7 @@
                 </div>
             </div>
             <div class="box-footer clearfix">
+                <strong>Hint:</strong>&nbsp;Please run <code>pihole -g</code> or update your gravity list <a href="gravity.php">online</a> after modifying your adlists.
                 <button id="btnAdd" class="btn btn-primary pull-right">Add</button>
             </div>
         </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Add info that users should run pihole -g (can also be done on the web interface) after modifying their adlists.

**How does this PR accomplish the above?:**

Add info texts:

On adlist management page:
![Screenshot from 2020-02-15 09-29-06](https://user-images.githubusercontent.com/16748619/74584770-08f39c00-4fd6-11ea-9d29-c76276b379bb.png)

On the gravity page when clicking the big `[Update]` button:
![Screenshot from 2020-02-15 09-28-54](https://user-images.githubusercontent.com/16748619/74584768-0729d880-4fd6-11ea-9891-3d7fee4b1ff9.png)


**What documentation changes (if any) are needed to support this PR?:**

None