### PR TITLE
fix group management buttons behaviour

### DIFF
--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -154,15 +154,17 @@ function initTable() {
             el.removeClass("dropup");
           }
 
+          this.$ul.addClass("hidden");
           var offset = el.offset();
           $("body").append(el);
           el.css("position", "absolute");
           el.css("top", offset.top + "px");
           el.css("left", offset.left + "px");
+          this.$ul.removeClass("hidden");
         },
         onDropdownHide: function() {
-          var el = $("#container" + data.id);
-          var home = $("#selectHome" + data.id);
+          var el = $("#container_" + data.id);
+          var home = $("#selectHome_" + data.id);
           home.append(el);
           el.removeAttr("style");
         }


### PR DESCRIPTION

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

fix wrong group groupmanagement as addressed on discourse:
https://discourse.pi-hole.net/t/web-interface-groupmanagement-shows-wrong-assignement-after-next-page/28808

**How does this PR accomplish the above?:**

- add missing underline character to element's id
- hiding the dropdown menu before retrieving the position prevents unexpected button's movement inside the table cell
