### PR TITLE
Only use IDN subroutines when the module is available

### DIFF
--- a/scripts/pi-hole/php/add.php
+++ b/scripts/pi-hole/php/add.php
@@ -22,7 +22,8 @@ $comment = trim($_POST['comment']);
 
 // Convert domain name to IDNA ASCII form for international domains
 // Do this only for exact domains, not for regex filters
-if ($list === "white" || $list === "black") {
+// Only do it when the php-intl extension is available
+if (extension_loaded("intl") && ($list === "white" || $list === "black")) {
 	foreach($domains as &$domain)
 	{
 		$domain = idn_to_ascii($domain);

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -352,10 +352,12 @@ if ($_POST['action'] == 'get_groups') {
                 array_push($groups, $gres['group_id']);
             }
             $res['groups'] = $groups;
-            if ($res['type'] === ListType::whitelist || $res['type'] === ListType::blacklist) {
+            if (extension_loaded("intl") &&
+                ($res['type'] === ListType::whitelist ||
+                 $res['type'] === ListType::blacklist) ) {
                 $utf8_domain = idn_to_utf8($res['domain']);
                 // Convert domain name to international form
-                // if applicable
+                // if applicable and extension is available
                 if($res['domain'] !== $utf8_domain)
                 {
                     $res['domain'] = $utf8_domain.' ('.$res['domain'].')';
@@ -389,7 +391,11 @@ if ($_POST['action'] == 'get_groups') {
         if ($type === ListType::whitelist || $type === ListType::blacklist) {
             // Convert domain name to IDNA ASCII form for international
             // domains and convert the domain to lower case
-            $domain = strtolower(idn_to_ascii($domain));
+            // Only use IDN routine when php-intl is available
+            if (extension_loaded("intl")) {
+                $domain = idn_to_ascii($domain);
+            }
+            $domain = strtolower($domain);
 
             // Check validity of domain
             if(filter_var($domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix a bug seen when incompatible `php-intl` extensions are installed.

**How does this PR accomplish the above?:**

Only use IDN subroutines when the module is available. We have seen reports that at least DietPi is having issues with not matching PHP base and extension versions.

**What documentation changes (if any) are needed to support this PR?:**

None