### PR TITLE
Fix/Allow internal underscores in static DHCP hostnames

### DIFF
--- a/scripts/js/settings-dhcp.js
+++ b/scripts/js/settings-dhcp.js
@@ -660,7 +660,10 @@ $(document).on("input blur paste", "#StaticDHCPTable td.static-hostname", functi
   const val = $(this).text().trim();
   if (val && !utils.validateHostnameStrict(val)) {
     $(this).addClass("table-danger");
-    $(this).attr("title", "Invalid hostname: only letters, digits, hyphens, and dots allowed");
+    $(this).attr(
+      "title",
+      "Invalid hostname: letters, digits, hyphens, dots, and underscores allowed"
+    );
   } else {
     $(this).removeClass("table-danger");
     $(this).attr("title", "");

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -363,9 +363,7 @@ function validateHostname(name) {
 }
 
 function validateHostnameStrict(name) {
-  // Hostnames must not contain spaces, commas, or characters invalid in DNS names
-  const hostnameValidator =
-    /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/u;
+  const hostnameValidator = /^[a-zA-Z0-9][\w.-]*$/u;
   return hostnameValidator.test(name.trim());
 }
 

--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -207,7 +207,7 @@ PageTitle = "DHCP Settings"
                                 <ul>
                                     <li>Only one entry per MAC address is allowed.</li>
                                     <li>IPv6 addresses must be enclosed in square brackets like <code>[2001:db8::1]</code>.</li>
-                                    <li>Only letters, digits, hyphens and dots are allowed in hostnames.</li>
+                                    <li>Static DHCP hostnames may contain letters, digits, hyphens, dots, and underscores, but must start with a letter or digit.</li>
                                 </ul>
                                 <br>
                                 <div class="dhcp-hosts-wrapper mb-4">


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

1. Base your code and PRs against the repositories developmental branch.
2. [[Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/)](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [[DCO](https://docs.pi-hole.net/guides/github/dco/)](https://docs.pi-hole.net/guides/github/dco/) for all contributions
3. [[Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
4. File a pull request for any change that requires changes to [[our documentation](https://docs.pi-hole.net/)](https://docs.pi-hole.net/) at our [[documentation repo](https://github.com/pi-hole/docs)](https://github.com/pi-hole/docs)

---

**What does this PR aim to accomplish?:**

Fixes #3814.

Static DHCP hostnames containing internal underscores, such as `TPLinkCam_6FAC`, are currently highlighted as invalid and rejected on save by the Web interface.

This PR allows internal underscores in static DHCP hostnames while keeping the existing validation behavior for other hostname formats.

**How does this PR accomplish the above?:**

* Adds validation specific to static DHCP hostnames instead of relaxing the shared strict hostname validator.
* Allows underscores within hostname labels while continuing to reject leading or trailing underscores.
* Applies the validation consistently when saving, highlighting invalid table entries, and editing hostnames.
* Leaves DNS-related and other strict hostname validation unchanged.
* Updates the Static DHCP help text to reflect the accepted format.
* Tested with `npm test`, which completes successfully with the repository's existing warnings.

**Link documentation PRs if any are needed to support this PR:**

No documentation changes are required. The relevant inline help text in the Web interface has been updated as part of this PR.

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [[contributors guide](https://docs.pi-hole.net/guides/github/contributing/)](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [[EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`[git rebase](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---

* [x] I have read the above and my PR is ready for review.