### PR TITLE
Improve dropdown/multiselect absolute positioning code

### DIFF
--- a/scripts/pi-hole/js/bootstrap-multiselect-ext.js
+++ b/scripts/pi-hole/js/bootstrap-multiselect-ext.js
@@ -1,0 +1,77 @@
+/*
+ * Extension to bootstrap-multiselect jQuery plugin
+ *
+ */
+
+(function($) {
+  var helperFunctions = {
+    extRemoveVisibleDropdowns: function() {
+      $('body > ul.dropdown-menu').remove();
+    }
+  }
+  var extMethods = {
+    /*
+     * Sets dropdown as direct child of body (to make it appear topmost),
+     * aligns it, and makes it visible
+     */
+    extShowDropdown: function() {
+      if (!this.$ul.parent().is('body')) {
+        $('body').append(this.$ul);
+      }
+      this.extAlignDropdown();
+      this.$ul.show();
+    },
+    /*
+     * Hides and moves dropdown to it's container
+     */
+    extHideDropdown: function() {
+      this.$ul.hide();
+      if (!this.$ul.parent().is(this.$container)) {
+        this.$container.append(this.$ul);
+      }
+    },
+    /*
+     * Aligns dropdown to the multiselect button
+     */
+    extAlignDropdown: function() {
+      var contRect = this.$container[0].getBoundingClientRect();
+      var contOffset = this.$container.offset();
+
+      // Set vertical shift
+      var bottom = $(window).height() - contRect.top;
+      var listHeight = this.$ul.height();
+      var vertShift = -listHeight;
+
+      if (bottom < listHeight + contRect.height) {
+        this.$container.addClass("dropup");
+      } else {
+        this.$container.removeClass("dropup");
+        vertShift = contRect.height;
+      }
+
+      // Set horizontal shift
+      var windowWidth = $(window).width();
+      var rightWidth = windowWidth - contOffset.left;
+      var listWidth = this.$ul.width();
+
+      if (windowWidth - 26 < contRect.right) {
+        // Button's right end is out of view, align dropdown
+        // to the table's right border
+        this.$ul.css("left", (windowWidth - listWidth - 26) + "px");
+      } else if (rightWidth < listWidth) {
+        // Dropdown's right end is out of view, align
+        // right end to button's right end
+        this.$ul.css("left", (contOffset.left - listWidth + contRect.width) + "px");
+      } else {
+        // Align dropdown's left end to the left end of the button
+        this.$ul.css("left", contOffset.left + "px");
+      }
+
+      this.$ul.css("position", "absolute");
+      this.$ul.css("top", (contOffset.top + vertShift) + "px");
+    }
+  }
+
+  $.extend(true, $.fn.multiselect, helperFunctions);
+  $.extend(true, $.fn.multiselect.Constructor.prototype, extMethods);
+})(jQuery);

--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -47,6 +47,9 @@ function initTable() {
     ],
     drawCallback: function() {
       $('button[id^="deleteAdlist_"]').on("click", deleteAdlist);
+
+      // Remove visible dropdowns to prevent orphaning
+      $.fn.multiselect.extRemoveVisibleDropdowns();
     },
     rowCallback: function(row, data) {
       $(row).attr("data-id", data.id);
@@ -111,32 +114,21 @@ function initTable() {
         includeSelectAllOption: true,
         buttonContainer: '<div id="container_' + data.id + '" class="btn-group"/>',
         maxHeight: 200,
-        onDropdownShown: function() {
-          var el = $("#container_" + data.id);
-          var top = el[0].getBoundingClientRect().top;
-          var bottom = $(window).height() - top - el.height();
-          if (bottom < 200) {
-            el.addClass("dropup");
-          }
-
-          if (bottom > 200) {
-            el.removeClass("dropup");
-          }
-
-          var offset = el.offset();
-          $("body").append(el);
-          el.css("position", "absolute");
-          el.css("top", offset.top + "px");
-          el.css("left", offset.left + "px");
+        onDropdownShow: function() {
+          this.extShowDropdown();
         },
         onDropdownHide: function() {
-          var el = $("#container_" + data.id);
-          var home = $("#selectHome_" + data.id);
-          home.append(el);
-          el.removeAttr("style");
+          this.extHideDropdown();
         }
       });
-      selectEl.on("change", editAdlist);
+      selectEl.on("change", function() {
+        editAdlist.call(this);
+
+        // Button might move a little, therefore realign
+        setTimeout(function() {
+          $("#multiselect_" + data.id).multiselect("extAlignDropdown");
+        });
+      });
 
       var button =
         '<button class="btn btn-danger btn-xs" type="button" id="deleteAdlist_' +

--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -90,6 +90,9 @@ function initTable() {
     ],
     drawCallback: function() {
       $('button[id^="deleteClient_"]').on("click", deleteClient);
+
+      // Remove visible dropdowns to prevent orphaning
+      $.fn.multiselect.extRemoveVisibleDropdowns();
     },
     rowCallback: function(row, data) {
       $(row).attr("data-id", data.id);
@@ -142,32 +145,21 @@ function initTable() {
         includeSelectAllOption: true,
         buttonContainer: '<div id="container_' + data.id + '" class="btn-group"/>',
         maxHeight: 200,
-        onDropdownShown: function() {
-          var el = $("#container_" + data.id);
-          var top = el[0].getBoundingClientRect().top;
-          var bottom = $(window).height() - top - el.height();
-          if (bottom < 200) {
-            el.addClass("dropup");
-          }
-
-          if (bottom > 200) {
-            el.removeClass("dropup");
-          }
-
-          var offset = el.offset();
-          $("body").append(el);
-          el.css("position", "absolute");
-          el.css("top", offset.top + "px");
-          el.css("left", offset.left + "px");
+        onDropdownShow: function() {
+          this.extShowDropdown();
         },
         onDropdownHide: function() {
-          var el = $("#container" + data.id);
-          var home = $("#selectHome" + data.id);
-          home.append(el);
-          el.removeAttr("style");
+          this.extHideDropdown();
         }
       });
-      selectEl.on("change", editClient);
+      selectEl.on("change", function() {
+        editClient.call(this);
+
+        // Button might move a little, therefore realign
+        setTimeout(function() {
+          $("#multiselect_" + data.id).multiselect("extAlignDropdown");
+        });
+      });
 
       var button =
         '<button class="btn btn-danger btn-xs" type="button" id="deleteClient_' +

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -61,6 +61,9 @@ function initTable() {
     ],
     drawCallback: function() {
       $('button[id^="deleteDomain_"]').on("click", deleteDomain);
+
+      // Remove visible dropdowns to prevent orphaning
+      $.fn.multiselect.extRemoveVisibleDropdowns();
     },
     rowCallback: function(row, data) {
       $(row).attr("data-id", data.id);
@@ -166,32 +169,21 @@ function initTable() {
           includeSelectAllOption: true,
           buttonContainer: '<div id="container_' + data.id + '" class="btn-group"/>',
           maxHeight: 200,
-          onDropdownShown: function() {
-            var el = $("#container_" + data.id);
-            var top = el[0].getBoundingClientRect().top;
-            var bottom = $(window).height() - top - el.height();
-            if (bottom < 200) {
-              el.addClass("dropup");
-            }
-
-            if (bottom > 200) {
-              el.removeClass("dropup");
-            }
-
-            var offset = el.offset();
-            $("body").append(el);
-            el.css("position", "absolute");
-            el.css("top", offset.top + "px");
-            el.css("left", offset.left + "px");
+          onDropdownShow: function() {
+            this.extShowDropdown();
           },
           onDropdownHide: function() {
-            var el = $("#container_" + data.id);
-            var home = $("#selectHome_" + data.id);
-            home.append(el);
-            el.removeAttr("style");
+            this.extHideDropdown();
           }
         });
-        selectEl.on("change", editDomain);
+        selectEl.on("change", function() {
+          editDomain.call(this);
+
+          // Button might move a little, therefore realign
+          setTimeout(function() {
+            $("#multiselect_" + data.id).multiselect("extAlignDropdown");
+          });
+        });
       }
 
       // Highlight row (if url parameter "domainid=" is used)

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -224,6 +224,7 @@
 
 <?php if(in_array($scriptname, array("groups.php", "groups-clients.php", "groups-domains.php", "groups-adlists.php"))){ ?>
     <script src="style/vendor/bootstrap/js/bootstrap-multiselect.js"></script>
+    <script src="scripts/pi-hole/js/bootstrap-multiselect-ext.js"></script>
     <link rel="stylesheet" href="style/vendor/bootstrap/css/bootstrap-multiselect.css">
     <script src="style/vendor/bootstrap/js/bootstrap-toggle.min.js"></script>
     <link rel="stylesheet" href="style/vendor/bootstrap/css/bootstrap-toggle.min.css">


### PR DESCRIPTION
Signed-off-by: trillaxe <trillax@tutanota.com>

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

- The ability to set the position of dropdown from anywhere, e.g after selecting an option.
- Fix a bug that occurs when table is redrawn (selecting next/previous) while dropdown is visible.

**How does this PR accomplish the above?:**

By extracting the code within onDropdownShown to it's own function, it allows us to set the position of a dropdown from anywhere in the code e.g right after selecting an option which sometimes shifts the multiselect button's position.

Remove visible dropdown when the table is redrawn to prevent orphaning.

The changes
- uses the ul element (dropdown) instead of the container (which includes the button)
- add horizontal shift calculation for small screen sizes
- remove any visible dropdown upon table redraw
- reposition of dropdown when selecting options
- comments

**What documentation changes (if any) are needed to support this PR?:**

None
