### PR TITLE
Improve wording for DNS interface recommended setting

### DIFF
--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -164,7 +164,7 @@ PageTitle = "DNS Settings"
                                         <div class="form-check">
                                             <input class="form-check-input" type="radio" name="DNSinterface" id="dns.listeningMode-LOCAL" data-key="dns.listeningMode" value="local">
                                             <label class="form-check-label" for="dns.listeningMode-LOCAL"><strong>Allow only local requests</strong></label>
-                                            <p class="help-block">Allows only queries from devices that are at most one hop away (local devices)</p>
+                                            <p class="help-block">Allows only queries from devices that are on a subnet directly connected to this Pi-hole (local devices).</p>
                                         </div>
                                     </div>
                                     <div class="danger-area">


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

<!--- Replace this with detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues -->

Change the DNS interface configuration help text to explain the actual implementation. The previous (current) wording can be very misleading, or at least it was to me when I was configuring my new network setup and spent too much time on debugging 😁 

**How does this PR accomplish the above?:**

Replaced misleading wording in the `dns.listeningMode` help text. The previous phrasing implied hop-count filtering when the actual behavior (via dnsmasq's `local-service`) accepts queries from hosts on subnets directly connected to the Pi-hole's interfaces.

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->
None - The documentation already states it correctly:

> [Allow only local requests](https://docs.pi-hole.net/ftldns/interfaces/#local)
>
> This setting accepts DNS queries only from hosts whose address is on a local subnet, i.e., a subnet for which an interface exists on the server

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
