### PR TITLE
Allow too long legend lines to break

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -237,6 +237,7 @@
 
 .chart-legend li {
     cursor: pointer;
+    word-break: break-all;
 }
 
 .chart-legend li span {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fixes #1220 

**How does this PR accomplish the above?:**

Allow too long legend lines to break

**BEFORE**
![Screenshot at 2020-04-27 23-22-17](https://user-images.githubusercontent.com/16748619/80422367-50ec4480-88de-11ea-89a8-55d72f1aa9c2.png)

**AFTER**
![Screenshot at 2020-04-27 23-24-24](https://user-images.githubusercontent.com/16748619/80422373-55b0f880-88de-11ea-8d3c-b8cefd3fee2b.png)


**What documentation changes (if any) are needed to support this PR?:**

None