### PR TITLE
Keep "custom" selection after clicking [Add].

### DIFF
--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -17,6 +17,7 @@ function reload_client_suggestions() {
     { action: "get_unconfigured_clients", token: token },
     function(data) {
       var sel = $("#select");
+      var customWasSelected = sel.val() === "custom";
       sel.empty();
       for (var key in data) {
         if (!Object.prototype.hasOwnProperty.call(data, key)) {
@@ -40,6 +41,9 @@ function reload_client_suggestions() {
           .val("custom")
           .text("Custom, specified below...")
       );
+      if (customWasSelected) {
+        sel.val("custom");
+      }
     },
     "json"
   );


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix a bug mentioned on Discourse.

**How does this PR accomplish the above?:**

Memorize if custom was selected before clicking on [Add]. If this was the case, re-select custom afterwards.

**What documentation changes (if any) are needed to support this PR?:**

None