### PR TITLE
Use the default AdminLTEv4 sidebar behavior

### DIFF
--- a/scripts/lua/header_authenticated.lp
+++ b/scripts/lua/header_authenticated.lp
@@ -27,7 +27,7 @@ mg.include('header.lp','r')
     <script src="<?=pihole.fileversion('vendor/waitMe-js/modernized-waitme-min.js')?>"></script>
     <script src="<?=pihole.fileversion('scripts/js/logout.js')?>"></script>
 </head>
-<body class="<?=theme.name?> hold-transition sidebar-mini sidebar-expand-lg bg-body-secondary <? if pihole.boxedlayout() then ?>layout-boxed<? end ?> logged-in page-<?=pihole.format_path(scriptname)?>" data-apiurl="<?=pihole.api_url()?>" data-webhome="<?=webhome?>" data-bs-theme="<?= bs_theme ?>">
+<body class="<?=theme.name?> hold-transition sidebar-expand-lg bg-body-secondary <? if pihole.boxedlayout() then ?>layout-boxed<? end ?> logged-in page-<?=pihole.format_path(scriptname)?>" data-apiurl="<?=pihole.api_url()?>" data-webhome="<?=webhome?>" data-bs-theme="<?= bs_theme ?>">
 <noscript>
     <!-- JS Warning -->
     <div>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -109,31 +109,9 @@ html {
   color: var(--bs-secondary-color);
 }
 
-/* AdminLTE 4 moved the logo to the sidebar (.sidebar-brand class).
-  By default, AdminLTE expects an image and a text for the logo, but we only use
-  "Pi-hole" text as logo.
-  AdminLTE 4 automatically hides the text when the sidebar is collapsed, rsulting
-  in an empty brand.
-  To avoid this issue, we use ::before and ::after pseudo elements to show a
-  smaller text, so the full "Pi-hole" wordmark is always shown. */
 .sidebar-brand .brand-text {
   margin: 0;
   font-size: 1.35em;
-}
-.sidebar-collapse .sidebar-brand .brand-link::before {
-  content: "Pi-";
-  color: var(--lte-sidebar-menu-active-color);
-  font-size: 15px;
-}
-.sidebar-collapse .sidebar-brand .brand-link::after {
-  content: "hole";
-  color: var(--lte-sidebar-menu-active-color);
-  font-size: 15px;
-  font-weight: bold;
-}
-.sidebar-collapse .app-sidebar:hover .brand-link::before,
-.sidebar-collapse .app-sidebar:hover .brand-link::after {
-  content: none;
 }
 
 @keyframes Pulse {

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -55,6 +55,7 @@ html {
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
   position: relative;
   background-color: var(--bs-secondary-bg);
+  overflow: hidden;
 }
 
 /* Bootstrap 5 dropped the `.hidden` utility that Bootstrap 3 (and AdminLTE 2)


### PR DESCRIPTION
### What does this PR aim to accomplish?

Use the default "slide" effect for the side bar.

The default behavior can be seen here (full screen):
https://adminlte.io/themes/v4/layout/unfixed-sidebar.html

And the same behavior applied to our custom "boxed layout":
<img width="1758" height="583" alt="sidebar" src="https://github.com/user-attachments/assets/9aa279fe-dff6-4412-a541-0a0ae4605b9e" />

Internal discussion:
https://team.pi-hole.net/pi-hole/pl/61nadgr6rig8in9hw94pebygzo

### How does this PR accomplish the above?

Removing the `.sidebar-mini` class from the body.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ ] I have read the above and my PR is ready for review. *Check this box to confirm*
