### PR TITLE
allow to clear email address

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -555,9 +555,9 @@ function addStaticDHCPLease($mac, $ip, $hostname) {
 				$adminemail = trim($_POST["adminemail"]);
 				if(strlen($adminemail) == 0 || !isset($adminemail))
 				{
-					$adminemail = 'noadminemail';
+					$adminemail = '';
 				}
-				elseif(!validEmail($adminemail))
+				if(strlen($adminemail) > 0 && !validEmail($adminemail))
 				{
 					$error .= "Administrator email address (".htmlspecialchars($adminemail).") is invalid!<br>";
 				}


### PR DESCRIPTION
Signed-off-by: Th3M3 <the_me@outlook.de>

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Allow to reset the administrator email address by removing the input field's text.

**How does this PR accomplish the above?:**

set `$adminemail` to an empty string if no email address value is given and then check for validity only if an address is entered.

**What documentation changes (if any) are needed to support this PR?:**

None.

PS: <b><i>I had a closer look into the code, but didn't find out why the value is set to `noadminemail` if the input field was empty.</i></b>