### PR TITLE
Fix selector container duplication that occurs when table is redrawn

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -47,6 +47,7 @@ function initTable() {
     ],
     drawCallback: function() {
       $('button[id^="deleteAdlist_"]').on("click", deleteAdlist);
+      $('body > [id^="container_"]').each(function () { $(this).remove(); });
     },
     rowCallback: function(row, data) {
       $(row).attr("data-id", data.id);

--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -90,6 +90,7 @@ function initTable() {
     ],
     drawCallback: function() {
       $('button[id^="deleteClient_"]').on("click", deleteClient);
+      $('body > [id^="container_"]').each(function () { $(this).remove(); });
     },
     rowCallback: function(row, data) {
       $(row).attr("data-id", data.id);
@@ -161,8 +162,8 @@ function initTable() {
           el.css("left", offset.left + "px");
         },
         onDropdownHide: function() {
-          var el = $("#container" + data.id);
-          var home = $("#selectHome" + data.id);
+          var el = $("#container_" + data.id);
+          var home = $("#selectHome_" + data.id);
           home.append(el);
           el.removeAttr("style");
         }

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -61,6 +61,7 @@ function initTable() {
     ],
     drawCallback: function() {
       $('button[id^="deleteDomain_"]').on("click", deleteDomain);
+      $('body > [id^="container_"]').each(function () { $(this).remove(); });
     },
     rowCallback: function(row, data) {
       $(row).attr("data-id", data.id);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Duplication of selector container (group selector) that tends to happen when the table is redrawn.

**How does this PR accomplish the above?:**

On drawCallback of table, remove any existing selector containers that are children of body

**What documentation changes (if any) are needed to support this PR?:**

None

I tested this on my end and it works but can definitely get some verification.
Don't know if it's a little too hacky way of doing this but here it is anyway.

This issue fixes the problem mentioned in
https://discourse.pi-hole.net/t/web-interface-groupmanagement-shows-wrong-assignement-after-next-page/28808