### PR TITLE
Prevent multiple tabs from being opened when clicking on a regex link on the Query Log page

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -282,6 +282,7 @@ $(document).ready(function() {
             this.style.color = "";
           }
         );
+        $("td:eq(4)", row).unbind(); // Release any possible previous onClick event handlers
         $("td:eq(4)", row).click(function() {
           var new_tab = window.open("groups-domains.php?domainid=" + data[9], "_blank");
           if (new_tab) {

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -282,7 +282,7 @@ $(document).ready(function() {
             this.style.color = "";
           }
         );
-        $("td:eq(4)", row).unbind(); // Release any possible previous onClick event handlers
+        $("td:eq(4)", row).off(); // Release any possible previous onClick event handlers
         $("td:eq(4)", row).click(function() {
           var new_tab = window.open("groups-domains.php?domainid=" + data[9], "_blank");
           if (new_tab) {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Prevent multiple tabs from being opened when clicking on a regex link on the Query Log page.
This bug has been reported on Discourse.

**How does this PR accomplish the above?:**

Release possible previous onClick event handler on regex links before assigning new ones.

**What documentation changes (if any) are needed to support this PR?:**

None