### PR TITLE
fix input fields spacing issues

### DIFF
--- a/custom_dns.php
+++ b/custom_dns.php
@@ -28,11 +28,11 @@
             <!-- /.box-header -->
             <div class="box-body">
                 <div class="row">
-                    <div class="col-md-6">
+                    <div class="form-group col-md-6">
                         <label for="domain">Domain:</label>
                         <input id="domain" type="text" class="form-control" placeholder="Add a domain (example.com or sub.example.com)">
                     </div>
-                    <div class="col-md-6">
+                    <div class="form-group col-md-6">
                         <label for="ip">IP Address:</label>
                         <input id="ip" type="text" class="form-control" placeholder="Associated IP address">
                     </div>

--- a/groups-adlists.php
+++ b/groups-adlists.php
@@ -26,12 +26,12 @@
             <!-- /.box-header -->
             <div class="box-body">
                 <div class="row">
-                    <div class="col-md-6">
-                        <label for="ex1">Address:</label>
+                    <div class="form-group col-md-6">
+                        <label for="new_address">Address:</label>
                         <input id="new_address" type="text" class="form-control" placeholder="http://..., https://..., file://...">
                     </div>
-                    <div class="col-md-6">
-                        <label for="ex2">Comment:</label>
+                    <div class="form-group col-md-6">
+                        <label for="new_comment">Comment:</label>
                         <input id="new_comment" type="text" class="form-control" placeholder="Adlist description (optional)">
                     </div>
                 </div>

--- a/groups-clients.php
+++ b/groups-clients.php
@@ -26,15 +26,15 @@
             <!-- /.box-header -->
             <div class="box-body">
                 <div class="row">
-                    <div class="col-md-6">
-                        <label for="ex1">Known clients:</label>
+                    <div class="form-group col-md-6">
+                        <label for="select">Known clients:</label>
                         <select id="select" class="form-control" placeholder="">
                             <option disabled selected>Loading...</option>
                         </select><br>
                         <input id="ip-custom" type="text" class="form-control" disabled placeholder="Client IP address (IPv4 or IPv6, CIDR subnetting available, optional)">
                     </div>
-                    <div class="col-md-6">
-                        <label for="ex3">Comment:</label>
+                    <div class="form-group col-md-6">
+                        <label for="new_comment">Comment:</label>
                         <input id="new_comment" type="text" class="form-control" placeholder="Client description (optional)">
                     </div>
                 </div>

--- a/groups.php
+++ b/groups.php
@@ -26,12 +26,12 @@
             <!-- /.box-header -->
             <div class="box-body">
                 <div class="row">
-                    <div class="col-md-6">
-                        <label for="ex1">Name:</label>
+                    <div class="form-group col-md-6">
+                        <label for="new_name">Name:</label>
                         <input id="new_name" type="text" class="form-control" placeholder="Group name">
                     </div>
-                    <div class="col-md-6">
-                        <label for="ex2">Description:</label>
+                    <div class="form-group col-md-6">
+                        <label for="new_desc">Description:</label>
                         <input id="new_desc" type="text" class="form-control" placeholder="Group description (optional)">
                     </div>
                 </div>

--- a/settings.php
+++ b/settings.php
@@ -694,6 +694,8 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                         <input type="text" name="custom1val" class="form-control"
                                                                <?php if (isset($custom1)){ ?>value="<?php echo $custom1; ?>"<?php } ?>>
                                                     </div>
+                                                </div>
+                                                <div class="form-group">
                                                     <label>Custom 2 (IPv4)</label>
                                                     <div class="input-group">
                                                         <div class="input-group-addon">
@@ -716,6 +718,8 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                         <input type="text" name="custom3val" class="form-control"
                                                                <?php if (isset($custom3)){ ?>value="<?php echo $custom3; ?>"<?php } ?>>
                                                     </div>
+                                                </div>
+                                                <div class="form-group">
                                                     <label>Custom 4 (IPv6)</label>
                                                     <div class="input-group">
                                                         <div class="input-group-addon">
@@ -975,10 +979,8 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "blocklists"
                                                 </div>
                                                 <h4>Administrator Email Address</h4>
                                                 <div class="form-group">
-                                                    <div class="input-group">
-                                                        <input type="text" class="form-control" name="adminemail"
-                                                               value="<?php echo htmlspecialchars($adminemail); ?>">
-                                                    </div>
+                                                    <input type="text" class="form-control" name="adminemail"
+                                                           value="<?php echo htmlspecialchars($adminemail); ?>">
                                                 </div>
                                                 <input type="hidden" name="field" value="webUI">
                                                 <input type="hidden" name="token" value="<?php echo $token ?>">


### PR DESCRIPTION
Signed-off-by: Th3M3 the_me@outlook.de

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`
**I've made this PR against `release/5.0`**. If this is wrong, feel free to close this.

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

- add a spacing between input fields
- change the _administrator email address_ field to full width
- display the _domain_ and _comment_ input fields at _Settings_ > _Blocklists_ in one line only if the screen is large

|before   | after
|:---------|:-------------|
<img width="214" alt="1_ 0" src="https://user-images.githubusercontent.com/28313514/78598069-e734c980-784e-11ea-8436-1fddfdf3f3b1.png">|<img width="214" alt="2_ 0" src="https://user-images.githubusercontent.com/28313514/78598119-016ea780-784f-11ea-99a6-11221b6002d3.png">
<img width="366" alt="1 1" src="https://user-images.githubusercontent.com/28313514/74684557-87199380-51cc-11ea-864c-b47b27758b2b.png">|<img width="366" alt="1 0" src="https://user-images.githubusercontent.com/28313514/74684543-7f59ef00-51cc-11ea-9ed5-d75b6992379e.png">
<img width="215" alt="2 1" src="https://user-images.githubusercontent.com/28313514/74684640-b4fed800-51cc-11ea-802a-4980edb29cd6.png">|<img width="215" alt="2 0" src="https://user-images.githubusercontent.com/28313514/74684652-ba5c2280-51cc-11ea-8400-434830a08e52.png">

**How does this PR accomplish the above?:**

- add `form-group`-classes to elements, which adds a 15px margin at the bottom
- remove `div.input-group` before _administrator email address_ input field


**What documentation changes (if any) are needed to support this PR?:**

None
