### PR TITLE
Reverse logic on Query Log buttons

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -478,10 +478,10 @@ $(document).ready(function() {
 
   $("#all-queries tbody").on("click", "button", function() {
     var data = tableApi.row($(this).parents("tr")).data();
-    if (data[4] === "1" || data[4] === "4" || data[4] === "5") {
-      add(data[2], "white");
-    } else {
+    if (data[4] === "2" || data[4] === "3") {
       add(data[2], "black");
+    } else {
+      add(data[2], "white");
     }
   });
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix bug mentioned on [Discourse](https://discourse.pi-hole.net/t/clicking-the-whitelist-button-on-a-query-of-type-blocked-regex-blacklist-cname-adds-the-domain-to-the-blacklist-instead/28242) resulting in a malfunction of the `[Whitelist]` button for the new CNAME blocking modes on the Query Log page.

This PR fixes it in a way that it doesn't happen again when more blocking modes are added in future releases.

**How does this PR accomplish the above?:**

Reverse logic on Query Log to ensure only permitted queries can be added to the blacklist.

**What documentation changes (if any) are needed to support this PR?:**

None