### PR TITLE
Hide mock hardware addresses

### DIFF
--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -123,6 +123,11 @@ $(document).ready(function() {
       if (data.macVendor && data.macVendor.length > 0) {
         $("td:eq(1)", row).html(data.hwaddr + "<br/>" + data.macVendor);
       }
+
+      // Hide mock MAC addresses
+      if (data.hwaddr.startsWith("ip-")) {
+        $("td:eq(1)", row).text("N/A");
+      }
     },
     dom:
       "<'row'<'col-sm-12'f>>" +

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -93,9 +93,9 @@ $(document).ready(function() {
         $("td:eq(5)", row).html("Never");
       }
 
-      // Set hostname to "N/A" if not available
+      // Set hostname to "unknown" if not available
       if (!data.name || data.name.length === 0) {
-        $("td:eq(3)", row).html("N/A");
+        $("td:eq(3)", row).html("<em>unknown</em>");
       }
 
       // Set number of queries to localized string (add thousand separators)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Hide mock hardware addresses (those starting in `ip-...`) on the network page.

**How does this PR accomplish the above?:**

Check if the hardware address starts in `ip-`.

**What documentation changes (if any) are needed to support this PR?:**

None